### PR TITLE
Fix ats & gnuplot install bug.

### DIFF
--- a/cmake/tpl/util/Install_Python_distutils_library.cmake
+++ b/cmake/tpl/util/Install_Python_distutils_library.cmake
@@ -6,8 +6,8 @@ macro(Install_Python_distutils_library lib_name lib_file lib_url lib_dir)
     )
   add_custom_target(${lib_name}
     COMMAND echo "-- pip installing ${lib_file}"
-    COMMAND ${PIP_EXE} ${OUT_PROTOCOL_PIP} install ${${lib_file}} --no-index --find-links ${CACHE_DIR}
-    DEPENDS pip-install ${${lib_file}_DEPENDS} ${lib_file}
+    COMMAND ${PYTHON_EXE} ${PIP_EXE} ${OUT_PROTOCOL_PIP} install ${lib_file} --no-index --find-links ${CACHE_DIR}
+    DEPENDS pip-install pip-setup-modules pip-modules ${${lib_file}_DEPENDS} ${lib_file}
     )
   list(APPEND spheral_py_depends ${lib_name})
 endmacro()

--- a/scripts/spheral-setup-venv.in
+++ b/scripts/spheral-setup-venv.in
@@ -4,7 +4,6 @@ echo "Creating Spheral virtual python environment ..."
 
 echo "Installing Spheral ..."
 cp @polytope_DIR@/lib/python2.7/site-packages/polytope/polytope.so @CMAKE_INSTALL_PREFIX@/.venv/lib/python2.7/site-packages/
-cp @polyclipper_DIR@/PolyClipper.so @CMAKE_INSTALL_PREFIX@/.venv/lib/python2.7/site-packages/
 cp Spheral.pth .venv/lib/python2.7/site-packages/
 mkdir -p .venv/lib/python2.7/site-packages/Spheral
 cd - > /dev/null


### PR DESCRIPTION
# Summary 
This PR fixes #72 : 
 - Fixes typo in Install_Python_distutils_library.cmake.
 - Add pip module dependencies for building ats & gnuplot.
 - Remove PolyClipper.so library copy to site-packages/ (no longer building).
