### PR TITLE
Update KelvinHelmholtz-2d_McNally.py

### DIFF
--- a/tests/functional/Hydro/KelvinHelmholtz/KelvinHelmholtz-2d_McNally.py
+++ b/tests/functional/Hydro/KelvinHelmholtz/KelvinHelmholtz-2d_McNally.py
@@ -585,7 +585,7 @@ def mixingScale(cycle, t, dt):
      yprof = mpi.reduce([x.y for x in nodeL.positions().internalValues()], mpi.SUM)
      vely = mpi.reduce([v.y for v in nodeL.velocity().internalValues()], mpi.SUM)
      hprof = mpi.reduce([1.0/sqrt(H.Determinant()) for H in nodeL.Hfield().internalValues()], mpi.SUM)
-     rhoprof = mpi.reduce(nodes.massDensity().internalValues(), mpi.SUM)
+     rhoprof = mpi.reduce(nodeL.massDensity().internalValues(), mpi.SUM)
      if mpi.rank == 0:
       for j in xrange (len(xprof)):
         ke.append(0.5*rhoprof[j]*vely[j]*vely[j])


### PR DESCRIPTION
mixing scale tracker had a typo in the reduced density -- rhoprof.  it as using "nodes" from the last iteration of the loop at ln 364 instead of nodeL from the local loop. 