### PR TITLE
updating CullenDehnen

### DIFF
--- a/src/ArtificialViscosity/CullenDehnenViscosity.cc
+++ b/src/ArtificialViscosity/CullenDehnenViscosity.cc
@@ -132,8 +132,8 @@ registerDerivatives(DataBase<Dimension>& dataBase,
                     StateDerivatives<Dimension>& derivs) {
   dataBase.resizeFluidFieldList(mPrevDivV2, 0.0, "mPrevDivV2", false);
   dataBase.resizeFluidFieldList(mCullAlpha2, 1.0, "mCullAlpha2", false);
-  dataBase.resizeFluidFieldList(mPrevDivV2, 0.0, "mDalphaDt", false);
-  dataBase.resizeFluidFieldList(mCullAlpha2, 0.0, "mAlphaLocal", false);
+  dataBase.resizeFluidFieldList(mDalphaDt, 0.0, "mDalphaDt", false);
+  dataBase.resizeFluidFieldList(mAlphaLocal, 0.0, "mAlphaLocal", false);
   dataBase.resizeFluidFieldList(mR, 0.0, "mR", false);
   dataBase.resizeFluidFieldList(mVsig, 0.0, "mVsig", false);
   derivs.enroll(mPrevDivV2);

--- a/src/ArtificialViscosity/CullenDehnenViscosity.cc
+++ b/src/ArtificialViscosity/CullenDehnenViscosity.cc
@@ -75,8 +75,7 @@ template<typename Dimension>
 CullenDehnenViscosity<Dimension>::
 ~CullenDehnenViscosity() {
 }
-
-    
+ 
 //------------------------------------------------------------------------------
 // On problem start up, we need to initialize our internal data.
 //------------------------------------------------------------------------------
@@ -91,8 +90,8 @@ initializeProblemStartup(DataBase<Dimension>& dataBase) {
   mCullAlpha2 = dataBase.newFluidFieldList(1.0, "mCullAlpha2");
   mDalphaDt = dataBase.newFluidFieldList(0.0, "Cullen alpha delta");
   mAlphaLocal = dataBase.newFluidFieldList(0.0, "Cullen alpha local");
-  mR = dataBase.newFluidFieldList(0.0,"mR");
-  mVsig = dataBase.newFluidFieldList(0.0,"mVsig");
+  mR = dataBase.newFluidFieldList(0.0, "mR");
+  mVsig = dataBase.newFluidFieldList(0.0, "mVsig");
 
   FieldList<Dimension, Scalar>& rvQ = myq.CqMultiplier();
   FieldList<Dimension, Scalar>& rvL = myq.ClMultiplier();
@@ -133,11 +132,10 @@ registerDerivatives(DataBase<Dimension>& dataBase,
                     StateDerivatives<Dimension>& derivs) {
   dataBase.resizeFluidFieldList(mPrevDivV2, 0.0, "mPrevDivV2", false);
   dataBase.resizeFluidFieldList(mCullAlpha2, 1.0, "mCullAlpha2", false);
-  dataBase.resizeFluidFieldList(mDalphaDt, 0.0, "mDalphaDt", false);
-  dataBase.resizeFluidFieldList(mAlphaLocal, 1.0, "mAlphaLocal", false);
+  dataBase.resizeFluidFieldList(mPrevDivV2, 0.0, "mDalphaDt", false);
+  dataBase.resizeFluidFieldList(mCullAlpha2, 0.0, "mAlphaLocal", false);
   dataBase.resizeFluidFieldList(mR, 0.0, "mR", false);
-  dataBase.resizeFluidFieldList(mVsig, 1.0, "mVsig", false);
-
+  dataBase.resizeFluidFieldList(mVsig, 0.0, "mVsig", false);
   derivs.enroll(mPrevDivV2);
   derivs.enroll(mCullAlpha2);
   derivs.enroll(mDalphaDt);
@@ -146,9 +144,6 @@ registerDerivatives(DataBase<Dimension>& dataBase,
   derivs.enroll(mVsig);
 }
 
-//------------------------------------------------------------------------------
-// eval derivs
-//------------------------------------------------------------------------------
 template<typename Dimension>
 void
 CullenDehnenViscosity<Dimension>::
@@ -172,35 +167,26 @@ finalizeDerivatives(const Scalar /*time*/,
                     StateDerivatives<Dimension>& derivs) const {
 
   // The kernels
-  const auto& W = this->kernel();
-  const auto kernelExtent = W.kernelExtent();
+  const TableKernel<Dimension>& W = this->kernel();
+  const Scalar kernelExtent = W.kernelExtent();
 
   // The connectivity.
-  const auto& connectivityMap = dataBase.connectivityMap();
-  const auto& nodeLists = connectivityMap.nodeLists();
+  const ConnectivityMap<Dimension>& connectivityMap = dataBase.connectivityMap();
+  const vector<const NodeList<Dimension>*>& nodeLists = connectivityMap.nodeLists();
   const size_t numNodeLists = nodeLists.size();
     
+  //State Fluid Lists
+  const FieldList<Dimension, Scalar> reducingViscosityMultiplierQ = state.fields(HydroFieldNames::ArtificialViscousCqMultiplier, 0.0);
 
-  const auto reducingViscosityMultiplierQ = state.fields(HydroFieldNames::ArtificialViscousCqMultiplier, 0.0);
-  const auto position = state.fields(HydroFieldNames::position, Vector::zero);
-  const auto mass = state.fields(HydroFieldNames::mass, 0.0);
-  const auto velocity = state.fields(HydroFieldNames::velocity, Vector::zero);
-  const auto massDensity = state.fields(HydroFieldNames::massDensity, 0.0);
-  const auto H = state.fields(HydroFieldNames::H, SymTensor::zero);
-  const auto soundSpeed = state.fields(HydroFieldNames::soundSpeed, 0.0);
-  const auto prevDivV = state.fields("mPrevDivV", 0.0);
-  const auto alpha0 = state.fields("mCullAlpha", 0.0);
+  const FieldList<Dimension, Vector> position = state.fields(HydroFieldNames::position, Vector::zero);
+  const FieldList<Dimension, Scalar> mass = state.fields(HydroFieldNames::mass, 0.0);
+  const FieldList<Dimension, Vector> velocity = state.fields(HydroFieldNames::velocity, Vector::zero);
+  const FieldList<Dimension, Scalar> massDensity = state.fields(HydroFieldNames::massDensity, 0.0);
+  const FieldList<Dimension, SymTensor> H = state.fields(HydroFieldNames::H, SymTensor::zero);
+  const FieldList<Dimension, Scalar> soundSpeed = state.fields(HydroFieldNames::soundSpeed, 0.0);
+  
+  FieldList<Dimension, Vector> prevDvDt = state.fields("mPrevDvDt", Vector::zero);
 
-  const auto DvDt = derivs.fields(HydroFieldNames::hydroAcceleration, Vector::zero);
-  auto DvDx = derivs.fields(HydroFieldNames::velocityGradient, Tensor::zero);
-  auto prevDvDt = state.fields("mPrevDvDt", Vector::zero);
-  auto alpha_local = derivs.fields("Cullen alpha local", 0.0);
-  auto DalphaDt = derivs.fields("Cullen alpha delta", 0.0);
-  auto R = dataBase.newFluidFieldList(0.0, "mR");
-  auto vsig = dataBase.newFluidFieldList(0.0, "mVsig");
-  auto alpha_tmp = derivs.fields("mCullAlpha2", 0.0);
-  
-  
   CHECK(mass.size() == numNodeLists);
   CHECK(position.size() == numNodeLists);
   CHECK(velocity.size() == numNodeLists);
@@ -211,9 +197,14 @@ finalizeDerivatives(const Scalar /*time*/,
   CHECK(reducingViscosityMultiplierQ.size() == numNodeLists);
 
   // Derivative FieldLists.
-  
+  FieldList<Dimension, Scalar> alpha_local = derivs.fields("Cullen alpha local", 0.0);
+  FieldList<Dimension, Scalar> DalphaDt = derivs.fields("Cullen alpha delta", 0.0);
+  FieldList<Dimension, Scalar> R = derivs.fields("mR", 0.0);
+  FieldList<Dimension, Scalar> vsig = derivs.fields("mVsig", 0.0);
+
   // We're using the hydro derivatives.
-  
+  const FieldList<Dimension, Vector> DvDt = derivs.fields(HydroFieldNames::hydroAcceleration, Vector::zero);
+  FieldList<Dimension, Tensor> DvDx = derivs.fields(HydroFieldNames::velocityGradient, Tensor::zero);
 
   // Apply boundaries to DvDx.
   for (ConstBoundaryIterator boundaryItr = this->boundaryBegin(); 
@@ -225,8 +216,6 @@ finalizeDerivatives(const Scalar /*time*/,
        boundaryItr != this->boundaryEnd();
        ++boundaryItr) (*boundaryItr)->finalizeGhostBoundary();
 
-  // We need to compute the R factor, which involves walking the neighbors.  We can simultaneously compute the signal velocity.
-  
   for (size_t nodeListi = 0; nodeListi != numNodeLists; ++nodeListi) {
     //const int firstGhostNodei = DvDx[nodeListi]->nodeList().firstGhostNode();
 
@@ -237,16 +226,16 @@ finalizeDerivatives(const Scalar /*time*/,
       const int i = *iItr;
 
       // Get the state for node i.
-      const auto& ri = position(nodeListi, i);
-      const auto& vi = velocity(nodeListi, i);
-      const auto& Hi = H(nodeListi, i);
-      const auto Hdeti = Hi.Determinant();
-      const auto mi = mass(nodeListi, i);
-      const auto rhoi = massDensity(nodeListi, i);
-      const auto divvi = DvDx(nodeListi, i).Trace();
-      const auto csi = soundSpeed(nodeListi, i);
-      auto& Ri = R(nodeListi, i);
-      auto& vsigi = vsig(nodeListi, i);
+      const Vector& ri = position(nodeListi, i);
+      const Vector& vi = velocity(nodeListi, i);
+      const SymTensor& Hi = H(nodeListi, i);
+      const Scalar Hdeti = Hi.Determinant();
+      const Scalar mi = mass(nodeListi, i);
+      const Scalar rhoi = massDensity(nodeListi, i);
+      const Scalar divvi = DvDx(nodeListi, i).Trace();
+      const Scalar csi = soundSpeed(nodeListi, i);
+      Scalar& Ri = R(nodeListi, i);
+      Scalar& vsigi = vsig(nodeListi, i);
 
       // Neighbors!
       const vector<vector<int> >& fullConnectivity = connectivityMap.connectivityForNode(nodeListi, i);
@@ -276,27 +265,27 @@ finalizeDerivatives(const Scalar /*time*/,
                                                          firstGhostNodej)) {
 
               // Get the state for node i.
-              const auto& rj = position(nodeListj, j);
-              const auto& vj = velocity(nodeListj, j);
-              const auto& Hj = H(nodeListj, j);
-              const auto Hdetj = Hj.Determinant();
-              const auto mj = mass(nodeListj, j);
-              const auto divvj = DvDx(nodeListj, j).Trace();
-              const auto csj = soundSpeed(nodeListj, j);
-              auto& Rj = R(nodeListj, j);
-              auto& vsigj = vsig(nodeListj, j);
+              const Vector& rj = position(nodeListj, j);
+              const Vector& vj = velocity(nodeListj, j);
+              const SymTensor& Hj = H(nodeListj, j);
+              const Scalar Hdetj = Hj.Determinant();
+              const Scalar mj = mass(nodeListj, j);
+              const Scalar divvj = DvDx(nodeListj, j).Trace();
+              const Scalar csj = soundSpeed(nodeListj, j);
+              Scalar& Rj = R(nodeListj, j);
+              Scalar& vsigj = vsig(nodeListj, j);
 
               // Symmetrized kernel weight and gradient.
-              const auto rij = ri - rj;
-              const auto Wi = W(Hi*rij, Hdeti);
-              const auto Wj = W(Hj*rij, Hdetj);
+              const Vector rij = ri - rj;
+              const Scalar Wi = W(Hi*rij, Hdeti);
+              const Scalar Wj = W(Hj*rij, Hdetj);
 
               // Compute R.
               Ri += sgn(divvj)*mj*Wi;
               Rj += sgn(divvi)*mi*Wj;
 
               // Check the signal velocity.
-              const auto vsigij = 0.5*(csi + csj) - std::min(0.0, (vi - vj).dot(rij.unitVector()));
+              const Scalar vsigij = 0.5*(csi + csj) - std::min(0.0, (vi - vj).dot(rij.unitVector()));
               vsigi = std::max(vsigi, vsigij);
               vsigj = std::max(vsigj, vsigij);
             }
@@ -314,37 +303,39 @@ finalizeDerivatives(const Scalar /*time*/,
   //   mCullAlpha  -> alpha0
   //   mCullAlpha2 -> alpha_tmp.
   //   alpha_local -> alpha
-  
+  const FieldList<Dimension, Scalar> prevDivV = state.fields("mPrevDivV", 0.0);
+  const FieldList<Dimension, Scalar> alpha0 = state.fields("mCullAlpha", 0.0);
+  FieldList<Dimension, Scalar> alpha_tmp = derivs.fields("mCullAlpha2", 0.0);
   for (size_t nodeListi = 0; nodeListi != numNodeLists; ++nodeListi) {
     const size_t n = DvDx[nodeListi]->numInternalElements();
     for (size_t i = 0; i != n; ++i) {
-      const auto& Hi = H(nodeListi, i);
-      const auto Ri = R(nodeListi, i);
-      const auto vsigi = vsig(nodeListi, i);
-      const auto DvDxi = DvDx(nodeListi, i);
-      const auto divvi = DvDxi.Trace();
-      const auto divai = (divvi - prevDivV(nodeListi, i))*safeInvVar(dt);
-      const auto Si = DvDxi.Symmetric() - divvi/Dimension::nDim * Tensor::one;
-      const auto alphai = reducingViscosityMultiplierQ(nodeListi, i);
-      auto& alpha_locali = alpha_local(nodeListi, i);
+      const SymTensor& Hi = H(nodeListi, i);
+      const Scalar Ri = R(nodeListi, i);
+      const Scalar vsigi = vsig(nodeListi, i);
+      const Tensor DvDxi = DvDx(nodeListi, i);
+      const Scalar divvi = DvDxi.Trace();
+      const Scalar divai = (divvi - prevDivV(nodeListi, i))*safeInvVar(dt);
+      const Tensor Si = DvDxi.Symmetric() - divvi/Dimension::nDim * Tensor::one;
+      const Scalar alphai = reducingViscosityMultiplierQ(nodeListi, i);
+      Scalar& alpha_locali = alpha_local(nodeListi, i);
       if (mboolHopkins) {
-        const auto hi = kernelExtent*Dimension::nDim/Hi.Trace();  // Harmonic averaging.
-        const auto alpha0i = alpha0(nodeListi, i);
-        auto& alpha_tmpi = alpha_tmp(nodeListi, i);
+        const Scalar hi = kernelExtent*Dimension::nDim/Hi.Trace();  // Harmonic averaging.
+        const Scalar alpha0i = alpha0(nodeListi, i);
+        Scalar& alpha_tmpi = alpha_tmp(nodeListi, i);
         alpha_tmpi = ((divvi >= 0.0 or divai >= 0.0) ?
                       0.0 :
                       malphMax*std::abs(divai)*safeInvVar(std::abs(divai) + mbetaC*vsigi*vsigi/FastMath::pow2(mfKern*hi)));
-        const auto thpt = FastMath::pow2(mbetaE*FastMath::pow4(1.0 - Ri)*divvi);
+        const Scalar thpt = FastMath::pow2(mbetaE*FastMath::pow4(1.0 - Ri)*divvi);
         // const Scalar taui = hi/kernelExtent*safeInvVar(2.0*mbetaD*vsigi);
         alpha_locali = std::max(malphMin, thpt*alpha0i*safeInvVar(thpt + (Si*Si.Transpose()).Trace()));
         // We abuse DalphaDt here to store the new value for alpha0 in the Hopkins approximation.
         DalphaDt(nodeListi, i) = alpha_tmpi + std::max(0.0, alpha0i - alpha_tmpi)*exp(-mbetaD*dt*abs(vsigi)/(2.0*mfKern*hi));
       } else {
-        const auto hi = kernelExtent*Dimension::nDim/Hi.Trace();  // Harmonic averaging.
-        const auto thpt = FastMath::pow2(2.0*FastMath::pow4(1.0 - Ri)*divvi);
-        const auto zetai = thpt*safeInvVar(thpt + (Si*Si.Transpose()).Trace());
-        const auto Ai = zetai*std::max(-divai, 0.0);
-        const auto taui = hi*safeInvVar(2.0*mbetaD*vsigi);
+        const Scalar hi = kernelExtent*Dimension::nDim/Hi.Trace();  // Harmonic averaging.
+        const Scalar thpt = FastMath::pow2(2.0*FastMath::pow4(1.0 - Ri)*divvi);
+        const Scalar zetai = thpt*safeInvVar(thpt + (Si*Si.Transpose()).Trace());
+        const Scalar Ai = zetai*std::max(-divai, 0.0);
+        const Scalar taui = hi*safeInvVar(2.0*mbetaD*vsigi);
         DalphaDt(nodeListi, i) = std::min(0.0, alpha_locali - alphai)*safeInv(taui);
         alpha_locali = std::max(alphai, malphMax*hi*hi*Ai*safeInvVar(vsigi*vsigi + hi*hi*Ai));
       }
@@ -363,13 +354,11 @@ finalize(const typename Dimension::Scalar /*time*/,
          DataBase<Dimension>& /*dataBase*/,
          State<Dimension>& state,
          StateDerivatives<Dimension>& derivs) {
-
-  auto prevDvDt = state.fields("mPrevDvDt", Vector::zero);
-  auto prevDivV = state.fields("mPrevDivV", 0.0);
-  const auto DvDt = derivs.fields(HydroFieldNames::hydroAcceleration, Vector::zero);
-  const auto DvDx = derivs.fields(HydroFieldNames::velocityGradient, Tensor::zero);
-  
+  FieldList<Dimension, Vector> prevDvDt = state.fields("mPrevDvDt", Vector::zero);
+  const FieldList<Dimension, Vector> DvDt = derivs.fields(HydroFieldNames::hydroAcceleration, Vector::zero);
   prevDvDt.assignFields(DvDt);
+  FieldList<Dimension, Scalar> prevDivV = state.fields("mPrevDivV", 0.0);
+  const FieldList<Dimension, Tensor> DvDx = derivs.fields(HydroFieldNames::velocityGradient, Tensor::zero);
   const unsigned numNodeLists = DvDx.numFields();
   CHECK(prevDivV.numFields() == numNodeLists);
   for (unsigned nodeListi = 0; nodeListi != numNodeLists; ++nodeListi) {

--- a/src/ArtificialViscosity/CullenDehnenViscosity.hh
+++ b/src/ArtificialViscosity/CullenDehnenViscosity.hh
@@ -131,7 +131,7 @@ public:
   const FieldList<Dimension, Scalar>&    vsig() const; 
 private:
   //--------------------------- Private Interface ---------------------------//
-        
+         
   CullenDehnenViscosity();
   CullenDehnenViscosity(const CullenDehnenViscosity&);
   CullenDehnenViscosity& operator=(const CullenDehnenViscosity&) const;

--- a/src/ArtificialViscosity/CullenDehnenViscosity.hh
+++ b/src/ArtificialViscosity/CullenDehnenViscosity.hh
@@ -131,7 +131,7 @@ public:
   const FieldList<Dimension, Scalar>&    vsig() const; 
 private:
   //--------------------------- Private Interface ---------------------------//
-         
+
   CullenDehnenViscosity();
   CullenDehnenViscosity(const CullenDehnenViscosity&);
   CullenDehnenViscosity& operator=(const CullenDehnenViscosity&) const;

--- a/src/ArtificialViscosity/CullenDehnenViscosity.hh
+++ b/src/ArtificialViscosity/CullenDehnenViscosity.hh
@@ -127,7 +127,8 @@ public:
   const FieldList<Dimension, Scalar>&    DalphaDt() const;
   const FieldList<Dimension, Scalar>&    alphaLocal() const;
   const FieldList<Dimension, Scalar>&    alpha0() const;
-    
+  const FieldList<Dimension, Scalar>&    R() const;
+  const FieldList<Dimension, Scalar>&    vsig() const; 
 private:
   //--------------------------- Private Interface ---------------------------//
         
@@ -144,6 +145,9 @@ private:
   FieldList<Dimension, Scalar>    mDalphaDt;     // Time derivative of alpha
   FieldList<Dimension, Scalar>    mAlphaLocal;   // Alpha local to be filled in derivatives
   FieldList<Dimension, Scalar>    mAlpha0;       // The Hopkins form actually evolves alpha0
+  
+  FieldList<Dimension, Scalar>    mR;    //Will enroll as derivs fields
+  FieldList<Dimension, Scalar>    mVsig; //Will enroll as derivs fields
 
   Scalar malphMax, malphMin, mbetaC, mbetaD, mbetaE, mfKern;
   bool mboolHopkins;//Use Hopkins Reformulation
@@ -155,6 +159,8 @@ private:
 };
     
 }
+
+#include "CullenDehnenViscosityInline.hh"
 
 #else
 

--- a/src/ArtificialViscosity/CullenDehnenViscosityInline.hh
+++ b/src/ArtificialViscosity/CullenDehnenViscosityInline.hh
@@ -1,0 +1,180 @@
+namespace Spheral{
+
+// Accessor Fns
+template<typename Dimension>
+inline
+void
+CullenDehnenViscosity<Dimension>::
+alphMax(Scalar val)
+{
+    malphMax = val;
+}
+
+template<typename Dimension>
+inline
+void
+CullenDehnenViscosity<Dimension>::
+alphMin(Scalar val)
+{
+    malphMin = val;
+}
+
+template<typename Dimension>
+inline
+void
+CullenDehnenViscosity<Dimension>::
+betaE(Scalar val)
+{
+    mbetaE = val;
+}
+
+template<typename Dimension>
+inline
+void
+CullenDehnenViscosity<Dimension>::
+betaD(Scalar val)
+{
+    mbetaD = val;
+}
+
+template<typename Dimension>
+inline
+void
+CullenDehnenViscosity<Dimension>::
+betaC(Scalar val)
+{
+    mbetaC = val;
+}
+
+template<typename Dimension>
+inline
+void
+CullenDehnenViscosity<Dimension>::
+fKern(Scalar val)
+{
+    mfKern = val;
+}
+
+template<typename Dimension>
+inline
+void
+CullenDehnenViscosity<Dimension>::
+boolHopkins(bool val)
+{
+    mboolHopkins = val;
+}
+
+//------------------------------------------------------------------------------
+// Access the main kernel
+//------------------------------------------------------------------------------
+template<typename Dimension>
+inline
+const TableKernel<Dimension>&
+CullenDehnenViscosity<Dimension>::kernel() const {
+  return mKernel;
+}
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, typename Dimension::Vector>&
+CullenDehnenViscosity<Dimension>::PrevDvDt() const {
+   return mPrevDvDt;
+}
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, typename Dimension::Scalar>&
+CullenDehnenViscosity<Dimension>::PrevDivV() const {
+   return mPrevDivV;
+}
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, typename Dimension::Scalar>&
+CullenDehnenViscosity<Dimension>::PrevDivV2() const {
+   return mPrevDivV2;
+}
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, typename Dimension::Scalar>&
+CullenDehnenViscosity<Dimension>::CullAlpha() const {
+   return mCullAlpha;
+}
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, typename Dimension::Scalar>&
+CullenDehnenViscosity<Dimension>::CullAlpha2() const {
+   return mCullAlpha2;
+}
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, typename Dimension::Scalar>&
+CullenDehnenViscosity<Dimension>::R() const {
+   return mR;
+}
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, typename Dimension::Scalar>&
+CullenDehnenViscosity<Dimension>::vsig() const {
+   return mVsig;
+}
+
+template<typename Dimension>
+inline
+typename Dimension::Scalar
+CullenDehnenViscosity<Dimension>::
+alphMax() const{return malphMax;}
+
+template<typename Dimension>
+inline
+typename Dimension::Scalar
+CullenDehnenViscosity<Dimension>::
+alphMin() const{return malphMin;}
+
+template<typename Dimension>
+inline
+typename Dimension::Scalar
+CullenDehnenViscosity<Dimension>::
+betaE() const{return mbetaE;}
+
+template<typename Dimension>
+inline
+typename Dimension::Scalar
+CullenDehnenViscosity<Dimension>::
+betaD() const{return mbetaD;}
+
+template<typename Dimension>
+inline
+typename Dimension::Scalar
+CullenDehnenViscosity<Dimension>::
+betaC() const{return mbetaC;}
+
+template<typename Dimension>
+inline
+typename Dimension::Scalar
+CullenDehnenViscosity<Dimension>::
+fKern() const{return mfKern;}
+
+template<typename Dimension>
+inline
+bool 
+CullenDehnenViscosity<Dimension>::
+boolHopkins() const{return mboolHopkins;}
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, typename Dimension::Scalar>&
+CullenDehnenViscosity<Dimension>::
+DalphaDt() const{ return mDalphaDt;}
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, typename Dimension::Scalar>&
+CullenDehnenViscosity<Dimension>::
+alphaLocal() const{ return mAlphaLocal;}
+
+}

--- a/src/Pybind11Wraps/ArtificialViscosity/CullenDehnenViscosity.py
+++ b/src/Pybind11Wraps/ArtificialViscosity/CullenDehnenViscosity.py
@@ -98,7 +98,9 @@ Hopkins arXiv:1409.7395
     CullAlpha2  = PYB11property("const FieldList<%(Dimension)s, Scalar>&", "CullAlpha2", returnpolicy="reference_internal")
     DalphaDt = PYB11property("const FieldList<%(Dimension)s, Scalar>&", "DalphaDt", returnpolicy="reference_internal")
     alphaLocal = PYB11property("const FieldList<%(Dimension)s, Scalar>&", "alphaLocal", returnpolicy="reference_internal")
-
+    R = PYB11property("const FieldList<%(Dimension)s, Scalar>&", "R", returnpolicy="reference_internal")
+    vsig = PYB11property("const FieldList<%(Dimension)s, Scalar>&", "vsig", returnpolicy="reference_internal")
+    
 #-------------------------------------------------------------------------------
 # Inject abstract interface
 #-------------------------------------------------------------------------------

--- a/tests/functional/Hydro/Sod/Sod-planar-1d.py
+++ b/tests/functional/Hydro/Sod/Sod-planar-1d.py
@@ -3,8 +3,8 @@
 #
 #ATS:sph1 = test(        SELF, "--crksph False --cfl 0.25 --graphics None --clearDirectories True  --restartStep 20 --steps 40", label="Planar Sod problem with SPH -- 1-D (serial)")
 #ATS:sph2 = testif(sph1, SELF, "--crksph False --cfl 0.25 --graphics None --clearDirectories False --restartStep 20 --steps 20 --restoreCycle 20 --checkRestart True", label="Planar Sod problem with SPH -- 1-D (serial) RESTART CHECK")
-#ATS:sphCD = test(        SELF, "--boolReduceViscosity --crksph False --cfl 0.25 --graphics None --clearDirectories True  --restartStep 20 --steps 40", label="Planar Sod problem with SPH and Morris-Monaghan Artificial Viscosity Limiter -- 1-D (serial)")
-#ATS:sphMMR = test(        SELF, "--boolCullenViscosity --crksph False --cfl 0.25 --graphics None --clearDirectories True  --restartStep 20 --steps 40", label="Planar Sod problem with SPH and Cullen-Dehnen Artificial Viscosity Limiter  -- 1-D (serial)")
+#ATS:sphCD = test(       SELF, "--boolReduceViscosity True --crksph False --cfl 0.25 --graphics None --clearDirectories True  --restartStep 20 --steps 40", label="Planar Sod problem with SPH and Morris-Monaghan Artificial Viscosity Limiter -- 1-D (serial)")
+#ATS:sphMMR = test(      SELF, "--boolCullenViscosity True --crksph False --cfl 0.25 --graphics None --clearDirectories True  --restartStep 20 --steps 40", label="Planar Sod problem with SPH and Cullen-Dehnen Artificial Viscosity Limiter  -- 1-D (serial)")
 #
 # CRK
 #
@@ -167,12 +167,20 @@ else:
 if solid:
     hydroname = "Solid" + hydroname
 
+
+if boolReduceViscosity:
+    viscosityLimiter="MorrisMonaghanViscosityLimiter"                               
+elif boolCullenViscosity:
+    viscosityLimiter="CullenDehnenViscosityLimiter"
+else:
+    viscosityLimiter = "NoViscosityLimiter"
+
 dataDir = os.path.join(dataDirBase, 
                        "numNodeLists=%i" % numNodeLists,
                        hydroname,
                        "nPerh=%f" % nPerh,
                        "compatibleEnergy=%s" % compatibleEnergy,
-                       "Cullen=%s" % boolCullenViscosity,
+                       viscosityLimiter,
                        "Condc=%s" % HopkinsConductivity,
                        "filter=%f" % filter,
                        "%i" % (nx1 + nx2))

--- a/tests/functional/Hydro/Sod/Sod-planar-1d.py
+++ b/tests/functional/Hydro/Sod/Sod-planar-1d.py
@@ -3,6 +3,8 @@
 #
 #ATS:sph1 = test(        SELF, "--crksph False --cfl 0.25 --graphics None --clearDirectories True  --restartStep 20 --steps 40", label="Planar Sod problem with SPH -- 1-D (serial)")
 #ATS:sph2 = testif(sph1, SELF, "--crksph False --cfl 0.25 --graphics None --clearDirectories False --restartStep 20 --steps 20 --restoreCycle 20 --checkRestart True", label="Planar Sod problem with SPH -- 1-D (serial) RESTART CHECK")
+#ATS:sphCD = test(        SELF, "--boolReduceViscosity --crksph False --cfl 0.25 --graphics None --clearDirectories True  --restartStep 20 --steps 40", label="Planar Sod problem with SPH and Morris-Monaghan Artificial Viscosity Limiter -- 1-D (serial)")
+#ATS:sphMMR = test(        SELF, "--boolCullenViscosity --crksph False --cfl 0.25 --graphics None --clearDirectories True  --restartStep 20 --steps 40", label="Planar Sod problem with SPH and Cullen-Dehnen Artificial Viscosity Limiter  -- 1-D (serial)")
 #
 # CRK
 #
@@ -24,6 +26,7 @@
 #ATS:mfm1 = test(         SELF, "--mfm True --cfl 0.25 --graphics None --clearDirectories True  --restartStep 20 --steps 40", label="Planar Sod problem with MFM -- 1-D (serial)")
 #ATS:mfm2 = testif(mfm1,  SELF, "--mfm True --cfl 0.25 --graphics None --clearDirectories False --restartStep 20 --steps 20 --restoreCycle 20 --checkRestart True", label="Planar Sod problem with MFM -- 1-D (serial) RESTART CHECK")
 #
+
 import os, sys
 import shutil
 from SolidSpheral1d import *


### PR DESCRIPTION
CullenDehnen artificial viscosity package was throwing a seg fault. Needed to have the DvDt hydrofieldname updated for modern spheral. All the other changes are aesthetic: made a bunch of types auto, added R and v_sig as fieldlists to remove the call to newFluidFieldList in the FinalizeDerivs method, and parsed out the set-get methods into an inline file.