### PR TITLE
Fix to just install files under version control for tests directory

### DIFF
--- a/cmake/SetupSpheral.cmake
+++ b/cmake/SetupSpheral.cmake
@@ -160,8 +160,26 @@ endif()
 if (ENABLE_TESTS)
   add_subdirectory(${SPHERAL_ROOT_DIR}/tests/unit/CXXTests)
 
-  install(DIRECTORY ${SPHERAL_ROOT_DIR}/tests/
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/tests
-        PATTERN "runCXXTests.ats" EXCLUDE
-       )
+  # A macro to preserve directory structure when installing files
+  macro(install_with_directory)
+      set(optionsArgs "")
+      set(oneValueArgs "DESTINATION")
+      set(multiValueArgs "FILES")
+      cmake_parse_arguments(CAS "${optionsArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+      foreach(FILE ${CAS_FILES})
+          get_filename_component(DIR ${FILE} DIRECTORY)
+          INSTALL(FILES ${FILE} DESTINATION ${CAS_DESTINATION}/${DIR})
+      endforeach()
+  endmacro(install_with_directory)
+
+  # Find the test files we want to install
+  execute_process(
+    COMMAND git ls-files tests
+    WORKING_DIRECTORY ${SPHERAL_ROOT_DIR}
+    OUTPUT_VARIABLE test_files)
+  string(REPLACE "\n" ";" test_files_list ${test_files})
+  install_with_directory(
+    FILES ${test_files_list} 
+    DESTINATION ${CMAKE_INSTALL_PREFIX})
 endif()

--- a/cmake/SetupSpheral.cmake
+++ b/cmake/SetupSpheral.cmake
@@ -177,9 +177,11 @@ if (ENABLE_TESTS)
   execute_process(
     COMMAND git ls-files tests
     WORKING_DIRECTORY ${SPHERAL_ROOT_DIR}
-    OUTPUT_VARIABLE test_files)
-  string(REPLACE "\n" ";" test_files_list ${test_files})
+    OUTPUT_VARIABLE test_files1)
+  string(REPLACE "\n" " " test_files ${test_files1})
+  separate_arguments(test_files)
+  list(REMOVE_ITEM test_files tests/unit/CXXTests/runCXXTests.ats)
   install_with_directory(
-    FILES ${test_files_list} 
+    FILES ${test_files} 
     DESTINATION ${CMAKE_INSTALL_PREFIX})
 endif()


### PR DESCRIPTION
This is a bugfix so that the install stage for tests only copies files under version control, rather than scraping everything from the tests source directory.