### PR TITLE
Adding the option to cull timers that didn't fire from the summary output

### DIFF
--- a/src/Pybind11Wraps/Utilities/Timer.py
+++ b/src/Pybind11Wraps/Utilities/Timer.py
@@ -41,7 +41,8 @@ class Timer:
 
     @PYB11static
     def TimerSummary(self,
-                     fname=("const std::string", '"time.table"')):
+                     fname=("const std::string", '"time.table"'),
+                     printAllTimers=("const bool", "false")):
         return "void"
 
     #...........................................................................

--- a/src/SimulationControl/SpheralController.py
+++ b/src/SimulationControl/SpheralController.py
@@ -48,7 +48,8 @@ class SpheralController:
                  reinitializeNeighborsStep = 10,
                  volumeType = RKVolumeType.RKVoronoiVolume,
                  facetedBoundaries = None,
-                 timerName = "" ):
+                 timerName = "",
+                 printAllTimers = False):
         self.restart = RestartableObject(self)
         self.integrator = integrator
         self.kernel = kernel
@@ -62,6 +63,7 @@ class SpheralController:
             self.timerName = "time.table"
         else:
             self.timerName = timerName
+        self.printAllTimers = printAllTimers
 
         # Determine the dimensionality of this run, based on the integrator.
         self.dim = "%id" % self.integrator.dataBase.nDim
@@ -364,7 +366,7 @@ class SpheralController:
         self.stepTimer.printStatus()
 
         # Output any timer info
-        Timer.TimerSummary(self.timerName)
+        Timer.TimerSummary(self.timerName, self.printAllTimers)
 
         return
 

