### PR TITLE
Fixing a compile time bug when compiling with Timer enabled.  Also simplified the Timer::TimerSummary a bit to a single function spec with a default argument.

### DIFF
--- a/src/Pybind11Wraps/Utilities/Timer.py
+++ b/src/Pybind11Wraps/Utilities/Timer.py
@@ -41,7 +41,7 @@ class Timer:
 
     @PYB11static
     def TimerSummary(self,
-                     fname="const std::string&"):
+                     fname=("const std::string", '"time.table"')):
         return "void"
 
     #...........................................................................

--- a/src/Utilities/Timer.cc
+++ b/src/Utilities/Timer.cc
@@ -229,7 +229,7 @@ double Timer::getTimeStampWC(){
 // the list of timers and make a list of parent timers.  From there i
 // can make for loops that step thru the tree and print out the
 // results.
-void Timer::TimerSummary( const std::string& fname ) {
+void Timer::TimerSummary( const std::string fname ) {
 
   int rank, number_procs;
 #ifdef USE_MPI

--- a/src/Utilities/Timer.hh
+++ b/src/Utilities/Timer.hh
@@ -63,8 +63,7 @@ public:
 
   static std::list<Timer*> TimerList;
 
-  static void TimerSummary(const std::string& fname);
-  static void TimerSummary() { TimerSummary("time.table"); }
+  static void TimerSummary(const std::string fname = "time.table");
   
 private:
   
@@ -135,11 +134,7 @@ public:
   
   inline long int Count() {return 0;}
   
-  static void TimerSummary(const int, const int) {
-    TimerSummary(); // backwards compatibilty...
-  }
-
-  static void TimerSummary(void) {
+  static void TimerSummary(const std::string fname = "time.table") {
     int rank;
 #ifdef USE_MPI
     MPI_Comm_rank(Spheral::Communicator::communicator(), &rank);


### PR DESCRIPTION
There was a compile time bug with the named timetable push, which this should resolve.  It also seemed reasonable to me to collapse the overloaded Timer::TimerSummary methods to a single case with a default argument, so I snuck that in as well.
