### PR TITLE
Single C++ lib

### DIFF
--- a/cmake/Compilers.cmake
+++ b/cmake/Compilers.cmake
@@ -48,7 +48,10 @@ if (NOT ENABLE_MISSING_INCLUDE_DIR_WARNINGS)
 endif()
 message("-- Compiler missing include dir warnings ${ENABLE_MISSING_INCLUDE_DIR_WARNINGS}")
 
+set(CUDA_WARNING_FLAGS -Xcudafe=\"--diag_suppress=esa_on_defaulted_function_ignored\")
+
 add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:${CXX_WARNING_FLAGS}>")
+add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${CUDA_WARNING_FLAGS}>")
 message("-- using warning flags ${CXX_WARNING_FLAGS}")
 
 # We build some Fortran code from outside sources (like the Helmholtz EOS) that

--- a/cmake/SetupSpheral.cmake
+++ b/cmake/SetupSpheral.cmake
@@ -70,7 +70,6 @@ if(ENABLE_CUDA)
   #set(CMAKE_CUDA_FLAGS  "${CMAKE_CUDA_FLAGS} -arch=${CUDA_ARCH} --extended-lambda -Xcudafe --display_error_number")
   set(CMAKE_CUDA_STANDARD 14)
   list(APPEND SPHERAL_CXX_DEPENDS cuda)
-  set(ENABLE_SHARED OFF)
 endif()
 
 option(BOOST_HEADER_ONLY "only use the header only components of Boost" OFF)

--- a/cmake/spheral/SpheralAddLibs.cmake
+++ b/cmake/spheral/SpheralAddLibs.cmake
@@ -27,6 +27,7 @@ function(spheral_add_cxx_library package_name)
                     HEADERS     ${${package_name}_headers}
                     SOURCES     ${${package_name}_sources}
                     DEPENDS_ON  -Wl,--start-group ${spheral_blt_depends} ${${package_name}_ADDITIONAL_DEPENDS} ${SPHERAL_CXX_DEPENDS} -Wl,--end-group
+                    OBJECT TRUE
                     SHARED      FALSE
                     )
   else()
@@ -35,6 +36,7 @@ function(spheral_add_cxx_library package_name)
                     HEADERS     ${${package_name}_headers}
                     SOURCES     ${${package_name}_sources}
                     DEPENDS_ON  -Wl,--start-group ${spheral_blt_depends} ${${package_name}_ADDITIONAL_DEPENDS} ${SPHERAL_CXX_DEPENDS} -Wl,--end-group
+                    OBJECT TRUE
                     SHARED      TRUE
                     )
   endif()
@@ -106,7 +108,7 @@ function(spheral_add_pybind11_library package_name)
   set(MODULE_NAME Spheral${package_name})
   blt_add_library(NAME         ${MODULE_NAME}
                   SOURCES      ${PYB11_GENERATED_SOURCE} ${${package_name}_ADDITIONAL_SOURCES}
-                  DEPENDS_ON   -Wl,--start-group ${SPHERAL_CXX_LIBS} ${spheral_blt_depends} ${${package_name}_ADDITIONAL_DEPENDS} ${SPHERAL_CXX_DEPENDS} -Wl,--end-group
+                  DEPENDS_ON   -Wl,--start-group Spheral_CXX ${spheral_blt_depends} ${${package_name}_ADDITIONAL_DEPENDS} -Wl,--end-group
                   INCLUDES     ${${package_name}_ADDITIONAL_INCLUDES}
                   OUTPUT_NAME  ${MODULE_NAME}
                   CLEAR_PREFIX TRUE

--- a/cmake/tpl/axom.cmake
+++ b/cmake/tpl/axom.cmake
@@ -1,3 +1,3 @@
 set(${lib_name}_libs 
-    libaxom.so 
+    libaxom.a 
    )

--- a/cmake/tpl/conduit.cmake
+++ b/cmake/tpl/conduit.cmake
@@ -1,18 +1,18 @@
 list(APPEND ${lib_name}_INCLUDES $<BUILD_INTERFACE:${${lib_name}_DIR}/include/${lib_name}>)
 
 set(${lib_name}_libs 
-    libconduit.so
-    libconduit_blueprint.so
-    libconduit_relay.so
+    libconduit.a
+    libconduit_blueprint.a
+    libconduit_relay.a
    )
 
 if(ENABLE_MPI)
   list(APPEND ${lib_name}_libs
-    libconduit_blueprint_mpi.so
-    libconduit_relay_mpi.so
-    libconduit_relay_mpi_io.so)
+    libconduit_blueprint_mpi.a
+    libconduit_relay_mpi.a
+    libconduit_relay_mpi_io.a)
 endif()
 
