### PR TITLE
RAJA Portability Suite Dependencies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ Notable changes include:
     * ATS bumped to version 7.0.9 for blueos smpi option support.
     * Eigen bumped to 3.4.0 for NVCC compatiblity.
     * C++ flag suppression is gaurded with build time CMake generators to only apply to C++ compilers.
+    * Adding RAJA, CAMP, Umpire and CHAI as dependencies of Spheral.
 
   * Bug Fixes / improvements:
     * spheral-atstest scripts always point to locally installed ATS instance.

--- a/cmake/Compilers.cmake
+++ b/cmake/Compilers.cmake
@@ -48,7 +48,11 @@ if (NOT ENABLE_MISSING_INCLUDE_DIR_WARNINGS)
 endif()
 message("-- Compiler missing include dir warnings ${ENABLE_MISSING_INCLUDE_DIR_WARNINGS}")
 
-set(CUDA_WARNING_FLAGS -Xcudafe=\"--diag_suppress=esa_on_defaulted_function_ignored\")
+set(CUDA_WARNING_FLAGS )
+# Suppress Eigen warnings.
+list(APPEND CUDA_WARNING_FLAGS -Xcudafe=\"--diag_suppress=esa_on_defaulted_function_ignored\")
+# Suppress: warning: a __device__ function("Spheral::X") redeclared with __host__ __device__, hence treated as a __host__ __device__ function
+list(APPEND CUDA_WARNING_FLAGS -Xcudafe=\"--diag_suppress=3148\")
 
 add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:${CXX_WARNING_FLAGS}>")
 add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${CUDA_WARNING_FLAGS}>")

--- a/cmake/InstallTPLs.cmake
+++ b/cmake/InstallTPLs.cmake
@@ -17,6 +17,10 @@ Spheral_Handle_TPL(hdf5 spheral_depends)
 Spheral_Handle_TPL(silo spheral_depends)
 Spheral_Handle_TPL(conduit spheral_depends)
 Spheral_Handle_TPL(axom spheral_depends)
+Spheral_Handle_TPL(raja spheral_depends)
+Spheral_Handle_TPL(chai spheral_depends)
+Spheral_Handle_TPL(umpire spheral_depends)
+Spheral_Handle_TPL(camp spheral_depends)
 
 # Some libraries are optional
 if (ENABLE_ANEOS)

--- a/cmake/SetupSpheral.cmake
+++ b/cmake/SetupSpheral.cmake
@@ -67,7 +67,7 @@ if(ENABLE_OPENMP)
 endif()
 
 if(ENABLE_CUDA)
-  #set(CMAKE_CUDA_FLAGS  "${CMAKE_CUDA_FLAGS} -arch=${CUDA_ARCH} --extended-lambda -Xcudafe --display_error_number")
+  set(CMAKE_CUDA_FLAGS  "${CMAKE_CUDA_FLAGS} --extended-lambda -Xcudafe --display_error_number")
   set(CMAKE_CUDA_STANDARD 14)
   list(APPEND SPHERAL_CXX_DEPENDS cuda)
 endif()

--- a/cmake/tpl/chai.cmake
+++ b/cmake/tpl/chai.cmake
@@ -1,0 +1,1 @@
+set(${lib_name}_libs libchai.so)

--- a/cmake/tpl/chai.cmake
+++ b/cmake/tpl/chai.cmake
@@ -1,1 +1,1 @@
-set(${lib_name}_libs libchai.so)
+set(${lib_name}_libs libchai.a)

--- a/cmake/tpl/raja.cmake
+++ b/cmake/tpl/raja.cmake
@@ -1,1 +1,1 @@
-set(${lib_name}_libs libRAJA.so)
+set(${lib_name}_libs libRAJA.a)

--- a/cmake/tpl/raja.cmake
+++ b/cmake/tpl/raja.cmake
@@ -1,0 +1,1 @@
+set(${lib_name}_libs libRAJA.so)

--- a/cmake/tpl/umpire.cmake
+++ b/cmake/tpl/umpire.cmake
@@ -1,0 +1,1 @@
+set(${lib_name}_libs libumpire.a)

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -56,11 +56,12 @@ class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
     depends_on('axom@0.5.0 ~shared +mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='+mpi')
     depends_on('axom@0.5.0 ~shared ~mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='~mpi')
 
-    depends_on('raja+cuda', when='+cuda')
-    depends_on('chai+cuda', when='+cuda')
+    depends_on('raja~shared+cuda', when='+cuda')
+    depends_on('chai~shared+cuda', when='+cuda')
+    depends_on('umpire~shared+cuda', when='+cuda')
 
-    depends_on('raja', when='~cuda')
-    depends_on('chai', when='~cuda')
+    depends_on('raja~shared', when='~cuda')
+    depends_on('chai~shared', when='~cuda')
     depends_on('umpire~shared', when='~cuda')
 
     depends_on('opensubdiv@3.4.3', type='build')

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -56,6 +56,13 @@ class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
     depends_on('axom@0.5.0 ~shared +mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='+mpi')
     depends_on('axom@0.5.0 ~shared ~mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='~mpi')
 
+    depends_on('raja+cuda', when='+cuda')
+    depends_on('chai+cuda', when='+cuda')
+
+    depends_on('raja', when='~cuda')
+    depends_on('chai', when='~cuda')
+    depends_on('umpire~shared', when='~cuda')
+
     depends_on('opensubdiv@3.4.3', type='build')
     depends_on('polytope', type='build')
 
@@ -202,6 +209,18 @@ class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
 
         entries.append(cmake_cache_option('polytope_BUILD', False))
         entries.append(cmake_cache_path('polytope_DIR', spec['polytope'].prefix))
+
+        entries.append(cmake_cache_option('raja_BUILD', False))
+        entries.append(cmake_cache_path('raja_DIR', spec['raja'].prefix))
+
+        entries.append(cmake_cache_option('chai_BUILD', False))
+        entries.append(cmake_cache_path('chai_DIR', spec['chai'].prefix))
+
+        entries.append(cmake_cache_option('umpire_BUILD', False))
+        entries.append(cmake_cache_path('umpire_DIR', spec['umpire'].prefix))
+
+        entries.append(cmake_cache_option('camp_BUILD', False))
+        entries.append(cmake_cache_path('camp_DIR', spec['camp'].prefix))
 
         entries.append(cmake_cache_option('ENABLE_MPI', '+mpi' in spec))
         if "+mpi" in spec:

--- a/src/CXXTests/Spheral_CUDA_Test.cc
+++ b/src/CXXTests/Spheral_CUDA_Test.cc
@@ -1,19 +1,13 @@
 #include <iostream>
 #include "DeviceTestLib/DeviceTest.hh"
 
+#include "RAJA/RAJA.hpp"
+
 int main() {
   int a,b,c;
   a = 3; b = 4;
 
-#if 1
   c = Spheral::launchCaller(a,b);
-#else
-  int *d_c;
-  cudaMalloc((void**) &d_c, sizeof(int));
-  launch<<<1,1>>>(a,b,d_c);
-  cudaMemcpy(&c, d_c, sizeof(int), cudaMemcpyDeviceToHost);
-  cudaFree(d_c);
-#endif
 
   std::cout << "C : " << c << "\n";
   


### PR DESCRIPTION
# Summary
This PR Adds RAJA, CHAI, Umpire and Camp as dependencies of Spheral.
We smoke test these libraries in our cuda launch test.