### PR TITLE
Fsisph damage update

### DIFF
--- a/src/FSISPH/FSISPHHydros.py
+++ b/src/FSISPH/FSISPHHydros.py
@@ -4,205 +4,6 @@ from spheralDimensions import spheralDimensions
 dims = spheralDimensions()
 
 #-------------------------------------------------------------------------------
-# The generic FSISPHHydro pattern.
-#-------------------------------------------------------------------------------
-FSISPHHydroFactoryString = """
-class %(classname)s%(dim)s(FSISPHHydroBase%(dim)s):
-
-    def __init__(self,
-                 dataBase,
-                 Q,
-                 slides,
-                 W,
-                 filter = 0.0,
-                 cfl = 0.5,
-                 surfaceForceCoefficient = 0.0,
-                 densityStabilizationCoefficient = 0.0,
-                 specificThermalEnergyDiffusionCoefficient = 0.0,  
-                 xsphCoefficient=0.0,
-                 interfaceMethod=HLLCInterface,                            
-                 sumDensityNodeLists = None,
-                 useVelocityMagnitudeForDt = False,
-                 compatibleEnergyEvolution = True,
-                 evolveTotalEnergy = False,
-                 gradhCorrection = False,
-                 XSPH = False,
-                 correctVelocityGradient = True,
-                 densityUpdate = RigorousSumDensity,
-                 HUpdate = IdealH,
-                 epsTensile = 0.0,
-                 nTensile = 4.0,
-                 xmin = Vector%(dim)s(-1e100, -1e100, -1e100),
-                 xmax = Vector%(dim)s( 1e100,  1e100,  1e100)):
-        self._smoothingScaleMethod = %(smoothingScaleMethod)s%(dim)s()
-
-        FSISPHHydroBase%(dim)s.__init__(self,
-                                          self._smoothingScaleMethod,
-                                          dataBase,
-                                          Q,
-                                          slides,
-                                          W,
-                                          filter,
-                                          cfl,
-                                          surfaceForceCoefficient,
-                                          densityStabilizationCoefficient,
-                                          specificThermalEnergyDiffusionCoefficient,
-                                          xsphCoefficient,
-                                          interfaceMethod,                      
-                                          sumDensityNodeLists,
-                                          useVelocityMagnitudeForDt,
-                                          compatibleEnergyEvolution,
-                                          evolveTotalEnergy,
-                                          gradhCorrection,
-                                          XSPH,
-                                          correctVelocityGradient,
-                                          densityUpdate,
-                                          HUpdate,
-                                          epsTensile,
-                                          nTensile,
-                                          xmin,
-                                          xmax)
-        return
-"""
-
-#-------------------------------------------------------------------------------
-# The generic FSISPHHydro RZ pattern.
-#-------------------------------------------------------------------------------
-FSISPHHydroRZFactoryString = """
-class %(classname)s(FSISPHHydroBaseRZ):
-
-    def __init__(self,
-                 dataBase,
-                 Q,
-                 slides,
-                 W,
-                 filter = 0.0,
-                 cfl = 0.5,
-                 surfaceForceCoefficient = 0.0,
-                 densityStabilizationCoefficient = 0.0,  
-                 specificThermalEnergyDiffusionCoefficient = 0.0,  
-                 xsphCoefficient=0.0,
-                 interfaceMethod=HLLCInterface,                 
-                 sumDensityNodeLists = None,
-                 useVelocityMagnitudeForDt = False,
-                 compatibleEnergyEvolution = True,
-                 evolveTotalEnergy = False,
-                 gradhCorrection = False,
-                 XSPH = False,
-                 correctVelocityGradient = True,
-                 densityUpdate = RigorousSumDensity,
-                 HUpdate = IdealH,
-                 epsTensile = 0.0,
-                 nTensile = 4.0,
-                 xmin = Vector2d(-1e100, -1e100),
-                 xmax = Vector2d( 1e100,  1e100),
-                 etaMinAxis = 0.1):
-        self._smoothingScaleMethod = %(smoothingScaleMethod)s2d()
-        
-        WPi = W
-
-        FSISPHHydroBaseRZ.__init__(self,
-                                   self._smoothingScaleMethod,
-                                   dataBase,
-                                    Q,
-                                    slides,
-                                    W,
-                                    filter,
-                                    cfl,
-                                    surfaceForceCoefficient,
-                                    densityStabilizationCoefficient,
-                                    specificThermalEnergyDiffusionCoefficient,     
-                                    xsphCoefficient,
-                                    interfaceMethod,           
-                                    sumDensityNodeLists,
-                                    useVelocityMagnitudeForDt,
-                                    compatibleEnergyEvolution,
-                                    evolveTotalEnergy,
-                                    gradhCorrection,
-                                    XSPH,
-                                    correctVelocityGradient,
-                                    densityUpdate,
-                                    HUpdate,
-                                    epsTensile,
-                                    nTensile,
-                                    xmin,
-                                    xmax)
-        self.zaxisBC = AxisBoundaryRZ(etaMinAxis)
-        self.appendBoundary(self.zaxisBC)
-        return
-"""
-#-------------------------------------------------------------------------------
-# The generic FSISPHHydro RZ pattern.
-#-------------------------------------------------------------------------------
-SolidFSISPHHydroRZFactoryString = """
-class %(classname)s(SolidFSISPHHydroBaseRZ):
-
-    def __init__(self,
-                 dataBase,
-                 Q,
-                 slides,
-                 W,
-                 filter = 0.0,
-                 cfl = 0.5,
-                 surfaceForceCoefficient = 0.0,
-                 densityStabilizationCoefficient = 0.0, 
-                 specificThermalEnergyDiffusionCoefficient = 0.0,   
-                 xsphCoefficient=0.0,
-                 interfaceMethod=HLLCInterface,                
-                 sumDensityNodeLists = None,
-                 useVelocityMagnitudeForDt = False,
-                 compatibleEnergyEvolution = True,
-                 evolveTotalEnergy = False,
-                 gradhCorrection = False,
-                 XSPH = False,
-                 correctVelocityGradient = True,
-                 densityUpdate = RigorousSumDensity,
-                 HUpdate = IdealH,
-                 epsTensile = 0.0,
-                 nTensile = 4.0,
-                 damageRelieveRubble = False,
-                 negativePressureInDamage = False,
-                 strengthInDamage = False,
-                 xmin = Vector2d(-1e100, -1e100),
-                 xmax = Vector2d( 1e100,  1e100),
-                 etaMinAxis = 0.1):
-        self._smoothingScaleMethod = %(smoothingScaleMethod)s2d()
-
-        SolidFSISPHHydroBaseRZ.__init__(self,
-                                        self._smoothingScaleMethod,
-                                        dataBase,
-                                        Q,
-                                        slides,
-                                        W,
-                                        filter,
-                                        cfl,
-                                        surfaceForceCoefficient,
-                                        densityStabilizationCoefficient,  
-                                        specificThermalEnergyDiffusionCoefficient, 
-                                        xsphCoefficient,
-                                        interfaceMethod,                  
-                                        sumDensityNodeLists,
-                                        useVelocityMagnitudeForDt,
-                                        compatibleEnergyEvolution,
-                                        evolveTotalEnergy,
-                                        gradhCorrection,
-                                        XSPH,
-                                        correctVelocityGradient,
-                                        densityUpdate,
-                                        HUpdate,
-                                        epsTensile,
-                                        nTensile,
-                                        damageRelieveRubble,
-                                        negativePressureInDamage,
-                                        strengthInDamage,
-                                        xmin,
-                                        xmax)
-        self.zaxisBC = AxisBoundaryRZ(etaMinAxis)
-        self.appendBoundary(self.zaxisBC)
-        return
-"""
-
-#-------------------------------------------------------------------------------
 # The generic solidFSISPHHydro pattern.
 #-------------------------------------------------------------------------------
 SolidFSISPHHydroFactoryString = """
@@ -219,7 +20,8 @@ class %(classname)s%(dim)s(SolidFSISPHHydroBase%(dim)s):
                  densityStabilizationCoefficient = 0.0, 
                  specificThermalEnergyDiffusionCoefficient = 0.0, 
                  xsphCoefficient=0.0,
-                 interfaceMethod=HLLCInterface,         
+                 interfaceMethod=HLLCInterface,
+                 kernelMethod = NeverAverageKernels,         
                  sumDensityNodeLists = None,
                  useVelocityMagnitudeForDt = False,
                  compatibleEnergyEvolution = True,
@@ -250,7 +52,8 @@ class %(classname)s%(dim)s(SolidFSISPHHydroBase%(dim)s):
                                           densityStabilizationCoefficient, 
                                           specificThermalEnergyDiffusionCoefficient,
                                           xsphCoefficient,
-                                          interfaceMethod,       
+                                          interfaceMethod, 
+                                          kernelMethod,      
                                           sumDensityNodeLists,
                                           useVelocityMagnitudeForDt,
                                           compatibleEnergyEvolution,
@@ -271,34 +74,14 @@ class %(classname)s%(dim)s(SolidFSISPHHydroBase%(dim)s):
 """
 
 for dim in dims:
