### PR TITLE
Bugfix/redistribution notification

### DIFF
--- a/src/DataOutput/RestartRegistrar.cc
+++ b/src/DataOutput/RestartRegistrar.cc
@@ -122,7 +122,8 @@ removeExpiredPointers() {
 //------------------------------------------------------------------------------
 vector<string>
 RestartRegistrar::
-uniqueLabels() const {
+uniqueLabels() {
+  this->removeExpiredPointers();
   vector<string> result;
   unsigned counter = 0;
   for (const_iterator itr = this->begin();
@@ -147,7 +148,8 @@ uniqueLabels() const {
 //------------------------------------------------------------------------------
 void
 RestartRegistrar::
-printLabels() const {
+printLabels() {
+  this->removeExpiredPointers();
   const vector<string> labels = this->uniqueLabels();
   for (std::vector<std::string>::const_iterator itr = labels.begin();
        itr != labels.end();
@@ -161,7 +163,8 @@ printLabels() const {
 //------------------------------------------------------------------------------
 void
 RestartRegistrar::
-dumpState(FileIO& file) const {
+dumpState(FileIO& file) {
+  this->removeExpiredPointers();
   const vector<string> labels = this->uniqueLabels();
   CHECK(labels.size() == mRestartHandles.size());
   for (size_t i = 0; i != labels.size(); ++i) {
@@ -174,7 +177,8 @@ dumpState(FileIO& file) const {
 //------------------------------------------------------------------------------
 void
 RestartRegistrar::
-restoreState(const FileIO& file) const {
+restoreState(const FileIO& file) {
+  this->removeExpiredPointers();
   const vector<string> labels = this->uniqueLabels();
   CHECK(labels.size() == mRestartHandles.size());
   for (auto i = 0u; i != labels.size(); ++i) {

--- a/src/DataOutput/RestartRegistrar.hh
+++ b/src/DataOutput/RestartRegistrar.hh
@@ -50,16 +50,16 @@ public:
   const_iterator end() const;
 
   // Generate unique labels for each of the restartable things.
-  std::vector<std::string> uniqueLabels() const;
+  std::vector<std::string> uniqueLabels();
 
   // Print out the current ordering and labels for the restart objects.
-  void printLabels() const;
+  void printLabels();
 
   // Cause all registered objects to write their state to the file.
-  void dumpState(FileIO& file) const;
+  void dumpState(FileIO& file);
 
   // Cause all registered objects to restore their state from the file.
-  void restoreState(const FileIO& file) const;
+  void restoreState(const FileIO& file);
 
 private:
   //------------------------===== Private Interface =====----------------------//

--- a/src/Utilities/RedistributionRegistrar.cc
+++ b/src/Utilities/RedistributionRegistrar.cc
@@ -106,7 +106,8 @@ removeExpiredPointers() {
 //------------------------------------------------------------------------------
 void
 RedistributionRegistrar::
-preRedistributionNotifications() const {
+preRedistributionNotifications() {
+  removeExpiredPointers();
   for (const_iterator itr = begin(); itr != end(); ++itr) itr->lock()->notifyBeforeRedistribution();
 }
 
@@ -115,7 +116,8 @@ preRedistributionNotifications() const {
 //------------------------------------------------------------------------------
 void
 RedistributionRegistrar::
-broadcastRedistributionNotifications() const {
+broadcastRedistributionNotifications() {
+  removeExpiredPointers();
   for (const_iterator itr = begin(); itr != end(); ++itr) itr->lock()->notifyAfterRedistribution();
 }
 

--- a/src/Utilities/RedistributionRegistrar.hh
+++ b/src/Utilities/RedistributionRegistrar.hh
@@ -43,8 +43,8 @@ public:
   const_iterator end() const;
 
   // Send out the notifications.
-  void preRedistributionNotifications() const;
-  void broadcastRedistributionNotifications() const;
+  void preRedistributionNotifications();
+  void broadcastRedistributionNotifications();
 
 private:
   //------------------------===== Private Interface =====----------------------//


### PR DESCRIPTION
Adding pedantic checking for expired pointers to the RestartRegistrar and RedistributionNotificationRegistrar, which ensures we don't try to call into objects that have been deleted.  This fixes a memory error Jason was encountering.