### PR TITLE
fixing DEM restart issue

### DIFF
--- a/src/DEM/DEM.py
+++ b/src/DEM/DEM.py
@@ -15,13 +15,20 @@ def LinearSpringDEM(dataBase,
                     staticFrictionCoefficient,
                     rollingFrictionCoefficient,
                     torsionalFrictionCoefficient,
-                    cohesiveTensileStrength=0.0,
-                    shapeFactor=0.0,
+                    cohesiveTensileStrength = 0.0,
+                    shapeFactor = 0.0,
                     stepsPerCollision = 25,
                     xmin = (-1e100, -1e100, -1e100),
                     xmax = ( 1e100,  1e100,  1e100)):
+
     assert dataBase.numDEMNodeLists == dataBase.numNodeLists, "all nodelists must be dem nodelists"
     assert stepsPerCollision > 10, "stepsPerCollision too low, reccomended is 25-50"
+
+    # we might want to allow the user to set less parameters with reasonable defaults
+    #if tangentialSpringConstant is None:
+    #    tangentialSpringConstant = normalSpringConstant * 2.0/7.0
+    #if tangentialRestitutionCoefficient is None:
+    #    tangentialRestitutionCoefficient = normalRestitutionCoefficient
 
     ndim = dataBase.nDim
 
@@ -62,8 +69,8 @@ def DEM(dataBase,
         staticFrictionCoefficient,
         rollingFrictionCoefficient,
         torsionalFrictionCoefficient,
-        cohesiveTensileStrength,
-        shapeFactor,
+        cohesiveTensileStrength=0.0,
+        shapeFactor=0.0,
         stepsPerCollision = 25,
         xmin = (-1e100, -1e100, -1e100),
         xmax = ( 1e100,  1e100,  1e100)):

--- a/src/DEM/DEMBase.cc
+++ b/src/DEM/DEMBase.cc
@@ -76,7 +76,7 @@ DEMBase(const DataBase<Dimension>& dataBase,
   mDataBase(dataBase),
   mFirstCycle(true),
   mCyclesSinceLastKulling(0),
-  mKullFrequency((int)stepsPerCollision),
+  mKullFrequency(1),//(int)stepsPerCollision),
   mStepsPerCollision(stepsPerCollision),
   mxmin(xmin),
   mxmax(xmax),
@@ -340,8 +340,8 @@ initialize(const Scalar  time,
     this->kullInactiveContacts(dataBase);
     this->kullInactiveContactsFromStatePairFieldLists(state);
 
-    this->initializeContacts(dataBase);
-    this->resizeStatePairFieldLists(state);
+    //this->initializeContacts(dataBase);
+    //this->resizeStatePairFieldLists(state);
   }
 
 }