-    '''
-    exec(FSISPHHydroFactoryString % {"dim"                  : "%id" % dim,
-                                     "classname"            : "FSISPHHydro",
-                                     "smoothingScaleMethod" : "SPHSmoothingScale"})
-    exec(FSISPHHydroFactoryString % {"dim"                  : "%id" % dim,
-                                     "classname"            : "AFSISPHHydro",
-                                     "smoothingScaleMethod" : "ASPHSmoothingScale"})
-    '''
+
     exec(SolidFSISPHHydroFactoryString % {"dim"                  : "%id" % dim,
                                        "classname"            : "SolidFSISPHHydro",
                                        "smoothingScaleMethod" : "SPHSmoothingScale"})
     exec(SolidFSISPHHydroFactoryString % {"dim"                  : "%id" % dim,
                                        "classname"            : "SolidAFSISPHHydro",
                                        "smoothingScaleMethod" : "ASPHSmoothingScale"})
-'''
-if 2 in dims:
-    exec(SolidFSISPHHydroRZFactoryString % {"classname"            : "SolidFSISPHHydroRZ",
-                                             "smoothingScaleMethod" : "SPHSmoothingScale"})
 
-    exec(SolidFSISPHHydroRZFactoryString % {"classname"            : "SolidAFSISPHHydroRZ",
-                                            "smoothingScaleMethod" : "ASPHSmoothingScale"})
-
-    exec(FSISPHHydroRZFactoryString % {"classname"            : "FSISPHHydroRZ",
-                                        "smoothingScaleMethod" : "SPHSmoothingScale"})
-
-    exec(FSISPHHydroRZFactoryString % {"classname"            : "AFSISPHHydroRZ",
-                                        "smoothingScaleMethod" : "ASPHSmoothingScale"})
-'''
 def FSISPH(dataBase,
         W,
         Q = None,
@@ -309,7 +92,8 @@ def FSISPH(dataBase,
         densityStabilizationCoefficient=0.0, 
         specificThermalEnergyDiffusionCoefficient=0.0, 
         xsphCoefficient=0.0,
-        interfaceMethod=HLLCInterface,       
+        interfaceMethod=HLLCInterface, 
+        kernelMethod=NeverAverageKernels,      
         sumDensityNodeLists=[],
         useVelocityMagnitudeForDt = False,
         compatibleEnergyEvolution = True,
@@ -422,6 +206,7 @@ def FSISPH(dataBase,
               "specificThermalEnergyDiffusionCoefficient" : specificThermalEnergyDiffusionCoefficient,        
               "xsphCoefficient" : xsphCoefficient,
               "interfaceMethod" : interfaceMethod,
+              "kernelMethod" : kernelMethod,
               "sumDensityNodeLists" : sumDensitySwitch,
               "useVelocityMagnitudeForDt" : useVelocityMagnitudeForDt,
               "compatibleEnergyEvolution" : compatibleEnergyEvolution,
@@ -461,7 +246,8 @@ def AFSISPH(dataBase,
          densityStabilizationCoefficient = 0.0,  
          specificThermalEnergyDiffusionCoefficient = 0.0,
          xsphCoefficient = 0.0,   
-         interfaceMethod = HLLCInterface,                     
+         interfaceMethod = HLLCInterface, 
+         kernelMethod = kernelMethod,                    
          sumDensityNodeLists = None,       
          useVelocityMagnitudeForDt = False,
          compatibleEnergyEvolution = True,
@@ -488,7 +274,8 @@ def AFSISPH(dataBase,
                densityStabilizationCoefficient = densityStabilizationCoefficient, 
                specificThermalEnergyDiffusionCoefficient = specificThermalEnergyDiffusionCoefficient,  
                xsphCoefficient = xsphCoefficient,   
-               interfaceMethod = interfaceMethod,                   
+               interfaceMethod = interfaceMethod,  
+               kernelMethod = kernelMethod,                 
                sumDensityNodeLists = sumDensityNodeLists,          
                useVelocityMagnitudeForDt = useVelocityMagnitudeForDt,
                compatibleEnergyEvolution = compatibleEnergyEvolution,

--- a/src/FSISPH/SolidFSISPHHydroBase.cc
+++ b/src/FSISPH/SolidFSISPHHydroBase.cc
@@ -678,7 +678,7 @@ if(this->correctVelocityGradient()){
       const auto decouple =  isExpanding and (cantSupportTension and isInTension);
 
       const auto constructInterface = (fSij < 0.99) and activateConstruction;
-      const auto negligableShearWave = max(fDi*mui,fDj*muj) < 1.0e-5*min(Ki,Kj);
+      const auto negligableShearWave = max(mui,muj) < 1.0e-5*min(Ki,Kj);
 
       if (!decouple){
 
@@ -794,11 +794,11 @@ if(this->correctVelocityGradient()){
         // separate functions at some point...
         if (constructInterface){
 
-          // weights weights
-          const auto Ci = (constructHLLC ? rhoi*ci : abs(Ki*volj*gWi) ) + tiny;
-          const auto Cj = (constructHLLC ? rhoj*cj : abs(Kj*voli*gWj) ) + tiny;
-          const auto Csi = fDi*(constructHLLC ? std::sqrt(rhoi*mui) : abs(mui*volj*gWi) ) + tiny;
-          const auto Csj = fDj*(constructHLLC ? std::sqrt(rhoj*muj) : abs(muj*voli*gWj) ) + tiny;
+          // weights 
+          const auto Ci =  (constructHLLC ? rhoi*ci : abs(Ki*volj*gWi) ) + tiny;
+          const auto Cj =  (constructHLLC ? rhoj*cj : abs(Kj*voli*gWj) ) + tiny;
+          const auto Csi = (constructHLLC ? std::sqrt(rhoi*mui) : abs(mui*volj*gWi) ) + tiny;
+          const auto Csj = (constructHLLC ? std::sqrt(rhoj*muj) : abs(muj*voli*gWj) ) + tiny;
 
           const auto weightUi = max(0.0, min(1.0, Ci/(Ci+Cj)));
           const auto weightUj = 1.0 - weightUi;
@@ -979,7 +979,7 @@ if(this->correctVelocityGradient()){
       const auto spin = localDvDxi.SkewSymmetric();
       const auto deviatoricDeformation = deformation - (deformation.Trace()/Dimension::nDim)*SymTensor::one;
       const auto spinCorrection = (spin*Si + Si*spin).Symmetric();
-      DSDti += spinCorrection + (2.0*mui*(1.0-Di))*deviatoricDeformation;
+      DSDti += spinCorrection + 2.0*mui*deviatoricDeformation;
 
       // In the presence of damage, add a term to reduce the stress on this point.
       if(Di>0.99) DSDti = (1.0 - Di)*DSDti - 0.125/dt*Di*Si;

--- a/src/FSISPH/SolidFSISPHHydroBase.cc
+++ b/src/FSISPH/SolidFSISPHHydroBase.cc
@@ -122,6 +122,7 @@ SolidFSISPHHydroBase(const SmoothingScaleBase<Dimension>& smoothingScaleMethod,
                   const double specificThermalEnergyDiffusionCoefficient,
                   const double xsphCoefficient,
                   const InterfaceMethod interfaceMethod,
+                  const KernelMethod kernelMethod,
                   const std::vector<int> sumDensityNodeLists,
                   const bool useVelocityMagnitudeForDt,
                   const bool compatibleEnergyEvolution,
@@ -168,6 +169,7 @@ SolidFSISPHHydroBase(const SmoothingScaleBase<Dimension>& smoothingScaleMethod,
   mSpecificThermalEnergyDiffusionCoefficient(specificThermalEnergyDiffusionCoefficient),
   mXSPHCoefficient(xsphCoefficient),
   mInterfaceMethod(interfaceMethod),
+  mKernelMethod(kernelMethod),
   mApplySelectDensitySum(false),
   mSumDensityNodeLists(sumDensityNodeLists),
   mPairDepsDt(){
@@ -338,6 +340,8 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
   const auto XSPH = xsphCoeff > tiny;
   const auto diffuseEnergy = epsDiffusionCoeff>tiny and compatibleEnergy;
   const auto stabilizeDensity = rhoStabilizeCoeff>tiny;
+  const auto alwaysAverageKernels = (mKernelMethod==KernelMethod::AlwaysAverageKernels);
+  const auto averageInterfaceKernels = (mKernelMethod==KernelMethod::AverageInterfaceKernels);
 
   // The connectivity.
   const auto& connectivityMap = dataBase.connectivityMap();
@@ -477,7 +481,8 @@ if(this->correctVelocityGradient()){
       auto& Mi = M_thread(nodeListi,i);
       auto& Mj = M_thread(nodeListj,j);
 
-      //const auto differentMatij = (nodeListi!=nodeListj);
+      const auto differentMatij = (nodeListi!=nodeListj);
+      const auto averageKernelij = ( (differentMatij and averageInterfaceKernels) or alwaysAverageKernels);
       // Kernels
       //--------------------------------------
       const auto rij = ri - rj;
@@ -500,11 +505,11 @@ if(this->correctVelocityGradient()){
       auto gradWj = gWj*Hetaj;
       
       //Wi & Wj --> Wij for interface better agreement DrhoDt and DepsDt
-      //if(differentMatij){
-        // const auto gradWij = 0.5*(gradWi+gradWj);
-        // gradWi = gradWij;
-        // gradWj = gradWij;
-      //}
+      if(averageKernelij){
+        const auto gradWij = 0.5*(gradWi+gradWj);
+        gradWi = gradWij;
+        gradWj = gradWij;
+      }
       // linear velocity gradient correction
       //---------------------------------------------------------------
       Mi -=  mj/rhoj * rij.dyad(gradWi);
@@ -657,7 +662,8 @@ if(this->correctVelocityGradient()){
 
       // Flag if this is a contiguous material pair or not.
       const auto sameMatij =  (nodeListi == nodeListj);// and fragIDi == fragIDj); 
-      //const auto differentMatij = !sameMatij;
+      const auto differentMatij = !sameMatij;
+      const auto averageKernelij = ( (differentMatij and averageInterfaceKernels) or alwaysAverageKernels);
 
       // Flag if at least one particle is free (0).
       const auto freeParticle = (pTypei == 0 or pTypej == 0);
@@ -707,16 +713,16 @@ if(this->correctVelocityGradient()){
         
         // average our kernels
         const auto gradWij = 0.5*(gradWi+gradWj);
-        //if(differentMatij){
-        //  const auto Wij = 0.5*(Wi+Wj);
-        //  const auto gWij = 0.5*(gWi+gWj);
-        //  Wi = Wij;
-        //  Wj = Wij;
-        //  gWi = gWij;
-        //  gWj = gWij;
-        //  gradWi = gradWij;
-        //  gradWj = gradWij;
-        //}
+        if(averageKernelij){
+          const auto Wij = 0.5*(Wi+Wj);
+          const auto gWij = 0.5*(gWi+gWj);
+          Wi = Wij;
+          Wj = Wij;
+          gWi = gWij;
+          gWj = gWij;
+          gradWi = gradWij;
+          gradWj = gradWij;
+        }
 
         if(this->correctVelocityGradient()){
          gradWi = Mi.Transpose()*gradWi;
@@ -758,8 +764,8 @@ if(this->correctVelocityGradient()){
         const auto Peffj = (Pj<0.0 ? fDj : 1.0) * Pj;
         const auto Pstar = (rhoi*Peffj + rhoj*Peffi)/(rhoi+rhoj);
 
-        sigmai = fDi * Si - (constructHLLC or sameMatij ? Peffi : Pstar) * SymTensor::one;
-        sigmaj = fDj * Sj - (constructHLLC or sameMatij ? Peffj : Pstar) * SymTensor::one;
+        sigmai = fDi * Si - (averageKernelij ? Pstar : Peffi) * SymTensor::one;
+        sigmaj = fDj * Sj - (averageKernelij ? Pstar : Peffj) * SymTensor::one;
 
         // Compute the tensile correction to add to the stress as described in 
         // Gray, Monaghan, & Swift (Comput. Methods Appl. Mech. Eng., 190, 2001)
@@ -821,14 +827,17 @@ if(this->correctVelocityGradient()){
   
         }
 
-        // diffusion added to vel gradient if additional stabilization is needed
-        if (stabilizeDensity){// and (constructModulus or sameMatij) ){
-          const auto denom = (sameMatij?(rhoi+rhoj)             :
-                                        (rhoi*ci*ci+rhoj*cj*cj));
-          const auto ustarStabilizer =  (sameMatij ? (rhoj-rhoi) :
-                                                    (Pj-Pi)     )/max(tiny,denom);
-         //const auto coeffEffective = min(max(rhoStabilizeCoeff,(fraci+fracj)),1.0);
-          vstar += rhoStabilizeCoeff * min(0.1, max(-0.1, ustarStabilizer)) * cij * rhatij;
+        // this is a little opaque. For HLLC we don't want to 
+        // stabilize across interface since thats baked into the 
+        // construction already.
+        if (stabilizeDensity and (!constructHLLC or sameMatij) ){
+          vstar += rhoStabilizeCoeff * min(0.1, max(-0.1, (Pj-Pi)/(rhoi*ci*ci+rhoj*cj*cj))) * cij * rhatij;
+        //   const auto denom = (sameMatij?(rhoi+rhoj)             :
+        //                                 (rhoi*ci*ci+rhoj*cj*cj));
+        //   const auto ustarStabilizer =  (sameMatij ? (rhoj-rhoi) :
+        //                                             (Pj-Pi)     )/max(tiny,denom);
+        //  //const auto coeffEffective = min(max(rhoStabilizeCoeff,(fraci+fracj)),1.0);
+        //   vstar += rhoStabilizeCoeff * min(0.1, max(-0.1, ustarStabilizer)) * cij * rhatij;
         }
 
         auto deltaDvDxi = 2.0*(vi-vstar).dyad(gradWi);

--- a/src/FSISPH/SolidFSISPHHydroBase.hh
+++ b/src/FSISPH/SolidFSISPHHydroBase.hh
@@ -17,6 +17,12 @@ enum class InterfaceMethod {
   NoInterface = 2,
 };
 
+enum class KernelMethod {
+  NeverAverageKernels = 0,
+  AlwaysAverageKernels = 1,
+  AverageInterfaceKernels = 2,
+};
+
 template<typename Dimension> class State;
 template<typename Dimension> class StateDerivatives;
 template<typename Dimension> class SmoothingScaleBase;
@@ -53,6 +59,7 @@ public:
                     const double specificThermalEnergyDiffusionCoefficient,
                     const double xsphCoefficient,
                     const InterfaceMethod interfaceMethod,
+                    const KernelMethod kernelMethod,
                     const std::vector<int> sumDensityNodeLists,
                     const bool useVelocityMagnitudeForDt,
                     const bool compatibleEnergyEvolution,
@@ -131,6 +138,9 @@ public:
   InterfaceMethod interfaceMethod() const;
   void interfaceMethod(InterfaceMethod method);
 
+  KernelMethod kernelMethod() const;
+  void kernelMethod(KernelMethod method);
+
   //****************************************************************************
   // Methods required for restarting.
   virtual std::string label() const override { return "SolidFSISPHHydroBase"; }
@@ -143,7 +153,8 @@ private:
   double mSpecificThermalEnergyDiffusionCoefficient;  // controls diffusion of eps
   double mXSPHCoefficient;                            // controls amount of xsph-ing
   InterfaceMethod mInterfaceMethod;                   // switch for material interface method
-  
+  KernelMethod mKernelMethod;                         // switch how we do our kernels
+
   bool   mApplySelectDensitySum;                      // switch for density sum
   std::vector<int> mSumDensityNodeLists;              // turn on density sum subset of nodeLists
   

--- a/src/FSISPH/SolidFSISPHHydroBaseInline.hh
+++ b/src/FSISPH/SolidFSISPHHydroBaseInline.hh
@@ -83,6 +83,24 @@ interfaceMethod() const {
 }
 
 //------------------------------------------------------------------------------
+// return our kernel method
+//------------------------------------------------------------------------------
+template<typename Dimension>
+inline
+void
+SolidFSISPHHydroBase<Dimension>::
+kernelMethod(KernelMethod x) {
+  mKernelMethod = x;
+}
+template<typename Dimension>
+inline
+KernelMethod
+SolidFSISPHHydroBase<Dimension>::
+kernelMethod() const {
+  return mKernelMethod;
+}
+
+//------------------------------------------------------------------------------
 // swtich to turn on density sum for different nodeLists
 //------------------------------------------------------------------------------
 template<typename Dimension>

--- a/src/Pybind11Wraps/FSISPH/FSISPHMOD.py
+++ b/src/Pybind11Wraps/FSISPH/FSISPHMOD.py
@@ -27,6 +27,10 @@ InterfaceMethod = PYB11enum(("HLLCInterface",
                              "ModulusInterface",
                              "NoInterface"), export_values = True)
 
+KernelMethod = PYB11enum(("NeverAverageKernels", 
+                          "AlwaysAverageKernels",
+                          "AverageInterfaceKernels"), export_values = True)
+
 #-------------------------------------------------------------------------------
 # Namespaces
 #-------------------------------------------------------------------------------

--- a/src/Pybind11Wraps/FSISPH/SolidFSISPHHydroBase.py
+++ b/src/Pybind11Wraps/FSISPH/SolidFSISPHHydroBase.py
@@ -30,6 +30,7 @@ class SolidFSISPHHydroBase(SolidSPHHydroBase):
                specificThermalEnergyDiffusionCoefficient = "const double",
                xsphCoefficient = "const double",
                interfaceMethod = "const InterfaceMethod",
+               kernelMethod = "const KernelMethod",
                sumDensityNodeLists = "std::vector<int>",
                useVelocityMagnitudeForDt = "const bool",
                compatibleEnergyEvolution = "const bool",
@@ -114,6 +115,9 @@ mass density, velocity, and specific thermal energy."""
     
     interfaceMethod = PYB11property("InterfaceMethod", "interfaceMethod", "interfaceMethod",
                                     doc="Flag to select how we want construct material interfaces")
+    
+    kernelMethod = PYB11property("KernelMethod", "kernelMethod", "kernelMethod",
+                                    doc="Flag to select our kernel type")
 #-------------------------------------------------------------------------------
 # Inject methods
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This was originally just to update for damage scaled shear modulus implementation; but, I've been waffling over the last couple months on how to handle the kernels (average vs not averaging). This seems to have a fairly significant effect at stiff-nonstiff interfaces. So, I added a flag to allow the user to specific the kernel method at run time and this actually accounts for the bulk of the files that were touched despite the PR name.   