-if(ENABLE_STATIC_TPL)
-  string(REPLACE ".so" ".a;" ${lib_name}_libs ${${lib_name}_libs})
-endif()
+#if(ENABLE_STATIC_TPL)
+#  string(REPLACE ".so" ".a;" ${lib_name}_libs ${${lib_name}_libs})
+#endif()

--- a/cmake/tpl/conduit.cmake
+++ b/cmake/tpl/conduit.cmake
@@ -1,18 +1,18 @@
 list(APPEND ${lib_name}_INCLUDES $<BUILD_INTERFACE:${${lib_name}_DIR}/include/${lib_name}>)
 
 set(${lib_name}_libs 
-    libconduit.a
-    libconduit_blueprint.a
-    libconduit_relay.a
+    libconduit.so
+    libconduit_blueprint.so
+    libconduit_relay.so
    )
 
 if(ENABLE_MPI)
   list(APPEND ${lib_name}_libs
-    libconduit_blueprint_mpi.a
-    libconduit_relay_mpi.a
-    libconduit_relay_mpi_io.a)
+    libconduit_blueprint_mpi.so
+    libconduit_relay_mpi.so
+    libconduit_relay_mpi_io.so)
 endif()
 
-#if(ENABLE_STATIC_TPL)
-#  string(REPLACE ".so" ".a;" ${lib_name}_libs ${${lib_name}_libs})
-#endif()
+if(ENABLE_STATIC_TPL)
+  string(REPLACE ".so" ".a;" ${lib_name}_libs ${${lib_name}_libs})
+endif()

--- a/cmake/tpl/qhull.cmake
+++ b/cmake/tpl/qhull.cmake
@@ -1,5 +1,5 @@
 # Setting this to just the release library until we support TPL debug builds on LC
-set(${lib_name}_libs libqhullstatic.a)
+set(${lib_name}_libs libqhull.so)
 if(ENABLE_STATIC_TPL)
   set(${lib_name}_libs libqhullstatic.a)
 endif()

--- a/cmake/tpl/qhull.cmake
+++ b/cmake/tpl/qhull.cmake
@@ -1,5 +1,5 @@
 # Setting this to just the release library until we support TPL debug builds on LC
-set(${lib_name}_libs libqhull.so)
+set(${lib_name}_libs libqhullstatic.a)
 if(ENABLE_STATIC_TPL)
   set(${lib_name}_libs libqhullstatic.a)
 endif()

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -50,8 +50,8 @@ class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
     depends_on('silo@4.10.2 +hdf5', type='build')
 
     # Zlib fix has been merged into conduit, using develop until next release.
