### PR TITLE
Switched StrainPorosity velocity gradient

### DIFF
--- a/src/SolidMaterial/StrainPorosity.cc
+++ b/src/SolidMaterial/StrainPorosity.cc
@@ -147,7 +147,7 @@ evaluateDerivatives(const Scalar /*time*/,
                     StateDerivatives<Dimension>& derivs) const {
 
   // Get the state fields.
-  const auto  gradvKey = State<Dimension>::buildFieldKey(HydroFieldNames::internalVelocityGradient, mNodeList.name());
+  const auto  gradvKey = State<Dimension>::buildFieldKey(HydroFieldNames::velocityGradient, mNodeList.name());
   const auto  strainKey = State<Dimension>::buildFieldKey(SolidFieldNames::porosityStrain, mNodeList.name());
   const auto  alphaKey = State<Dimension>::buildFieldKey(SolidFieldNames::porosityAlpha, mNodeList.name());
   const auto  DalphaDtKey = State<Dimension>::buildFieldKey(IncrementBoundedState<Dimension, Scalar, Scalar>::prefix() + SolidFieldNames::porosityAlpha, mNodeList.name());


### PR DESCRIPTION
Changed the velocity gradient that StrainPorosity uses to calculate distension time-derivative from the nodelist-local velocity gradient to the nodelist-global version. This should give better consistency w/ the density time-derivative which also uses the global version. The difference seemed to cause some ringing in the distension/density for quasi-steady state interactions of different nodelists on longer run-outs.