--- a/src/Utilities/Timer.cc
+++ b/src/Utilities/Timer.cc
@@ -228,7 +228,8 @@ double Timer::getTimeStampWC(){
 // the list of timers and make a list of parent timers.  From there i
 // can make for loops that step thru the tree and print out the
 // results.
-void Timer::TimerSummary( const std::string fname ) {
+void Timer::TimerSummary( const std::string fname,
+                          const bool printAllTimers ) {
 
   int rank, number_procs;
 #ifdef USE_MPI
@@ -347,74 +348,75 @@ void Timer::TimerSummary( const std::string fname ) {
   //time_unit_factor = 60.0; // for seconds;
   
   for(pti=ParentList.begin() ; pti != ParentList.end() ; pti++) {
+    if ((*pti)->Count() > 0 or printAllTimers) {
     
-    fprintf(OUT, "\n");
+      fprintf(OUT, "\n");
 
-    writeTableHeader(OUT);
-      
-    double table_avg_sum     = 0.0;
-    double table_min_sum     = 0.0;
-    double table_max_sum     = 0.0;
-    double table_percent;
+      writeTableHeader(OUT);
 
-    double wc_avg = (*pti)->avgWC*time_unit_factor;
-    double wc_min = (*pti)->minWC*time_unit_factor;
-    double wc_max = (*pti)->maxWC*time_unit_factor;
+      double table_avg_sum     = 0.0;
+      double table_min_sum     = 0.0;
+      double table_max_sum     = 0.0;
+      double table_percent;
 
-    double parent_avg = wc_avg;
+      double wc_avg = (*pti)->avgWC*time_unit_factor;
+      double wc_min = (*pti)->minWC*time_unit_factor;
+      double wc_max = (*pti)->maxWC*time_unit_factor;
 
-    // Parent for each table
-#ifdef PAPI
-    writeLineOfData(OUT, (*pti)->Name().c_str(), (*pti)->Count(), -1, 
-		    wc_avg, wc_min, wc_max,
-		    (double)(*pti)->papi_counter1(), 
-		    (double)(*pti)->papi_counter2());
-#else
-    writeLineOfData(OUT, (*pti)->Name().c_str(), (*pti)->Count(), -1,
-		    wc_avg, wc_min, wc_max, 0, 0);
-#endif
+      double parent_avg = wc_avg;
 
-    writeSingleLineSeparator(OUT);
+      // Parent for each table
+  #ifdef PAPI
+      writeLineOfData(OUT, (*pti)->Name().c_str(), (*pti)->Count(), -1, 
+                      wc_avg, wc_min, wc_max,
+                      (double)(*pti)->papi_counter1(), 
+                      (double)(*pti)->papi_counter2());
+  #else
+      writeLineOfData(OUT, (*pti)->Name().c_str(), (*pti)->Count(), -1,
+                      wc_avg, wc_min, wc_max, 0, 0);
+  #endif
 
-    for(tli=TimerList.begin() ; tli != TimerList.end() ; tli++) {
-      
-      if ((*tli)->diagnostic) continue;
-      
-      if( &((*tli)->Parent) == *pti && *tli != &((*tli)->Parent) ) {
+      writeSingleLineSeparator(OUT);
 
-  	wc_avg = (*tli)->avgWC*time_unit_factor;
-  	wc_min = (*tli)->minWC*time_unit_factor;
-  	wc_max = (*tli)->maxWC*time_unit_factor;
-	
- 	if(parent_avg  > 0.) {
- 	  table_percent  = wc_avg/parent_avg*100.0;
- 	} else {
- 	  table_percent = 0.;
-	}
+      for(tli=TimerList.begin() ; tli != TimerList.end() ; tli++) {
 
-  	table_avg_sum  += wc_avg;	
-  	table_min_sum  += wc_min;	
-  	table_max_sum  += wc_max;	
+        if ((*tli)->diagnostic) continue;
 
-	// Children
-#ifdef PAPI
-	writeLineOfData(OUT, (*tli)->Name().c_str(), (*tli)->Count(), 
-			table_percent, wc_avg, wc_min, wc_max,
-			(double)(*tli)->papi_counter1(), 
-			(double)(*tli)->papi_counter2());	
-#else
-	writeLineOfData(OUT, (*tli)->Name().c_str(), (*tli)->Count(), 
-			table_percent, wc_avg, wc_min, wc_max, 0, 0);
-#endif
-      }
-      
-    } // end of table loop for this parent
+        if( &((*tli)->Parent) == *pti && *tli != &((*tli)->Parent) ) {
 
-    writeTableTotals(OUT, parent_avg, table_avg_sum, 
-		     table_min_sum,  table_max_sum);
-    
-    
-    fprintf(OUT,"\n\n");
+          wc_avg = (*tli)->avgWC*time_unit_factor;
+          wc_min = (*tli)->minWC*time_unit_factor;
+          wc_max = (*tli)->maxWC*time_unit_factor;
+
+          if(parent_avg  > 0.) {
+            table_percent  = wc_avg/parent_avg*100.0;
+          } else {
+            table_percent = 0.;
+          }
+
+          table_avg_sum  += wc_avg;	
+          table_min_sum  += wc_min;	
+          table_max_sum  += wc_max;	
+
+          // Children
+  #ifdef PAPI
+          writeLineOfData(OUT, (*tli)->Name().c_str(), (*tli)->Count(), 
+                          table_percent, wc_avg, wc_min, wc_max,
+                          (double)(*tli)->papi_counter1(), 
+                          (double)(*tli)->papi_counter2());	
+  #else
+          writeLineOfData(OUT, (*tli)->Name().c_str(), (*tli)->Count(), 
+                          table_percent, wc_avg, wc_min, wc_max, 0, 0);
+  #endif
+        }
+      } // end of table loop for this parent
+
+      writeTableTotals(OUT, parent_avg, table_avg_sum, 
+                       table_min_sum,  table_max_sum);
+
+
+      fprintf(OUT,"\n\n");
+    }
   } // end of parent loop
 
 

--- a/src/Utilities/Timer.hh
+++ b/src/Utilities/Timer.hh
@@ -65,7 +65,8 @@ public:
 
   static std::list<Timer*> TimerList;
 
-  static void TimerSummary(const std::string fname = "time.table");
+  static void TimerSummary(const std::string fname = "time.table",
+                           const bool printAllTimers = false);
   
 private:
   
@@ -136,8 +137,10 @@ public:
   
   inline long int Count() {return 0;}
   
-  static void TimerSummary(const std::string fname = "time.table") {
+  static void TimerSummary(const std::string fname = "time.table",
+                           const bool printAllTimers = false) {
     CONTRACT_VAR(fname);
+    CONTRACT_VAR(printAllTimers);
     int rank;
 #ifdef USE_MPI
     MPI_Comm_rank(Spheral::Communicator::communicator(), &rank);


### PR DESCRIPTION
This is a simple extension to the TimerSummary method, that allows us to prevent timers that did not fire from being printed to the output. 