-    depends_on('conduit@0.8.2 ~shared +mpi +hdf5 -test', type='build', when='+mpi')
-    depends_on('conduit@0.8.2 ~shared ~mpi +hdf5 -test', type='build', when='~mpi')
+    depends_on('conduit@0.8.2 +shared +mpi +hdf5 -test', type='build', when='+mpi')
+    depends_on('conduit@0.8.2 +shared ~mpi +hdf5 -test', type='build', when='~mpi')
 
     depends_on('axom@0.5.0 ~shared +mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='+mpi')
     depends_on('axom@0.5.0 ~shared ~mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='~mpi')

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -28,8 +28,7 @@ class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
     variant('mpi', default=True, description='Enable MPI Support.')
     variant('openmp', default=True, description='Enable OpenMP Support.')
     variant('docs', default=False, description='Enable building Docs.')
-    variant('shared', default=True, when='~cuda', description='Build C++ libs as shared.')
-    variant('shared', default=False, when='+cuda', description='Build C++ libs as shared.')
+    variant('shared', default=True, description='Build C++ libs as shared.')
 
     # -------------------------------------------------------------------------
     # DEPENDS
@@ -54,8 +53,8 @@ class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
     depends_on('conduit@0.8.2 +mpi +hdf5 -test', type='build', when='+mpi')
     depends_on('conduit@0.8.2 ~mpi +hdf5 -test', type='build', when='~mpi')
 
-    depends_on('axom@0.5.0 +shared +mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='+mpi')
-    depends_on('axom@0.5.0 +shared ~mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='~mpi')
+    depends_on('axom@0.5.0 ~shared +mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='+mpi')
+    depends_on('axom@0.5.0 ~shared ~mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='~mpi')
 
     depends_on('opensubdiv@3.4.3', type='build')
     depends_on('polytope', type='build')
@@ -75,7 +74,6 @@ class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
     # DEPENDS
     # -------------------------------------------------------------------------
     conflicts('cuda_arch=none', when='+cuda', msg='CUDA architecture is required')
-    conflicts('+shared', when='+cuda', msg='Cannot build C++ libs shared when CUDA is enabled.')
 
     def _get_sys_type(self, spec):
         sys_type = spec.architecture

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -50,8 +50,8 @@ class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
     depends_on('silo@4.10.2 +hdf5', type='build')
 
     # Zlib fix has been merged into conduit, using develop until next release.
-    depends_on('conduit@0.8.2 +mpi +hdf5 -test', type='build', when='+mpi')
-    depends_on('conduit@0.8.2 ~mpi +hdf5 -test', type='build', when='~mpi')
+    depends_on('conduit@0.8.2 ~shared +mpi +hdf5 -test', type='build', when='+mpi')
+    depends_on('conduit@0.8.2 ~shared ~mpi +hdf5 -test', type='build', when='~mpi')
 
     depends_on('axom@0.5.0 ~shared +mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='+mpi')
     depends_on('axom@0.5.0 ~shared ~mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='~mpi')

--- a/src/ArtificialConduction/CMakeLists.txt
+++ b/src/ArtificialConduction/CMakeLists.txt
@@ -12,5 +12,5 @@ set(ArtificialConduction_headers
     ArtificialConductionPolicy.hh
     ) 
 
-spheral_add_cxx_library(ArtificialConduction)
+spheral_add_obj_library(ArtificialConduction)
 

--- a/src/ArtificialViscosity/CMakeLists.txt
+++ b/src/ArtificialViscosity/CMakeLists.txt
@@ -50,5 +50,5 @@ set(ArtificialViscosity_headers
     VonNeumanViscosity.hh
     )
 
-spheral_add_cxx_library(ArtificialViscosity)
+spheral_add_obj_library(ArtificialViscosity)
 

--- a/src/Boundary/CMakeLists.txt
+++ b/src/Boundary/CMakeLists.txt
@@ -80,5 +80,5 @@ set(Boundary_headers
 
 spheral_install_python_files(ExpandingDomain.py)
 
-spheral_add_cxx_library(Boundary)
+spheral_add_obj_library(Boundary)
 

--- a/src/Boundary/InflowOutflowBoundaryInst.cc.py
+++ b/src/Boundary/InflowOutflowBoundaryInst.cc.py
@@ -2,7 +2,7 @@ text = """
 //------------------------------------------------------------------------------
 // Explicit instantiation.
 //------------------------------------------------------------------------------
-#include "InflowOutflowBoundary.cc"
+#include "Boundary/InflowOutflowBoundary.cc"
 #include "Geometry/Dimension.hh"
 
 namespace Spheral {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,19 +65,24 @@ message("${SPHERAL_CXX_LIBS}")
 message("CHECK")
 blt_add_library(NAME        Spheral_CXX
                 SOURCES     spheralCXX.cc
-                DEPENDS_ON  ${SPHERAL_CXX_LIBS}
+                DEPENDS_ON  ${SPHERAL_CXX_LIBS} ${SPHERAL_CXX_DEPENDS}
                 SHARED      TRUE
                 )
-  # Install Spheral C++ target and set it as an exportable CMake target
-  install(TARGETS             Spheral_CXX
-          DESTINATION         lib
-          EXPORT              ${PROJECT_NAME}-targets
-          )
 
-  # Set the r-path of the C++ lib such that it is independent of the build dir when installed
-  set_target_properties(Spheral_CXX PROPERTIES
-                      INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${qhull_DIR}/lib;${conduit_DIR}/lib;${axom_DIR}/lib;${boost_DIR}/lib"
-                      )
+if(ENABLE_CUDA)
+  set_target_properties(Spheral_CXX PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+endif()
+
+# Install Spheral C++ target and set it as an exportable CMake target
+install(TARGETS             Spheral_CXX
+        DESTINATION         lib
+        EXPORT              ${PROJECT_NAME}-targets
+        )
+
+# Set the r-path of the C++ lib such that it is independent of the build dir when installed
+set_target_properties(Spheral_CXX PROPERTIES
+                    INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${qhull_DIR}/lib;${conduit_DIR}/lib;${axom_DIR}/lib;${boost_DIR}/lib"
+                    )
 
 include_directories(${extra_packages_DIR})
 foreach(e_package ${extra_packages})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,34 +59,13 @@ foreach(_package ${_packages})
   add_subdirectory(${_package})
 endforeach()
 
-#spheral_add_cxx_library(CXX)
-get_property(SPHERAL_CXX_LIBS GLOBAL PROPERTY SPHERAL_CXX_LIBS)
-message("${SPHERAL_CXX_LIBS}")
-message("CHECK")
-blt_add_library(NAME        Spheral_CXX
-                SOURCES     spheralCXX.cc
-                DEPENDS_ON  ${SPHERAL_CXX_LIBS} ${SPHERAL_CXX_DEPENDS}
-                SHARED      TRUE
-                )
-
-if(ENABLE_CUDA)
-  set_target_properties(Spheral_CXX PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-endif()
-
-# Install Spheral C++ target and set it as an exportable CMake target
-install(TARGETS             Spheral_CXX
-        DESTINATION         lib
-        EXPORT              ${PROJECT_NAME}-targets
-        )
-
-# Set the r-path of the C++ lib such that it is independent of the build dir when installed
-set_target_properties(Spheral_CXX PROPERTIES
-                    INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${qhull_DIR}/lib;${conduit_DIR}/lib;${axom_DIR}/lib;${boost_DIR}/lib"
-                    )
-
 include_directories(${extra_packages_DIR})
 foreach(e_package ${extra_packages})
   add_subdirectory(${extra_packages_DIR}/${e_package} ${CMAKE_CURRENT_BINARY_DIR}/${e_package})
 endforeach()
+
+set(CXX_sources spheralCXX.cc)
+
+spheral_add_cxx_library(CXX)
 
 install(EXPORT ${PROJECT_NAME}-targets DESTINATION Spheral/lib/cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,26 @@ foreach(_package ${_packages})
   add_subdirectory(${_package})
 endforeach()
 
+#spheral_add_cxx_library(CXX)
+get_property(SPHERAL_CXX_LIBS GLOBAL PROPERTY SPHERAL_CXX_LIBS)
+message("${SPHERAL_CXX_LIBS}")
+message("CHECK")
+blt_add_library(NAME        Spheral_CXX
+                SOURCES     spheralCXX.cc
+                DEPENDS_ON  ${SPHERAL_CXX_LIBS}
+                SHARED      TRUE
+                )
+  # Install Spheral C++ target and set it as an exportable CMake target
+  install(TARGETS             Spheral_CXX
+          DESTINATION         lib
+          EXPORT              ${PROJECT_NAME}-targets
+          )
+
+  # Set the r-path of the C++ lib such that it is independent of the build dir when installed
+  set_target_properties(Spheral_CXX PROPERTIES
+                      INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${qhull_DIR}/lib;${conduit_DIR}/lib;${axom_DIR}/lib;${boost_DIR}/lib"
+                      )
+
 include_directories(${extra_packages_DIR})
 foreach(e_package ${extra_packages})
   add_subdirectory(${extra_packages_DIR}/${e_package} ${CMAKE_CURRENT_BINARY_DIR}/${e_package})

--- a/src/CRKSPH/CMakeLists.txt
+++ b/src/CRKSPH/CMakeLists.txt
@@ -49,7 +49,7 @@ set(CRKSPH_headers
     zerothOrderSurfaceCorrections.hh
     )
 
-spheral_add_cxx_library(CRKSPH)
+spheral_add_obj_library(CRKSPH)
     
 spheral_install_python_files(CRKSPHHydros.py)
 

--- a/src/CXXTests/DeviceTestLib/CMakeLists.txt
+++ b/src/CXXTests/DeviceTestLib/CMakeLists.txt
@@ -14,5 +14,5 @@ set(DeviceTestLib_headers
 spheral_install_python_files(
     )
 
-spheral_add_cxx_library(DeviceTestLib)
+spheral_add_obj_library(DeviceTestLib)
 

--- a/src/Damage/CMakeLists.txt
+++ b/src/Damage/CMakeLists.txt
@@ -73,5 +73,5 @@ spheral_install_python_files(
   ShadowIvanoviSALEDamageModel.py
   )
 
-spheral_add_cxx_library(Damage)
+spheral_add_obj_library(Damage)
 

--- a/src/DataBase/CMakeLists.txt
+++ b/src/DataBase/CMakeLists.txt
@@ -54,5 +54,5 @@ set(DataBase_headers
     UpdatePolicyBaseInline.hh
     )
 
-spheral_add_cxx_library(DataBase)
+spheral_add_obj_library(DataBase)
 

--- a/src/DataOutput/CMakeLists.txt
+++ b/src/DataOutput/CMakeLists.txt
@@ -14,5 +14,5 @@ set(DataOutput_headers
     registerWithRestart.hh
     )
 
-spheral_add_cxx_library(DataOutput)
+spheral_add_obj_library(DataOutput)
 

--- a/src/Distributed/CMakeLists.txt
+++ b/src/Distributed/CMakeLists.txt
@@ -70,7 +70,7 @@ if (ENABLE_MPI)
           RENAME      mpi.py
           )
 
-  spheral_add_cxx_library(Distributed)
+  spheral_add_obj_library(Distributed)
 
 else()
   #----------------------------------------------------------------------------

--- a/src/ExternalForce/CMakeLists.txt
+++ b/src/ExternalForce/CMakeLists.txt
@@ -27,5 +27,5 @@ set(ExternalForce_includes
    )
 
 
-spheral_add_cxx_library(ExternalForce)
+spheral_add_obj_library(ExternalForce)
 

--- a/src/FSISPH/CMakeLists.txt
+++ b/src/FSISPH/CMakeLists.txt
@@ -26,5 +26,5 @@ spheral_install_python_files(
   SlideSurfaces.py
   )
 
-spheral_add_cxx_library(FSISPH)
+spheral_add_obj_library(FSISPH)
 

--- a/src/Field/CMakeLists.txt
+++ b/src/Field/CMakeLists.txt
@@ -45,5 +45,5 @@ set(Field_headers
     uvm_allocator.hh
     )
 
-spheral_add_cxx_library(Field)
+spheral_add_obj_library(Field)
 

--- a/src/FieldOperations/CMakeLists.txt
+++ b/src/FieldOperations/CMakeLists.txt
@@ -40,5 +40,5 @@ set(FieldOperations_headers
     sampleMultipleFields2Lattice.hh
     )
 
-spheral_add_cxx_library(FieldOperations)
+spheral_add_obj_library(FieldOperations)
 

--- a/src/FileIO/CMakeLists.txt
+++ b/src/FileIO/CMakeLists.txt
@@ -27,5 +27,5 @@ spheral_install_python_files(
   PlyFileIO.py
   )
 
-spheral_add_cxx_library(FileIO)
+spheral_add_obj_library(FileIO)
 

--- a/src/GSPH/CMakeLists.txt
+++ b/src/GSPH/CMakeLists.txt
@@ -59,5 +59,5 @@ instantiate(GSPH_inst GSPH_sources)
 
 spheral_install_python_files(GSPHHydros.py)
 
-spheral_add_cxx_library(GSPH)
+spheral_add_obj_library(GSPH)
 

--- a/src/Geometry/CMakeLists.txt
+++ b/src/Geometry/CMakeLists.txt
@@ -100,5 +100,5 @@ set(Geometry_headers
     outerProduct.hh
     )
 
-spheral_add_cxx_library(Geometry)
+spheral_add_obj_library(Geometry)
 

--- a/src/Gravity/CMakeLists.txt
+++ b/src/Gravity/CMakeLists.txt
@@ -17,5 +17,5 @@ set(Gravity_headers
   )
 
 
-spheral_add_cxx_library(Gravity)
+spheral_add_obj_library(Gravity)
 

--- a/src/Hydro/CMakeLists.txt
+++ b/src/Hydro/CMakeLists.txt
@@ -59,5 +59,5 @@ set(Hydro_headers
     entropyWeightingFunction.hh
     )
 
-spheral_add_cxx_library(Hydro)
+spheral_add_obj_library(Hydro)
 

--- a/src/Integrator/CMakeLists.txt
+++ b/src/Integrator/CMakeLists.txt
@@ -24,5 +24,5 @@ set(Integrator_headers
     Verlet.hh
     )
 
-spheral_add_cxx_library(Integrator)
+spheral_add_obj_library(Integrator)
 

--- a/src/Kernel/CMakeLists.txt
+++ b/src/Kernel/CMakeLists.txt
@@ -68,5 +68,5 @@ set(Kernel_headers
     WendlandC6KernelInline.hh
     )
 
-spheral_add_cxx_library(Kernel)
+spheral_add_obj_library(Kernel)
 

--- a/src/Material/CMakeLists.txt
+++ b/src/Material/CMakeLists.txt
@@ -42,5 +42,5 @@ endif()
 
 instantiate(Material_inst Material_sources)
 
-spheral_add_cxx_library(Material)
+spheral_add_obj_library(Material)
 

--- a/src/Mesh/CMakeLists.txt
+++ b/src/Mesh/CMakeLists.txt
@@ -54,5 +54,5 @@ spheral_install_python_files(
   siloMeshDump.py
   )
 
-spheral_add_cxx_library(Mesh)
+spheral_add_obj_library(Mesh)
 

--- a/src/Neighbor/CMakeLists.txt
+++ b/src/Neighbor/CMakeLists.txt
@@ -30,5 +30,5 @@ set(Neighbor_headers
     TreeNeighbor.hh
     )
 
-spheral_add_cxx_library(Neighbor)
+spheral_add_obj_library(Neighbor)
 

--- a/src/NodeGenerators/CMakeLists.txt
+++ b/src/NodeGenerators/CMakeLists.txt
@@ -68,5 +68,5 @@ spheral_install_python_files(
   GenerateSphericalNodeDistribution1d.py
   )
 
-spheral_add_cxx_library(NodeGenerators)
+spheral_add_obj_library(NodeGenerators)
 

--- a/src/NodeList/CMakeLists.txt
+++ b/src/NodeList/CMakeLists.txt
@@ -41,5 +41,5 @@ spheral_install_python_files(
   VoidNodeLists.py
   )
 
-spheral_add_cxx_library(NodeList)
+spheral_add_obj_library(NodeList)
 

--- a/src/Physics/CMakeLists.txt
+++ b/src/Physics/CMakeLists.txt
@@ -17,5 +17,5 @@ set(Physics_headers
     PhysicsInline.hh
     )
 
-spheral_add_cxx_library(Physics)
+spheral_add_obj_library(Physics)
 

--- a/src/Pybind11Wraps/CXXTests/CMakeLists.txt
+++ b/src/Pybind11Wraps/CXXTests/CMakeLists.txt
@@ -1,2 +1,2 @@
-set(CXXTests_ADDITIONAL_DEPENDS Spheral_DeviceTestLib)
+#set(CXXTests_ADDITIONAL_DEPENDS Spheral_DeviceTestLib)
 spheral_add_pybind11_library(CXXTests)

--- a/src/RK/CMakeLists.txt
+++ b/src/RK/CMakeLists.txt
@@ -61,5 +61,5 @@ set(RK_headers
     interpolateRK.hh
     )
 
-spheral_add_cxx_library(RK)
+spheral_add_obj_library(RK)
 

--- a/src/SPH/CMakeLists.txt
+++ b/src/SPH/CMakeLists.txt
@@ -63,5 +63,5 @@ spheral_install_python_files(
     FacetedSurfaceASPHHydro.py
     )
 
-spheral_add_cxx_library(SPH)
+spheral_add_obj_library(SPH)
 

--- a/src/SVPH/CMakeLists.txt
+++ b/src/SVPH/CMakeLists.txt
@@ -42,5 +42,5 @@ set(SVPH_headers
 
 spheral_install_python_files(SVPHHydros.py)
 
-spheral_add_cxx_library(SVPH)
+spheral_add_obj_library(SVPH)
 

--- a/src/SolidMaterial/CMakeLists.txt
+++ b/src/SolidMaterial/CMakeLists.txt
@@ -80,5 +80,5 @@ instantiate(SolidMaterial_inst SolidMaterial_sources)
 # Ignore -W-maybe-uninitialized warnings thrown from bisectSearch for possibly uninitialized iterators from boost multi-array.
 set_source_files_properties(ANEOSInst1d.cc ANEOSInst2d.cc ANEOSInst3d.cc PROPERTIES COMPILE_FLAGS "$<$<COMPILE_LANGUAGE:CXX>:-Wno-uninitialized>")
 
-spheral_add_cxx_library(SolidMaterial)
+spheral_add_obj_library(SolidMaterial)
 

--- a/src/SolidMaterial/CMakeLists.txt
+++ b/src/SolidMaterial/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 instantiate(SolidMaterial_inst SolidMaterial_sources)
 
 # Ignore -W-maybe-uninitialized warnings thrown from bisectSearch for possibly uninitialized iterators from boost multi-array.
-set_source_files_properties(ANEOSInst1d.cc ANEOSInst2d.cc ANEOSInst3d.cc PROPERTIES COMPILE_FLAGS -Wno-uninitialized)
+set_source_files_properties(ANEOSInst1d.cc ANEOSInst2d.cc ANEOSInst3d.cc PROPERTIES COMPILE_FLAGS "$<$<COMPILE_LANGUAGE:CXX>:-Wno-uninitialized>")
 
 spheral_add_cxx_library(SolidMaterial)
 

--- a/src/Strength/CMakeLists.txt
+++ b/src/Strength/CMakeLists.txt
@@ -27,5 +27,5 @@ set(Strength_headers
     effectiveKernelVolume.hh
     )
 
-spheral_add_cxx_library(Strength)
+spheral_add_obj_library(Strength)
 

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -142,5 +142,5 @@ set(Utilities_headers
 
 spheral_install_python_files(fitspline.py)
 
-spheral_add_cxx_library(Utilities)
+spheral_add_obj_library(Utilities)
 

--- a/src/spheralCXX.cc
+++ b/src/spheralCXX.cc
@@ -1,0 +1,1 @@
+// Dummy file to link C++ object libs.


### PR DESCRIPTION
# Summary
This PR is a refactor of the C++ Spheral library structure.

## Design Review
This PR refactors our current C++ libraries to be defined in CMake as OBJECT libraries (A collection of compiled object files and headers without a linked library). These object libraries are then linked into a single `SpheralCXX` library.

This is required to solve a number of runtime anomalies found when running the python interface of Spheral. These anomalies commonly occurred when building Spheral C++ libs as static.

### Other Wins
 - The single C++ library also seems to solve some of out TPL shared/ static library issues:
   - Can use static Conduit and Qhull (will be resolved in future PRs...)
 - Less C++ libs to link to for customer apps.
 - Smaller overall C++ lib size as everything is linked down into one file.  