### PR TITLE
Removing expensive timers from SPHEvaluateDerivatives.

### DIFF
--- a/src/CRKSPH/CRKSPHEvaluateDerivatives.cc
+++ b/src/CRKSPH/CRKSPHEvaluateDerivatives.cc
@@ -113,7 +113,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
 
 #pragma omp for
     for (auto kk = 0u; kk < npairs; ++kk) {
-      const auto start = Timing::currentTime();
       i = pairs[kk].i_node;
       j = pairs[kk].j_node;
       nodeListi = pairs[kk].i_list;
@@ -256,13 +255,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
         XSPHDeltaVi -= weightj*Wj*vij;
         XSPHDeltaVj += weighti*Wi*vij;
       }
-
-      // Add timing info for work
-      const auto deltaTimePair = 0.5*Timing::difference(start, Timing::currentTime());
-#pragma omp atomic
-      nodeLists[nodeListi]->work()(i) += deltaTimePair;
-#pragma omp atomic
-      nodeLists[nodeListj]->work()(j) += deltaTimePair;
     }
 
     // Reduce the thread values to the master.

--- a/src/CRKSPH/CRKSPHHydroBaseRZ.cc
+++ b/src/CRKSPH/CRKSPHHydroBaseRZ.cc
@@ -309,7 +309,6 @@ evaluateDerivatives(const Dim<2>::Scalar /*time*/,
 
 #pragma omp for
     for (auto kk = 0u; kk < npairs; ++kk) {
-      const auto start = Timing::currentTime();
       i = pairs[kk].i_node;
       j = pairs[kk].j_node;
       nodeListi = pairs[kk].i_list;
@@ -452,13 +451,6 @@ evaluateDerivatives(const Dim<2>::Scalar /*time*/,
         XSPHDeltaVi -= weightj*Wj*vij;
         XSPHDeltaVj += weighti*Wi*vij;
       }
-
-      // Add timing info for work
-      const auto deltaTimePair = 0.5*Timing::difference(start, Timing::currentTime());
-#pragma omp atomic
-      nodeLists[nodeListi]->work()(i) += deltaTimePair;
-#pragma omp atomic
-      nodeLists[nodeListj]->work()(j) += deltaTimePair;
     }
 
     // Reduce the thread values to the master.

--- a/src/CRKSPH/SolidCRKSPHHydroBase.cc
+++ b/src/CRKSPH/SolidCRKSPHHydroBase.cc
@@ -410,7 +410,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
 
 #pragma omp for
     for (auto kk = 0u; kk < npairs; ++kk) {
-      const auto start = Timing::currentTime();
       i = pairs[kk].i_node;
       j = pairs[kk].j_node;
       nodeListi = pairs[kk].i_list;
@@ -577,13 +576,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
       // Estimate of delta v (for XSPH).
       XSPHDeltaVi -= fij*weightj*Wj*vij;
       XSPHDeltaVj += fij*weighti*Wi*vij;
-
-      // Add timing info for work
-      const auto deltaTimePair = 0.5*Timing::difference(start, Timing::currentTime());
-#pragma omp atomic
-      nodeLists[nodeListi]->work()(i) += deltaTimePair;
-#pragma omp atomic
-      nodeLists[nodeListj]->work()(j) += deltaTimePair;
     }
 
     // Reduce the thread values to the master.

--- a/src/CRKSPH/SolidCRKSPHHydroBaseRZ.cc
+++ b/src/CRKSPH/SolidCRKSPHHydroBaseRZ.cc
@@ -403,7 +403,6 @@ evaluateDerivatives(const Dim<2>::Scalar /*time*/,
 
 #pragma omp for
     for (auto kk = 0u; kk < npairs; ++kk) {
-      const auto start = Timing::currentTime();
       i = pairs[kk].i_node;
       j = pairs[kk].j_node;
       nodeListi = pairs[kk].i_list;
@@ -573,13 +572,6 @@ evaluateDerivatives(const Dim<2>::Scalar /*time*/,
       // Estimate of delta v (for XSPH).
       XSPHDeltaVi -= fij*weightj*Wj*vij;
       XSPHDeltaVj += fij*weighti*Wi*vij;
-
-      // Add timing info for work
-      const auto deltaTimePair = 0.5*Timing::difference(start, Timing::currentTime());
-#pragma omp atomic
-      nodeLists[nodeListi]->work()(i) += deltaTimePair;
-#pragma omp atomic
-      nodeLists[nodeListj]->work()(j) += deltaTimePair;
     }
 
     // Reduce the thread values to the master.

--- a/src/SPH/PSPHHydroBase.cc
+++ b/src/SPH/PSPHHydroBase.cc
@@ -372,7 +372,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
 
 #pragma omp for
     for (auto kk = 0u; kk < npairs; ++kk) {
-      const auto start = Timing::currentTime();
       i = pairs[kk].i_node;
       j = pairs[kk].j_node;
       nodeListi = pairs[kk].i_list;
@@ -569,13 +568,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
         localMi -= mj*rij.dyad(gradWi);
         localMj -= mi*rij.dyad(gradWj);
       }
-
-      // Add timing info for work
-      const auto deltaTimePair = 0.5*Timing::difference(start, Timing::currentTime());
-#pragma omp atomic
-      nodeLists[nodeListi]->work()(i) += deltaTimePair;
-#pragma omp atomic
-      nodeLists[nodeListj]->work()(j) += deltaTimePair;
 
     } // loop over pairs
 

--- a/src/SPH/SPHEvaluateDerivatives.cc
+++ b/src/SPH/SPHEvaluateDerivatives.cc
@@ -132,7 +132,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
 
 #pragma omp for
     for (auto kk = 0u; kk < npairs; ++kk) {
-      const auto start = Timing::currentTime();
       i = pairs[kk].i_node;
       j = pairs[kk].j_node;
       nodeListi = pairs[kk].i_list;
@@ -312,13 +311,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
         localMi -= mj*rij.dyad(gradWi);
         localMj -= mi*rij.dyad(gradWj);
       }
-
-      // Add timing info for work
-      const auto deltaTimePair = 0.5*Timing::difference(start, Timing::currentTime());
-#pragma omp atomic
-      nodeLists[nodeListi]->work()(i) += deltaTimePair;
-#pragma omp atomic
-      nodeLists[nodeListj]->work()(j) += deltaTimePair;
 
     } // loop over pairs
 

--- a/src/SPH/SPHHydroBaseRZ.cc
+++ b/src/SPH/SPHHydroBaseRZ.cc
@@ -329,7 +329,6 @@ evaluateDerivatives(const Dim<2>::Scalar /*time*/,
 
 #pragma omp for
     for (auto kk = 0u; kk < npairs; ++kk) {
-      const auto start = Timing::currentTime();
       i = pairs[kk].i_node;
       j = pairs[kk].j_node;
       nodeListi = pairs[kk].i_list;
@@ -509,13 +508,6 @@ evaluateDerivatives(const Dim<2>::Scalar /*time*/,
         localMi -= mRZj*xij.dyad(gradWi);
         localMj -= mRZi*xij.dyad(gradWj);
       }
-
-      // Add timing info for work
-      const auto deltaTimePair = 0.5*Timing::difference(start, Timing::currentTime());
-#pragma omp atomic
-      nodeLists[nodeListi]->work()(i) += deltaTimePair;
-#pragma omp atomic
-      nodeLists[nodeListj]->work()(j) += deltaTimePair;
 
     } // loop over pairs
 

--- a/src/SPH/SolidSPHEvaluateDerivatives.cc
+++ b/src/SPH/SolidSPHEvaluateDerivatives.cc
@@ -154,7 +154,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
 
 #pragma omp for
     for (auto kk = 0u; kk < npairs; ++kk) {
-      const auto start = Timing::currentTime();
       i = pairs[kk].i_node;
       j = pairs[kk].j_node;
       nodeListi = pairs[kk].i_list;
@@ -372,13 +371,6 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
         localMi -= mj*rij.dyad(gradWGi);
         localMj -= mi*rij.dyad(gradWGj);
       }
-
-      // Add timing info for work
-      const auto deltaTimePair = 0.5*Timing::difference(start, Timing::currentTime());
-#pragma omp atomic
-      nodeLists[nodeListi]->work()(i) += deltaTimePair;
-#pragma omp atomic
-      nodeLists[nodeListj]->work()(j) += deltaTimePair;
 
     } // loop over pairs
 

--- a/src/SPH/SolidSPHHydroBaseRZ.cc
+++ b/src/SPH/SolidSPHHydroBaseRZ.cc
@@ -388,7 +388,6 @@ evaluateDerivatives(const Dim<2>::Scalar /*time*/,
 
 #pragma omp for
     for (auto kk = 0u; kk < npairs; ++kk) {
-      const auto start = Timing::currentTime();
       i = pairs[kk].i_node;
       j = pairs[kk].j_node;
       nodeListi = pairs[kk].i_list;
@@ -618,13 +617,6 @@ evaluateDerivatives(const Dim<2>::Scalar /*time*/,
         localMi -= mRZj*xij.dyad(gradWGi);
         localMj -= mRZi*xij.dyad(gradWGj);
       }
-
-      // Add timing info for work
-      const auto deltaTimePair = 0.5*Timing::difference(start, Timing::currentTime());
-#pragma omp atomic
-      nodeLists[nodeListi]->work()(i) += deltaTimePair;
-#pragma omp atomic
-      nodeLists[nodeListj]->work()(j) += deltaTimePair;
 
     } // loop over pairs
 


### PR DESCRIPTION
Removes timer code from SPHEvaluateDerivatives and SolidSPHEvaluateDerivatives which were causing performance hits.