### PR TITLE
Bugfix to return exit status codes from Spheral process.

### DIFF
--- a/scripts/spheral-env.in
+++ b/scripts/spheral-env.in
@@ -2,5 +2,5 @@
 
 source @CMAKE_INSTALL_PREFIX@/.venv/bin/activate
 python "$@"
+exit $?
 deactivate
-

--- a/scripts/spheral-env.in
+++ b/scripts/spheral-env.in
@@ -2,5 +2,6 @@
 
 source @CMAKE_INSTALL_PREFIX@/.venv/bin/activate
 python "$@"
-exit $?
+exit_result=$?
 deactivate
+exit $exit_result


### PR DESCRIPTION
When we went to using Python virtual environments to encapsulate the Spheral python, we inadvertently hid any exit codes from the actual Spheral process.  This is why our unit tests are always passing -- the unit test framework correctly detects errors and exits, but that exit code is hidden from the user by our "spheral" bash script.

This bugfix captures and returns the spheral process exit code, but I did this in a simple-minded way.  Any improvements/suggestions are welcome in this review.
