### PR TITLE
Named timing output file

### DIFF
--- a/src/Pybind11Wraps/Utilities/Timer.py
+++ b/src/Pybind11Wraps/Utilities/Timer.py
@@ -40,7 +40,8 @@ class Timer:
         return "double"
 
     @PYB11static
-    def TimerSummary(self):
+    def TimerSummary(self,
+                     fname="const std::string&"):
         return "void"
 
     #...........................................................................

--- a/src/SimulationControl/SpheralController.py
+++ b/src/SimulationControl/SpheralController.py
@@ -47,7 +47,8 @@ class SpheralController:
                  numHIterationsBetweenCycles = 0,
                  reinitializeNeighborsStep = 10,
                  volumeType = RKVolumeType.RKVoronoiVolume,
-                 facetedBoundaries = None):
+                 facetedBoundaries = None,
+                 timerName = "" ):
         self.restart = RestartableObject(self)
         self.integrator = integrator
         self.kernel = kernel
@@ -56,6 +57,11 @@ class SpheralController:
         self.SPH = SPH
         self.numHIterationsBetweenCycles = numHIterationsBetweenCycles
         self._break = False
+
+        if timerName == "":
+            self.timerName = "time.table"
+        else:
+            self.timerName = timerName
 
         # Determine the dimensionality of this run, based on the integrator.
         self.dim = "%id" % self.integrator.dataBase.nDim
@@ -358,7 +364,7 @@ class SpheralController:
         self.stepTimer.printStatus()
 
         # Output any timer info
-        Timer.TimerSummary()
+        Timer.TimerSummary(self.timerName)
 
         return
 

--- a/src/Utilities/Timer.cc
+++ b/src/Utilities/Timer.cc
@@ -18,6 +18,7 @@ using std::max;
 using std::abs;
 
 #include "Timer.hh"
+#include "DBC.hh"
 
 // Must initialize the static list defined in Timer.hh
 // list<Timer*> Timer::TimerList(0); 
@@ -91,7 +92,7 @@ Timer::Timer(const string& name, Timer& parent):
 }
 
 // Diagnostic Non-root Managed Timer construction for separate table
-Timer::Timer(const string& name, Timer& parent, bool d):
+Timer::Timer(const string& name, Timer& parent, bool):
   timer_name(name),  Parent(parent) {
 
   //cout << "   Diagnostic Timer construction for = " << name << endl;
@@ -629,6 +630,9 @@ static void writeLineOfData(FILE *out,
 			    const double wc_max,
 			    const double counter1,
 			    const double counter2) {
+
+  CONTRACT_VAR(counter1);
+  CONTRACT_VAR(counter2);
 
 #ifdef PAPI
 

--- a/src/Utilities/Timer.cc
+++ b/src/Utilities/Timer.cc
@@ -228,7 +228,7 @@ double Timer::getTimeStampWC(){
 // the list of timers and make a list of parent timers.  From there i
 // can make for loops that step thru the tree and print out the
 // results.
-void Timer::TimerSummary(void) {
+void Timer::TimerSummary( const std::string& fname ) {
 
   int rank, number_procs;
 #ifdef USE_MPI
@@ -321,16 +321,16 @@ void Timer::TimerSummary(void) {
 
 
    
-  cout << " rank" << rank << " writing time.table " << endl;
+  cout << " rank" << rank << " writing " << fname << endl;
 
   FILE *OUT;
   
   if(TIMER_COUNTER == 0) {
-    OUT = fopen("time.table", "w");
+    OUT = fopen(fname.c_str(), "w");
   } else if (TIMER_COUNTER == 1) {
-    OUT = fopen("time.table1", "w");
+    OUT = fopen((fname + "1").c_str(), "w");
   } else {
-    OUT = fopen("time.table2", "w");
+    OUT = fopen((fname + "2").c_str(), "w");
   }
   if(OUT == NULL) {
     printf("problem opening output file in Timer\n");  

--- a/src/Utilities/Timer.hh
+++ b/src/Utilities/Timer.hh
@@ -64,10 +64,7 @@ public:
   static std::list<Timer*> TimerList;
 
   static void TimerSummary(const std::string& fname);
-  static void TimerSummary(){ TimerSummary("time.table"); }
-  static void TimerSummary(const int, const int) {
-    TimerSummary(); // backwards compatibilty...
-  }
+  static void TimerSummary() { TimerSummary("time.table"); }
   
 private:
   

--- a/src/Utilities/Timer.hh
+++ b/src/Utilities/Timer.hh
@@ -63,11 +63,11 @@ public:
 
   static std::list<Timer*> TimerList;
 
-  static void TimerSummary(const int bert, const int ernie) {
+  static void TimerSummary(const std::string& fname);
+  static void TimerSummary(){ TimerSummary("time.table"); }
+  static void TimerSummary(const int, const int) {
     TimerSummary(); // backwards compatibilty...
   }
-  
-  static void TimerSummary(void);
   
 private:
   

--- a/tests/Hydro/Noh/Noh-spherical-3d.py
+++ b/tests/Hydro/Noh/Noh-spherical-3d.py
@@ -115,6 +115,8 @@ commandLine(order = 5,
             comparisonFile = "None",
 
             graphics = True,
+
+            timerName = ""
             )
 
 assert not(boolReduceViscosity and boolCullenViscosity)
@@ -410,6 +412,7 @@ control = SpheralController(integrator, WT,
                             vizDerivs = vizDerivs,
                             #skipInitialPeriodicWork = SVPH,
                             SPH = True,        # Only for iterating H
+                            timerName = timerName
                             )
 output("control")
 


### PR DESCRIPTION
This adds the ability to define a name for a given output timing file. If no name is passed to the SpheralController the default  name`time.table` will be used and behavior will remain the same.