@@ -428,6 +428,7 @@ DEMBase<Dimension>::
 dumpState(FileIO& file, const string& pathName) const {
 
   file.write(mCyclesSinceLastKulling, pathName + "/cyclesSinceLastKulling");
+  file.write(mFirstCycle, pathName + "/firstCycle");
 
   file.write(mTimeStepMask, pathName + "/timeStepMask");
   file.write(mOmega, pathName + "/omega");
@@ -460,7 +461,8 @@ DEMBase<Dimension>::
 restoreState(const FileIO& file, const string& pathName) {
 
   file.read(mCyclesSinceLastKulling, pathName + "/cyclesSinceLastKulling");
-
+  file.read(mFirstCycle, pathName + "/firstCycle");
+  
   file.read(mTimeStepMask, pathName + "/timeStepMask");
   file.read(mOmega, pathName + "/omega");
   file.read(mDomegaDt, pathName + "/DomegaDt");

--- a/src/DEM/DEMBase.hh
+++ b/src/DEM/DEMBase.hh
@@ -117,6 +117,8 @@ public:
 
   void initializeContacts(const DataBase<Dimension>& dataBase);
 
+  void resetContacts(const DataBase<Dimension>& dataBase);
+  
   void kullInactiveContacts(const DataBase<Dimension>& dataBase);
 
   // Optionally we can provide a bounding box for use generating the mesh
@@ -144,9 +146,10 @@ public:
   const FieldList<Dimension, Vector>& DvDt() const;
   const FieldList<Dimension, RotationType>& omega() const;
   const FieldList<Dimension, RotationType>& DomegaDt() const;
-
-  // access for pair fieldLists
   const FieldList<Dimension, int>& uniqueIndices() const;
+  const FieldList<Dimension, int>& maxNumberOfNeighbors() const;
+  
+  // access for pair fieldLists
   const FieldList<Dimension, std::vector<int>>& isActiveContact() const;
   const FieldList<Dimension, std::vector<int>>& neighborIndices() const;
   const FieldList<Dimension, std::vector<Vector>>& shearDisplacement() const;
@@ -168,8 +171,8 @@ public:
                          const Scalar particleRadiusi) const;
 
   RotationType torsionMoment(const Vector rhatij,
-                             const Vector omegai,
-                             const Vector omegaj) const;
+                             const RotationType omegai,
+                             const RotationType omegaj) const;
 
   RotationType rollingMoment(const Vector rhatij,
                              const Vector vroti,
@@ -205,15 +208,16 @@ protected:
   FieldList<Dimension, RotationType> mOmega;          // angular velocity
   FieldList<Dimension, RotationType> mDomegaDt;       // angular acceleration
   FieldList<Dimension,int>           mUniqueIndices;  // each node gets a global unique index
-  
+  FieldList<Dimension,int>           mMaxNumberOfNeighbors;
+
   // state fields attached to the pair interactions
-  FieldList<Dimension,std::vector<int>> mNeighborIndices;              // tracks unique indices of contacts-we upate these (note treated specially compared to other state pair field lists)
+  FieldList<Dimension,std::vector<int>>    mNeighborIndices;           // tracks unique indices of contacts-we upate these (note treated specially compared to other state pair field lists)
   FieldList<Dimension,std::vector<Scalar>> mEquilibriumOverlap;        // nonzero values for composite particles
   FieldList<Dimension,std::vector<Vector>> mShearDisplacement;         // displacement for sliding spring
   FieldList<Dimension,std::vector<Vector>> mRollingDisplacement;       // displacement for rolling spring
   FieldList<Dimension,std::vector<Scalar>> mTorsionalDisplacement;     // displacement for torsional spring
-  FieldList<Dimension,std::vector<int>> mIsActiveContact;              // tracks if a interfaction is still active
-  
+  FieldList<Dimension,std::vector<int>>    mIsActiveContact;           // tracks if a interaction is still active
+
    // deriv fields attached to the pair interactions
   FieldList<Dimension,std::vector<Vector>> mDDtShearDisplacement;      // derivative to evolve frictional spring displacement
   FieldList<Dimension,std::vector<Vector>> mNewShearDisplacement;      // handles rotation of frictional spring and reset on slip

--- a/src/DEM/DEMBase.hh
+++ b/src/DEM/DEMBase.hh
@@ -93,13 +93,18 @@ public:
   void initializeBeforeRedistribution();
   void finalizeAfterRedistribution();
 
+  void prepNeighborIndicesForRedistribution();
+  
+  template<typename Value>
+  void prepPairFieldListForRedistribution(Value& pairFieldList);
+
   // templated methods
   template<typename Value1, typename Value2>
   void addContactsToPairFieldList(Value1& pairFieldList, const Value2& newValue) const;
 
   template<typename Value>
-  void kullInactiveContactsFromPairFieldList(Value& pairFieldList) const;
-  
+  void removeInactiveContactsFromPairFieldList(Value& pairFieldList) const;
+
   //#############################################################################
   // special methods for the pair fields if you add pairFieldLists 
   // make sure to follow the pattern in these methods.
@@ -110,16 +115,19 @@ public:
   void resizeStatePairFieldLists(State<Dimension>& state) const;
 
   virtual 
-  void kullInactiveContactsFromStatePairFieldLists(State<Dimension>& state) const;
+  void removeInactiveContactsFromStatePairFieldLists(State<Dimension>& state) const;
+
+  virtual 
+  void removeInactiveContactsFromDerivativePairFieldLists(StateDerivatives<Dimension>& derivs) const;
   //#############################################################################
 
   void initializeOverlap(const DataBase<Dimension>& dataBase);
 
-  void initializeContacts(const DataBase<Dimension>& dataBase);
+  void updateContactMapAndNeighborIndices(const DataBase<Dimension>& dataBase);
 
-  void resetContacts(const DataBase<Dimension>& dataBase);
+  void updateContactMap(const DataBase<Dimension>& dataBase);
   
-  void kullInactiveContacts(const DataBase<Dimension>& dataBase);
+  void identifyInactiveContacts(const DataBase<Dimension>& dataBase);
 
   // Optionally we can provide a bounding box for use generating the mesh
   // for the Voronoi mass density update.
@@ -131,11 +139,11 @@ public:
   Scalar stepsPerCollision() const;
   void   stepsPerCollision(Scalar x);
 
-  int cyclesSinceLastKulling() const;
-  void   cyclesSinceLastKulling(int x);
+  int  cycle() const;
+  void cycle(int x);
 
-  int kullFrequency() const;
-  void   kullFrequency(int x);
+  int  contactRemovalFrequency() const;
+  void contactRemovalFrequency(int x);
 
   bool firstCycle() const;
   void firstCycle(bool x);
@@ -147,11 +155,10 @@ public:
   const FieldList<Dimension, RotationType>& omega() const;
   const FieldList<Dimension, RotationType>& DomegaDt() const;
   const FieldList<Dimension, int>& uniqueIndices() const;
-  const FieldList<Dimension, int>& maxNumberOfNeighbors() const;
-  
+
   // access for pair fieldLists
-  const FieldList<Dimension, std::vector<int>>& isActiveContact() const;
-  const FieldList<Dimension, std::vector<int>>& neighborIndices() const;
+  const FieldList<Dimension, std::vector<int>>&    isActiveContact() const;
+  const FieldList<Dimension, std::vector<int>>&    neighborIndices() const;
   const FieldList<Dimension, std::vector<Vector>>& shearDisplacement() const;
   const FieldList<Dimension, std::vector<Vector>>& rollingDisplacement() const;
   const FieldList<Dimension, std::vector<Scalar>>& torsionalDisplacement() const;
@@ -192,8 +199,8 @@ protected:
 
   bool mFirstCycle;
 
-  int mCyclesSinceLastKulling;
-  int mKullFrequency;
+  int mCycle;
+  int mContactRemovalFrequency;
   
   // number of steps per collision time-scale
   Scalar mStepsPerCollision;              
@@ -208,7 +215,6 @@ protected:
   FieldList<Dimension, RotationType> mOmega;          // angular velocity
   FieldList<Dimension, RotationType> mDomegaDt;       // angular acceleration
   FieldList<Dimension,int>           mUniqueIndices;  // each node gets a global unique index
-  FieldList<Dimension,int>           mMaxNumberOfNeighbors;
 
   // state fields attached to the pair interactions
   FieldList<Dimension,std::vector<int>>    mNeighborIndices;           // tracks unique indices of contacts-we upate these (note treated specially compared to other state pair field lists)

--- a/src/DEM/DEMBase.hh
+++ b/src/DEM/DEMBase.hh
@@ -129,6 +129,15 @@ public:
   Scalar stepsPerCollision() const;
   void   stepsPerCollision(Scalar x);
 
+  int cyclesSinceLastKulling() const;
+  void   cyclesSinceLastKulling(int x);
+
+  int kullFrequency() const;
+  void   kullFrequency(int x);
+
+  bool firstCycle() const;
+  void firstCycle(bool x);
+
   // access for node fieldLists
   const FieldList<Dimension, int>&    timeStepMask() const;
   const FieldList<Dimension, Vector>& DxDt() const;
@@ -190,20 +199,22 @@ protected:
   Vector mxmin, mxmax;
 
   // fields attached to the nodes
-  FieldList<Dimension, int>      mTimeStepMask;
-  FieldList<Dimension, Vector>   mDxDt;           // linear position derivative
-  FieldList<Dimension, Vector>   mDvDt;           // linear acceleration
-  FieldList<Dimension, RotationType> mOmega;      // angular velocity
-  FieldList<Dimension, RotationType> mDomegaDt;   // angular acceleration
-  FieldList<Dimension,int> mUniqueIndices;        // each node gets a global unique index
+  FieldList<Dimension, int>          mTimeStepMask;   // filter out particle from timestep calc (not active right now for DEM)
+  FieldList<Dimension, Vector>       mDxDt;           // linear position derivative
+  FieldList<Dimension, Vector>       mDvDt;           // linear acceleration
+  FieldList<Dimension, RotationType> mOmega;          // angular velocity
+  FieldList<Dimension, RotationType> mDomegaDt;       // angular acceleration
+  FieldList<Dimension,int>           mUniqueIndices;  // each node gets a global unique index
   
-  // fields attached to the pair interactions
-  FieldList<Dimension,std::vector<int>> mNeighborIndices;              // tracks unique indices of contacts-we upate these 
+  // state fields attached to the pair interactions
+  FieldList<Dimension,std::vector<int>> mNeighborIndices;              // tracks unique indices of contacts-we upate these (note treated specially compared to other state pair field lists)
   FieldList<Dimension,std::vector<Scalar>> mEquilibriumOverlap;        // nonzero values for composite particles
   FieldList<Dimension,std::vector<Vector>> mShearDisplacement;         // displacement for sliding spring
   FieldList<Dimension,std::vector<Vector>> mRollingDisplacement;       // displacement for rolling spring
   FieldList<Dimension,std::vector<Scalar>> mTorsionalDisplacement;     // displacement for torsional spring
   FieldList<Dimension,std::vector<int>> mIsActiveContact;              // tracks if a interfaction is still active
+  
+   // deriv fields attached to the pair interactions
   FieldList<Dimension,std::vector<Vector>> mDDtShearDisplacement;      // derivative to evolve frictional spring displacement
   FieldList<Dimension,std::vector<Vector>> mNewShearDisplacement;      // handles rotation of frictional spring and reset on slip
   FieldList<Dimension,std::vector<Vector>> mDDtRollingDisplacement;    // derivative to evolve frictional spring displacement

--- a/src/DEM/DEMBaseInline.hh
+++ b/src/DEM/DEMBaseInline.hh
@@ -150,11 +150,6 @@ omega() const {
   return mOmega;
 }
 
-
-
-//------------------------------------------------------------------------------
-// Pair things
-//------------------------------------------------------------------------------
 template<typename Dimension>
 inline
 const FieldList<Dimension, int>&
@@ -162,6 +157,19 @@ DEMBase<Dimension>::
 uniqueIndices() const {
   return mUniqueIndices;
 }
+
+template<typename Dimension>
+inline
+const FieldList<Dimension, int>&
+DEMBase<Dimension>::
+maxNumberOfNeighbors() const {
+  return mMaxNumberOfNeighbors;
+}
+
+//------------------------------------------------------------------------------
+// Pair things
+//------------------------------------------------------------------------------
+
 
 template<typename Dimension>
 inline
@@ -304,8 +312,8 @@ inline
 DEMDimension<Dim<1>>::AngularVector
 DEMBase<Dim<1>>::
 torsionMoment(const Dim<1>::Vector rhatij, 
-              const Dim<1>::Vector omegai,
-              const Dim<1>::Vector omegaj) const {
+              const DEMDimension<Dim<1>>::AngularVector omegai,
+              const DEMDimension<Dim<1>>::AngularVector omegaj) const {
   return 0.0;
 }
 
@@ -314,8 +322,8 @@ inline
 DEMDimension<Dim<2>>::AngularVector
 DEMBase<Dim<2>>::
 torsionMoment(const Dim<2>::Vector rhatij, 
-              const Dim<2>::Vector omegai,
-              const Dim<2>::Vector omegaj) const {
+              const DEMDimension<Dim<2>>::AngularVector omegai,
+              const DEMDimension<Dim<2>>::AngularVector omegaj) const {
   return 0.0;
 }
 
@@ -324,8 +332,8 @@ inline
 DEMDimension<Dim<3>>::AngularVector
 DEMBase<Dim<3>>::
 torsionMoment(const Dim<3>::Vector rhatij, 
-              const Dim<3>::Vector omegai,
-              const Dim<3>::Vector omegaj) const {
+              const DEMDimension<Dim<3>>::AngularVector omegai,
+              const DEMDimension<Dim<3>>::AngularVector omegaj) const {
   return rhatij;
 }
 

--- a/src/DEM/DEMBaseInline.hh
+++ b/src/DEM/DEMBaseInline.hh
@@ -59,32 +59,32 @@ template<typename Dimension>
 inline
 int
 DEMBase<Dimension>::
-kullFrequency() const {
-  return mKullFrequency;
+contactRemovalFrequency() const {
+  return mContactRemovalFrequency;
 }
 
 template<typename Dimension>
 inline
 void
 DEMBase<Dimension>::
-kullFrequency(int x) {
-  mKullFrequency = x;
+contactRemovalFrequency(int x) {
+  mContactRemovalFrequency = x;
 }
 
 template<typename Dimension>
 inline
 int
 DEMBase<Dimension>::
-cyclesSinceLastKulling() const {
-  return mCyclesSinceLastKulling;
+cycle() const {
+  return mCycle;
 }
 
 template<typename Dimension>
 inline
 void
 DEMBase<Dimension>::
-cyclesSinceLastKulling(int x) {
-  mCyclesSinceLastKulling = x;
+cycle(int x) {
+  mCycle = x;
 }
 
 //------------------------------------------------------------------------------
@@ -158,13 +158,6 @@ uniqueIndices() const {
   return mUniqueIndices;
 }
 
-template<typename Dimension>
-inline
-const FieldList<Dimension, int>&
-DEMBase<Dimension>::
-maxNumberOfNeighbors() const {
-  return mMaxNumberOfNeighbors;
-}
 
 //------------------------------------------------------------------------------
 // Pair things

--- a/src/DEM/DEMBaseInline.hh
+++ b/src/DEM/DEMBaseInline.hh
@@ -35,6 +35,58 @@ xmax(const typename Dimension::Vector& x) {
   mxmax = x;
 }
 
+
+//------------------------------------------------------------------------------
+// set get for numerical switches
+//------------------------------------------------------------------------------
+template<typename Dimension>
+inline
+bool
+DEMBase<Dimension>::
+firstCycle() const {
+  return mFirstCycle;
+}
+
+template<typename Dimension>
+inline
+void
+DEMBase<Dimension>::
+firstCycle(bool x) {
+  mFirstCycle = x;
+}
+
+template<typename Dimension>
+inline
+int
+DEMBase<Dimension>::
+kullFrequency() const {
+  return mKullFrequency;
+}
+
+template<typename Dimension>
+inline
+void
+DEMBase<Dimension>::
+kullFrequency(int x) {
+  mKullFrequency = x;
+}
+
+template<typename Dimension>
+inline
+int
+DEMBase<Dimension>::
+cyclesSinceLastKulling() const {
+  return mCyclesSinceLastKulling;
+}
+
+template<typename Dimension>
+inline
+void
+DEMBase<Dimension>::
+cyclesSinceLastKulling(int x) {
+  mCyclesSinceLastKulling = x;
+}
+
 //------------------------------------------------------------------------------
 // CFL number (ratio to estimated contact duration)
 //------------------------------------------------------------------------------

--- a/src/DEM/LinearSpringDEM.cc
+++ b/src/DEM/LinearSpringDEM.cc
@@ -238,15 +238,16 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
       const int pairNode = contacts[kk].pairNode;
 
       // simple test for our store/pair selection
-      //const bool orientationOne = (storeNodeList==nodeListi and storeNode==i and pairNodeList==nodeListj and pairNode==j);
-      //const bool orientationTwo = (storeNodeList==nodeListj and storeNode==j and pairNodeList==nodeListi and pairNode==i);
-      //if(not(orientationOne or orientationTwo)) throw std::invalid_argument("AddPositiveIntegers arguments must be positive");
+      const bool orientationOne = (storeNodeList==nodeListi and storeNode==i and pairNodeList==nodeListj and pairNode==j);
+      const bool orientationTwo = (storeNodeList==nodeListj and storeNode==j and pairNodeList==nodeListi and pairNode==i);
+      if(not(orientationOne or orientationTwo)) throw std::invalid_argument("AddPositiveIntegers arguments must be positive");
 
       
-      // storage sign to make pairwise values i-j independent
+      // storage sign, this makes pairwise values i-j independent
+      const auto uIdi = uniqueIndices(nodeListi,i);
       const auto uIds = uniqueIndices(storeNodeList,storeNode);
       const auto uIdp = uniqueIndices(pairNodeList,pairNode);
-      const int storageSign = (uIds <= uIdp ? 1 : -1);
+      const int storageSign = (uIdi == std::min(uIds,uIdp) ? 1 : -1);
 
       // stored pair-wise values
       const auto overlapij = equilibriumOverlap(storeNodeList,storeNode)[storeContact];

--- a/src/DEM/LinearSpringDEM.cc
+++ b/src/DEM/LinearSpringDEM.cc
@@ -252,7 +252,7 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
       const auto overlapij = equilibriumOverlap(storeNodeList,storeNode)[storeContact];
       const auto deltaSlidij = storageSign*shearDisplacement(storeNodeList,storeNode)[storeContact];
       const auto deltaRollij =             rollingDisplacement(storeNodeList,storeNode)[storeContact];
-      const auto deltaTorsij = storageSign*torsionalDisplacement(storeNodeList,storeNode)[storeContact];
+      const auto deltaTorsij =             torsionalDisplacement(storeNodeList,storeNode)[storeContact];
 
       // Get the state for node i.
       const auto& ri = position(nodeListi, i);
@@ -360,10 +360,10 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
         const Scalar MtStatic = muT*shapeFactor*muS*fnMag;
 
         // limit to static
-        if  (std::abs(MtorsionMag) > MtStatic){
-          MtorsionMag =  (MtorsionMag > 0.0 ? 1.0 : -1.0)*MtStatic;
-          newDeltaTorsij = (std::abs(Mt0damp) > MtStatic ? 0.0 :  -(MtorsionMag-Mt0damp)*invKt);
-        }
+        //if  (std::abs(MtorsionMag) > MtStatic){
+        //  MtorsionMag =  (MtorsionMag > 0.0 ? 1.0 : -1.0)*MtStatic;
+        //  newDeltaTorsij = (std::abs(Mt0damp) > MtStatic ? 0.0 :  -(MtorsionMag-Mt0damp)*invKt);
+        //}
 
         // rolling
         //------------------------------------------------------------
@@ -401,8 +401,8 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
         // for spring updates
         newShearDisplacement(storeNodeList,storeNode)[storeContact] = storageSign*newDeltaSlidij;
         DDtShearDisplacement(storeNodeList,storeNode)[storeContact] = storageSign*vs;
-        newTorsionalDisplacement(storeNodeList,storeNode)[storeContact] = storageSign*newDeltaTorsij;
-        DDtTorsionalDisplacement(storeNodeList,storeNode)[storeContact] = storageSign*vt;
+        newTorsionalDisplacement(storeNodeList,storeNode)[storeContact] = newDeltaTorsij;
+        DDtTorsionalDisplacement(storeNodeList,storeNode)[storeContact] = vt;
         newRollingDisplacement(storeNodeList,storeNode)[storeContact] = newDeltaRollij;
         DDtRollingDisplacement(storeNodeList,storeNode)[storeContact] = vr;
     

--- a/src/DEM/LinearSpringDEM.cc
+++ b/src/DEM/LinearSpringDEM.cc
@@ -238,9 +238,9 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
       const int pairNode = contacts[kk].pairNode;
 
       // simple test for our store/pair selection
-      const bool orientationOne = (storeNodeList==nodeListi and storeNode==i and pairNodeList==nodeListj and pairNode==j);
-      const bool orientationTwo = (storeNodeList==nodeListj and storeNode==j and pairNodeList==nodeListi and pairNode==i);
-      if(not(orientationOne or orientationTwo)) throw std::invalid_argument("AddPositiveIntegers arguments must be positive");
+      //const bool orientationOne = (storeNodeList==nodeListi and storeNode==i and pairNodeList==nodeListj and pairNode==j);
+      //const bool orientationTwo = (storeNodeList==nodeListj and storeNode==j and pairNodeList==nodeListi and pairNode==i);
+      //if(not(orientationOne or orientationTwo)) throw std::invalid_argument("AddPositiveIntegers arguments must be positive");
 
       
       // storage sign to make pairwise values i-j independent
@@ -360,10 +360,10 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
         const Scalar MtStatic = muT*shapeFactor*muS*fnMag;
 
         // limit to static
-        //if  (std::abs(MtorsionMag) > MtStatic){
-        //  MtorsionMag =  (MtorsionMag > 0.0 ? 1.0 : -1.0)*MtStatic;
-        //  newDeltaTorsij = (std::abs(Mt0damp) > MtStatic ? 0.0 :  -(MtorsionMag-Mt0damp)*invKt);
-        //}
+        if  (std::abs(MtorsionMag) > MtStatic){
+         MtorsionMag =  (MtorsionMag > 0.0 ? 1.0 : -1.0)*MtStatic;
+         newDeltaTorsij = (std::abs(Mt0damp) > MtStatic ? 0.0 :  -(MtorsionMag-Mt0damp)*invKt);
+        }
 
         // rolling
         //------------------------------------------------------------

--- a/src/DEM/LinearSpringDEM.cc
+++ b/src/DEM/LinearSpringDEM.cc
@@ -413,6 +413,7 @@ template<typename Dimension>
 void
 LinearSpringDEM<Dimension>::
 dumpState(FileIO& file, const std::string& pathName) const {
+  DEMBase<Dimension>::dumpState(file, pathName);
   file.write(mTimeStep, pathName + "/timeStep");
 }
 
@@ -423,6 +424,7 @@ template<typename Dimension>
 void
 LinearSpringDEM<Dimension>::
 restoreState(const FileIO& file, const std::string& pathName) {
+  DEMBase<Dimension>::restoreState(file, pathName);
   file.read(mTimeStep, pathName + "/timeStep");
 }
 

--- a/src/DEM/LinearSpringDEM.hh
+++ b/src/DEM/LinearSpringDEM.hh
@@ -55,7 +55,9 @@ public:
                                    const DataBase<Dimension>& dataBase,
                                    const State<Dimension>& state,
                                          StateDerivatives<Dimension>& derivs) const override;
-  
+
+  virtual void setTimeStep(const DataBase<Dimension>& dataBase);
+
   Scalar normalSpringConstant() const;
   void   normalSpringConstant(Scalar x);
 
@@ -98,6 +100,8 @@ public:
   //****************************************************************************
   // Methods required for restarting.
   virtual std::string label() const override { return "LinearSpringDEM" ; }
+  virtual void dumpState(FileIO& file, const std::string& pathName) const;
+  virtual void restoreState(const FileIO& file, const std::string& pathName);
   //****************************************************************************
 
 private:
@@ -106,12 +110,12 @@ private:
   Scalar mNormalRestitutionCoefficient;
   Scalar mTangentialSpringConstant;
   Scalar mTangentialRestitutionCoefficient;
-  Scalar mDynamicFrictionCoefficient;     // coefficient of friciton - dynamic
-  Scalar mStaticFrictionCoefficient;      // coefficient of friction - static
-  Scalar mRollingFrictionCoefficient;     // coefficient of friction - rolling
-  Scalar mTorsionalFrictionCoefficient;   // coefficient of friction - torsional 
+  Scalar mDynamicFrictionCoefficient;       // coefficient of friciton - dynamic
+  Scalar mStaticFrictionCoefficient;        // coefficient of friction - static
+  Scalar mRollingFrictionCoefficient;       // coefficient of friction - rolling
+  Scalar mTorsionalFrictionCoefficient;     // coefficient of friction - torsional 
   Scalar mCohesiveTensileStrength;
-  Scalar mShapeFactor;                    // varies between 0 and 1 to account to non spherical shapes & influences rolling/torsion spring parameters
+  Scalar mShapeFactor;                      // varies between 0 and 1 to account to non spherical shapes & influences rolling/torsion spring parameters
 
   Scalar mNormalBeta;
   Scalar mTangentialBeta;

--- a/src/DEM/LinearSpringDEM.hh
+++ b/src/DEM/LinearSpringDEM.hh
@@ -1,7 +1,14 @@
 //---------------------------------Spheral++----------------------------------//
-// LinearSpringDEM -- contact model based on damped linear springs
-//                       Cundall & Strack Geotechnique, vol. 29, no. 1,
-//                       pp. 47-65, 1979.
+// DEM -- damped linear spring contact model based on pkdgrav immplementation
+//---------------------------------------------------------------------------
+// Schwartz, S.R. and Richards, D.C. "An implementation of the soft-sphere 
+// discrete element method in a high-performance parallel gravity tree-code,"
+// Granular Matter, (2012) 14:363–380, 10.1007/s10035-012-0346-z.
+//
+// Zhang et. al. "Rotational Failure of Rubble-pile Bodies: Influences of 
+// Shear and Cohesive Strengths," The Astrophysical Journal, (2018) 857:15, 20
+// 10.3847/1538-4357/aab5b2.
+//
 //----------------------------------------------------------------------------//
 #ifndef __Spheral_LinearSpringDEM_hh__
 #define __Spheral_LinearSpringDEM_hh__

--- a/src/Pybind11Wraps/DEM/DEMBase.py
+++ b/src/Pybind11Wraps/DEM/DEMBase.py
@@ -99,8 +99,8 @@ class DEMBase(Physics):
     
     stepsPerCollision = PYB11property("Scalar", "stepsPerCollision", "stepsPerCollision", doc="number of steps resolving the collision time scale")
     
-    cyclesSinceLastKulling = PYB11property("int", "cyclesSinceLastKulling", "cyclesSinceLastKulling", doc="every n-cycles we prune our contact list to only the active contacts. This counts how long its been.")
-    kullFrequency = PYB11property("int", "kullFrequency", "kullFrequency", doc="every n-cycles we prune our contact list to only the active contacts. This is the frequency.")
+    cycle = PYB11property("int", "cycle", "cycle", doc="tracks what cycle we are on.")
+    contactRemovalFrequency = PYB11property("int", "contactRemovalFrequency", "contactRemovalFrequency", doc="every n-cycles we prune our contact list to only the active contacts. This is the frequency.")
     firstCycle = PYB11property("bool", "firstCycle", "firstCycle", doc="boolean flag thats true for the first cycle of a run.")
     
     timeStepMask =  PYB11property("const FieldList<%(Dimension)s, int>&", "timeStepMask", returnpolicy="reference_internal")

--- a/src/Pybind11Wraps/DEM/DEMBase.py
+++ b/src/Pybind11Wraps/DEM/DEMBase.py
@@ -99,6 +99,10 @@ class DEMBase(Physics):
     
     stepsPerCollision = PYB11property("Scalar", "stepsPerCollision", "stepsPerCollision", doc="number of steps resolving the collision time scale")
     
+    cyclesSinceLastKulling = PYB11property("int", "cyclesSinceLastKulling", "cyclesSinceLastKulling", doc="every n-cycles we prune our contact list to only the active contacts. This counts how long its been.")
+    kullFrequency = PYB11property("int", "kullFrequency", "kullFrequency", doc="every n-cycles we prune our contact list to only the active contacts. This is the frequency.")
+    firstCycle = PYB11property("bool", "firstCycle", "firstCycle", doc="boolean flag thats true for the first cycle of a run.")
+    
     timeStepMask =  PYB11property("const FieldList<%(Dimension)s, int>&", "timeStepMask", returnpolicy="reference_internal")
     DxDt =          PYB11property("const FieldList<%(Dimension)s, Vector>&","DxDt", returnpolicy="reference_internal")
     DvDt =          PYB11property("const FieldList<%(Dimension)s, Vector>&", "DvDt", returnpolicy="reference_internal")

--- a/src/Pybind11Wraps/DEM/LinearSpringDEM.py
+++ b/src/Pybind11Wraps/DEM/LinearSpringDEM.py
@@ -64,4 +64,3 @@ class LinearSpringDEM(DEMBase):
     normalBeta = PYB11property("Scalar", "normalBeta", "normalBeta", doc="a damping parameter")
     tangentialBeta = PYB11property("Scalar", "tangentialBeta", "tangentialBeta", doc="a damping parameter")
     timeStep = PYB11property("Scalar", "timeStep", "timeStep", doc="constant time-step for this model")
-  

--- a/tests/functional/DEM/DEMTests.ats
+++ b/tests/functional/DEM/DEMTests.ats
@@ -3,4 +3,4 @@ source("LinearSpringDEM/twoParticleCollision-2d.py")
 source("LinearSpringDEM/twoParticleCollision-3d.py")
 source("LinearSpringDEM/impactingSquares-2d.py")
 source("LinearSpringDEM/impactingSquares-3d.py")
-
+source("LinearSpringDEM/fiveParticleCollision-2d.py")

--- a/tests/functional/DEM/LinearSpringDEM/dropTest-2d.py
+++ b/tests/functional/DEM/LinearSpringDEM/dropTest-2d.py
@@ -55,6 +55,9 @@ commandLine(numParticlePerLength = 50,     # number of particles on a side of th
             restartStep = 1000,
             redistributeStep = 100,
             dataDir = "dumps-DEM-2d",
+
+            # ats type things
+            checkRestart=False,
             )
 
 #-------------------------------------------------------------------------------
@@ -214,7 +217,7 @@ output("integrator.rigorousBoundaries")
 output("integrator.verbose")
 
 #-------------------------------------------------------------------------------
-# Periodic Work Function: Track conseravation
+# Periodic Work Function: Track conservation
 #-------------------------------------------------------------------------------
 
 conservation = TrackConservation(db,
@@ -256,3 +259,14 @@ if not steps is None:
 else:
     control.advance(goalTime, maxSteps)
 
+
+if checkRestart:
+    control.setRestartBaseName(restartBaseName)
+    state0 = State(db, integrator.physicsPackages())
+    state0.copyState()
+    control.loadRestartFile(control.totalSteps)
+    state1 = State(db, integrator.physicsPackages())
+    if not state1 == state0:
+        raise ValueError, "The restarted state does not match!"
+    else:
+        print "Restart check PASSED."

--- a/tests/functional/DEM/LinearSpringDEM/dropTest-2d.py
+++ b/tests/functional/DEM/LinearSpringDEM/dropTest-2d.py
@@ -6,7 +6,7 @@ from findLastRestart import *
 from GenerateNodeDistribution2d import *
 from GenerateDEMfromSPHGenerator import GenerateDEMfromSPHGenerator2d
 
-from DEMConservationTracker import TrackConservation3d as TrackConservation
+from DEMConservationTracker import TrackConservation2d as TrackConservation
 
 if mpi.procs > 1:
     from PeanoHilbertDistributeNodes import distributeNodes2d
@@ -24,6 +24,7 @@ commandLine(numParticlePerLength = 50,     # number of particles on a side of th
             normalRestitutionCoefficient=0.55,        # restitution coefficient to get damping const
             tangentialSpringConstant=2857.0,          # spring constant for LDS model
             tangentialRestitutionCoefficient=0.55,    # restitution coefficient to get damping const
+            cohesiveTensileStrength = 0.0,            # units of pressure
             dynamicFriction = 1.0,                    # static friction coefficient sliding
             staticFriction = 1.0,                     # dynamic friction coefficient sliding
             rollingFriction = 1.05,                   # static friction coefficient for rolling
@@ -156,6 +157,7 @@ dem = DEM(db,
           staticFrictionCoefficient = staticFriction,
           rollingFrictionCoefficient = rollingFriction,
           torsionalFrictionCoefficient = torsionalFriction,
+          cohesiveTensileStrength = cohesiveTensileStrength,
           shapeFactor = shapeFactor,
           stepsPerCollision = stepsPerCollision)
 

--- a/tests/functional/DEM/LinearSpringDEM/fiveParticleCollision-2d.py
+++ b/tests/functional/DEM/LinearSpringDEM/fiveParticleCollision-2d.py
@@ -85,7 +85,7 @@ assert cohesiveTensileStrength >= 0.0
 #-------------------------------------------------------------------------------
 testName = "DEM-fiveParticleCollision-2d"
 dataDir = os.path.join(dataDir,
-                       mpi.procs)
+                       "mpiprocs=%s" % mpi.procs)
 restartDir = os.path.join(dataDir, "restarts")
 vizDir = os.path.join(dataDir, "visit")
 restartBaseName = os.path.join(restartDir, testName)

--- a/tests/functional/DEM/LinearSpringDEM/fiveParticleCollision-2d.py
+++ b/tests/functional/DEM/LinearSpringDEM/fiveParticleCollision-2d.py
@@ -181,10 +181,6 @@ dem = DEM(db,
           stepsPerCollision = stepsPerCollision)
 
 packages = [dem]
-print "KULLFREAK = %s" % dem.kullFrequency
-dem.kullFrequency = 1
-
-
 
 #-------------------------------------------------------------------------------
 # Initial Conditions

--- a/tests/functional/DEM/LinearSpringDEM/fiveParticleCollision-2d.py
+++ b/tests/functional/DEM/LinearSpringDEM/fiveParticleCollision-2d.py
@@ -1,0 +1,412 @@
+#ATS:DEM2d5part0 = test(SELF, "--clearDirectories True --checkContacts True --checkAngularMomentum True", label="DEM 5 particle collision tests for pairwise storage -- 2-D (serial)")
+#ATS:DEM2d5part1 = test(SELF, "--clearDirectories True --checkContacts True --checkAngularMomentum True", label="DEM 5 particle collision tests for pairwise storage -- 2-D (parallel", np=5)
+
+import os, sys, shutil, mpi
+from math import *
+from Spheral2d import *
+from SpheralTestUtilities import *
+from findLastRestart import *
+from GenerateNodeDistribution2d import *
+from DEMConservationTracker import TrackConservation2d as TrackConservation
+from GenerateDEMfromSPHGenerator import GenerateDEMfromSPHGenerator2d
+
+if mpi.procs > 1:
+    from PeanoHilbertDistributeNodes import distributeNodes2d
+else:
+    from DistributeNodes import distributeNodes2d
+
+title("DEM Restitution Coefficient Test")
+
+#-------------------------------------------------------------------------------
+# Generic problem parameters
+#-------------------------------------------------------------------------------
+commandLine(vImpact = 1.0,                            # impact velocity
+
+            radius = 0.25,                            # particle radius
+            normalSpringConstant=10000.0,             # spring constant for LDS model
+            normalRestitutionCoefficient=0.55,        # restitution coefficient to get damping const
+            tangentialSpringConstant=2857.0,          # spring constant for LDS model
+            tangentialRestitutionCoefficient=0.55,    # restitution coefficient to get damping const
+            dynamicFriction = 1.0,                    # dynamic sliding friction coefficient
+            staticFriction = 1.0,                     # static sliding friction coefficient
+            rollingFriction = 1.05,                   # rolling friction coefficient
+            torsionalFriction = 1.3,                  # torisional friction coefficient
+            cohesiveTensileStrength =0.0,             # units of pressure
+            shapeFactor = 0.5,                        # shape irregularity parameter 0-1 (1 most irregular)
+            
+            nPerh = 1.01,                             # this should basically always be 1 for DEM
+
+            # integration
+            IntegratorConstructor = VerletIntegrator,    # Verlet only integrator that garentees conservation of Rot Mom w/ DEM
+            stepsPerCollision = 50,                      # replaces CFL for DEM
+            goalTime = None,
+            dt = 1e-8,
+            dtMin = 1.0e-8, 
+            dtMax = 0.1,
+            dtGrowth = 2.0,
+            steps = 10,
+            maxSteps = None,
+            statsStep = 10,
+            domainIndependent = False,
+            rigorousBoundaries = False,
+            dtverbose = False,
+            
+            # output control
+            vizCycle = None,
+            vizTime = None,
+            clearDirectories = False,
+            restoreCycle = None,
+            restartStep = 10,
+            redistributeStep = 500,
+            dataDir = "dumps-DEM-2particle-2d",
+
+             # ats parameters
+            checkAngularMomentum = True,       # soft check to make sure angular velocity of central particle drops
+            checkContacts = True,              # turn on error checking for our contacts
+            checkRestart = False,              # turn on error checking for restartability
+            checkConservation = False,         # turn on error checking for momentum conservation
+            conservationErrorThreshold = 1e-15 # relative error for momentum conservation
+            )
+
+#-------------------------------------------------------------------------------
+# check for bad inputs
+#-------------------------------------------------------------------------------
+assert mpi.procs == 1 or mpi.procs==5
+assert nPerh >= 1
+assert shapeFactor <= 1.0 and shapeFactor >= 0.0
+assert dynamicFriction >= 0.0
+assert staticFriction >= 0.0
+assert torsionalFriction >= 0.0
+assert rollingFriction >= 0.0
+assert cohesiveTensileStrength >= 0.0
+
+#-------------------------------------------------------------------------------
+# file things
+#-------------------------------------------------------------------------------
+testName = "DEM-fiveParticleCollision-2d"
+dataDir = os.path.join(dataDir,
+                       mpi.procs)
+restartDir = os.path.join(dataDir, "restarts")
+vizDir = os.path.join(dataDir, "visit")
+restartBaseName = os.path.join(restartDir, testName)
+vizBaseName = testName
+
+
+if vizCycle is None and vizTime is None:
+    vizBaseName=None
+
+#-------------------------------------------------------------------------------
+# Check if the necessary output directories exist.  If not, create them.
+#-------------------------------------------------------------------------------
+if mpi.rank == 0:
+    if clearDirectories and os.path.exists(dataDir):
+        shutil.rmtree(dataDir)
+    if not os.path.exists(restartDir):
+        os.makedirs(restartDir)
+    if not os.path.exists(vizDir):
+        os.makedirs(vizDir)
+mpi.barrier()
+
+#-------------------------------------------------------------------------------
+# If we're restarting, find the set of most recent restart files.
+#-------------------------------------------------------------------------------
+if restoreCycle is None:
+    restoreCycle = findLastRestart(restartBaseName)
+
+#-------------------------------------------------------------------------------
+# This doesn't really matter kernel filler for neighbor algo
+#-------------------------------------------------------------------------------
+WT = TableKernel(WendlandC2Kernel(), 1000)
+
+#-------------------------------------------------------------------------------
+# Make the NodeList.
+#-------------------------------------------------------------------------------
+units = CGuS()
+nodes1 = makeDEMNodeList("nodeList1",
+                          hmin = 1.0e-30,
+                          hmax = 1.0e30,
+                          hminratio = 100.0,
+                          nPerh = nPerh,
+                          kernelExtent = WT.kernelExtent)
+nodeSet = [nodes1]
+for nodes in nodeSet:
+    output("nodes.name")
+    output("nodes.hmin")
+    output("nodes.hmax")
+    output("nodes.hminratio")
+    output("nodes.nodesPerSmoothingScale")
+
+#-------------------------------------------------------------------------------
+# Set the node properties.
+#-------------------------------------------------------------------------------
+
+generator0 = GenerateNodeDistribution2d(5, 1,
+                                        rho = 1.0,
+                                        distributionType = "lattice",
+                                        xmin = (-0.5,  0.0),
+                                        xmax = (2.0,  0.5),
+                                        nNodePerh = nPerh)
+
+generator1 = GenerateDEMfromSPHGenerator2d(WT,
+                                           generator0,
+                                           nPerh=nPerh)
+distributeNodes2d((nodes1, generator1))
+
+#-------------------------------------------------------------------------------
+# Construct a DataBase to hold our node list
+#-------------------------------------------------------------------------------
+db = DataBase()
+output("db")
+for nodes in nodeSet:
+    db.appendNodeList(nodes)
+output("db.numNodeLists")
+output("db.numDEMNodeLists")
+output("db.numFluidNodeLists")
+
+
+#-------------------------------------------------------------------------------
+# DEM
+#-------------------------------------------------------------------------------
+dem = DEM(db,
+          normalSpringConstant = normalSpringConstant,
+          normalRestitutionCoefficient = normalRestitutionCoefficient,
+          tangentialSpringConstant = tangentialSpringConstant,
+          tangentialRestitutionCoefficient = tangentialRestitutionCoefficient,
+          dynamicFrictionCoefficient = dynamicFriction,
+          staticFrictionCoefficient = staticFriction,
+          rollingFrictionCoefficient = rollingFriction,
+          torsionalFrictionCoefficient = torsionalFriction,
+          cohesiveTensileStrength =cohesiveTensileStrength,
+          shapeFactor = shapeFactor,
+          stepsPerCollision = stepsPerCollision)
+
+packages = [dem]
+print "KULLFREAK = %s" % dem.kullFrequency
+dem.kullFrequency = 1
+
+
+
+#-------------------------------------------------------------------------------
+# Initial Conditions
+#-------------------------------------------------------------------------------
+
+velocity = nodes1.velocity()
+position = nodes1.positions()
+particleRadius = nodes1.particleRadius()
+
+uniqueIndices = dem.uniqueIndices
+omega = dem.omega 
+neighborIndices = dem.neighborIndices
+
+for i in range(nodes.numInternalNodes):
+    if position[i][0]<0.0:
+        velocity[i] = Vector(0,0.0)
+        position[i] = Vector( 0.25, 0.25)
+        omega[0][i]=1
+        uniqueIndices[0][i]=0
+        particleRadius[i] = radius
+    elif position[i][0]<0.5:
+        velocity[i] = Vector( vImpact,0.0)
+        position[i] = Vector(-0.25, 0.25)
+        particleRadius[i] = radius
+        uniqueIndices[0][i]=1
+    elif position[i][0]<1.0:
+        velocity[i] = Vector(-vImpact,0.0)
+        position[i] = Vector( 0.75, 0.25)
+        particleRadius[i] = radius
+        uniqueIndices[0][i]=2
+    elif position[i][0]<1.5:
+        velocity[i] = Vector(0.0, vImpact)
+        position[i] = Vector( 0.25,-0.25)
+        particleRadius[i] = radius
+        uniqueIndices[0][i]=3
+    elif position[i][0]<2.0:
+        velocity[i] = Vector(0.0,-vImpact)
+        position[i] = Vector( 0.25, 0.75)
+        particleRadius[i] = radius
+        uniqueIndices[0][i]=4
+
+
+
+#-------------------------------------------------------------------------------
+# Construct a time integrator, and add the physics packages.
+#-------------------------------------------------------------------------------
+
+integrator = IntegratorConstructor(db)
+for p in packages:
+    integrator.appendPhysicsPackage(p)
+integrator.lastDt = dt
+integrator.dtMin = dtMin
+integrator.dtMax = dtMax
+integrator.dtGrowth = dtGrowth
+integrator.domainDecompositionIndependent = domainIndependent
+integrator.verbose = dtverbose
+integrator.rigorousBoundaries = rigorousBoundaries
+
+integrator.cullGhostNodes = False
+
+output("integrator")
+output("integrator.havePhysicsPackage(dem)")
+output("integrator.lastDt")
+output("integrator.dtMin")
+output("integrator.dtMax")
+output("integrator.dtGrowth")
+output("integrator.domainDecompositionIndependent")
+output("integrator.rigorousBoundaries")
+output("integrator.verbose")
+
+#-------------------------------------------------------------------------------
+# Periodic Work Function : track conservation
+#-------------------------------------------------------------------------------
+conservation = TrackConservation(db,
+                                  dem,
+                                  verbose=False)
+                                  
+periodicWork = [(conservation.periodicWorkFunction,1)]
+
+
+#-------------------------------------------------------------------------------
+# Make the problem controller.
+#-------------------------------------------------------------------------------
+control = SpheralController(integrator, WT,
+                            iterateInitialH = False,
+                            initializeDerivatives = True,
+                            statsStep = statsStep,
+                            restartStep = restartStep,
+                            restartBaseName = restartBaseName,
+                            restoreCycle = restoreCycle,
+                            vizBaseName = vizBaseName,
+                            vizDir = vizDir,
+                            vizStep = vizCycle,
+                            vizTime = vizTime,
+                            periodicWork = periodicWork)
+output("control")
+
+#-------------------------------------------------------------------------------
+# Advance to the end time.
+#-------------------------------------------------------------------------------
+
+if not steps is None:
+    if checkRestart:
+        control.setRestartBaseName(restartBaseName + "_CHECK")
+    control.step(steps)
+else:
+    control.advance(goalTime, maxSteps)
+
+#-------------------------------------------------------------------------------
+# Great success?
+#-------------------------------------------------------------------------------
+if checkRestart:
+    control.setRestartBaseName(restartBaseName)
+    state0 = State(db, integrator.physicsPackages())
+    state0.copyState()
+    control.loadRestartFile(control.totalSteps)
+    state1 = State(db, integrator.physicsPackages())
+    if not state1 == state0:
+        raise ValueError, "The restarted state does not match!"
+    else:
+        print "Restart check PASSED."
+
+if checkContacts and mpi.procs==5:
+    for i in range(nodes.numInternalNodes):
+        if  uniqueIndices[0][i]==0:
+            if set(neighborIndices[0][i]) != set([1,2,3,4]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "Central node contact list is incorrect "
+        elif uniqueIndices[0][i]==1:
+            if set(neighborIndices[0][i]) != set([0]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "node 1 contact list is incorrect "
+        elif uniqueIndices[0][i]==2:
+            if set(neighborIndices[0][i]) != set([0]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "node 2 contact list is incorrect "
+        elif uniqueIndices[0][i]==3:
+            if set(neighborIndices[0][i]) != set([0]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "node 3 contact list is incorrect "
+        elif uniqueIndices[0][i]==4:
+            if set(neighborIndices[0][i]) != set([0]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "node 4 contact list is incorrect "
+
+
+if checkContacts and mpi.procs==1:
+    for i in range(nodes.numInternalNodes):
+        if  uniqueIndices[0][i]==0:
+            if set(neighborIndices[0][i]) != set([1,2,3,4]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "Central node contact list is incorrect "
+        elif uniqueIndices[0][i]==1:
+            if set(neighborIndices[0][i]) != set([]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "node 1 contact list is incorrect "
+        elif uniqueIndices[0][i]==2:
+            if set(neighborIndices[0][i]) != set([]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "node 2 contact list is incorrect "
+        elif uniqueIndices[0][i]==3:
+            if set(neighborIndices[0][i]) != set([]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "node 3 contact list is incorrect "
+        elif uniqueIndices[0][i]==4:
+            if set(neighborIndices[0][i]) != set([]):
+                print "-----------------------------"
+                print "unique index   : %s" % uniqueIndices[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "neighborIndices: %s" % neighborIndices[0][i]
+                print "-----------------------------"
+                raise ValueError, "node 4 contact list is incorrect "
+
+if checkAngularMomentum:
+    if  uniqueIndices[0][i]==0:
+            if omega[0][i] > 1:
+                print "-----------------------------"
+                print "Angular momentum : %s" % omega[0][i]
+                print "mpi rank       : %s" % mpi.rank
+                print "-----------------------------"
+                raise ValueError, "Central particles spin increased!"
+
+if checkConservation:
+    if  conservation.deltaLinearMomentumX() > conservationErrorThreshold:
+        raise ValueError, "linear momentum - x conservation error, %g, exceeds bounds" % conservation.deltaLinearMomentumX()
+    if  conservation.deltaLinearMomentumY() > conservationErrorThreshold:
+        raise ValueError, "linear momentum - y conservation error, %g, exceeds bounds" % conservation.deltaLinearMomentumY()
+    if  conservation.deltaRotationalMomentumZ() > conservationErrorThreshold:
+        raise ValueError, "rotational momentum -z conservation error, %g, exceeds bounds" % conservation.deltaRotationalMomentumZ()

--- a/tests/functional/DEM/LinearSpringDEM/impactingSquares-2d.py
+++ b/tests/functional/DEM/LinearSpringDEM/impactingSquares-2d.py
@@ -264,6 +264,16 @@ if not steps is None:
 else:
     control.advance(goalTime, maxSteps)
 
+if checkRestart:
+    control.setRestartBaseName(restartBaseName)
+    state0 = State(db, integrator.physicsPackages())
+    state0.copyState()
+    control.loadRestartFile(control.totalSteps)
+    state1 = State(db, integrator.physicsPackages())
+    if not state1 == state0:
+        raise ValueError, "The restarted state does not match!"
+    else:
+        print "Restart check PASSED."
 
 if checkConservation:
     if  conservation.deltaLinearMomentumX() > conservationErrorThreshold:

--- a/tests/functional/DEM/LinearSpringDEM/impactingSquares-2d.py
+++ b/tests/functional/DEM/LinearSpringDEM/impactingSquares-2d.py
@@ -61,6 +61,7 @@ commandLine(numParticlePerLength = 10,                # number of particles on a
             dataDir = "dumps-DEM-impactingSquares-2d",
             
             # ats
+            checkRestart = False,
             checkConservation = False,             # turn on error checking for momentum conservation
             conservationErrorThreshold = 1e-14,    # relative error for momentum conservation
             

--- a/tests/functional/DEM/LinearSpringDEM/impactingSquares-3d.py
+++ b/tests/functional/DEM/LinearSpringDEM/impactingSquares-3d.py
@@ -61,9 +61,9 @@ commandLine(numParticlePerLength = 4,                 # number of particles on a
             dataDir = "dumps-DEM-impactingSquares-3d",
 
             # ats
+            checkRestart = False,
             checkConservation = False,             # turn on error checking for momentum conservation
-            conservationErrorThreshold = 1e-14,    # relative error for momentum conservation
-            
+            conservationErrorThreshold = 1e-14,    # relative error for momentum conservation  
             )
 
 #-------------------------------------------------------------------------------

--- a/tests/functional/DEM/LinearSpringDEM/impactingSquares-3d.py
+++ b/tests/functional/DEM/LinearSpringDEM/impactingSquares-3d.py
@@ -271,6 +271,17 @@ if not steps is None:
 else:
     control.advance(goalTime, maxSteps)
 
+if checkRestart:
+    control.setRestartBaseName(restartBaseName)
+    state0 = State(db, integrator.physicsPackages())
+    state0.copyState()
+    control.loadRestartFile(control.totalSteps)
+    state1 = State(db, integrator.physicsPackages())
+    if not state1 == state0:
+        raise ValueError, "The restarted state does not match!"
+    else:
+        print "Restart check PASSED."
+
 if checkConservation:
 # check momentum conservation
 #-------------------------------------------------------------


### PR DESCRIPTION
This is a fix for a restart issue with DEM  in which the timestep -> infty. The issue would occur if the script was set up to skip node generation during restarts. DEM was simply setting the timestep on construction and without nodes the timestep calculation returns infty. To fix the issue, the timestep var is now a restartable var.

Updated 10/31/2022
In addition to the above, this PR also fixes conservation issues that would occur if the kullFrequency (now contactRemovalFrequency) was set to a number greater than 1. It also fixes conservation issues that would occur during redistribution. DEM should now be safe for arbitrary contactRemovalFrequency and with redistribution.


------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [x] LLNLSpheral PR has passed all tests.