### PR TITLE
when: always clean-dir

### DIFF
--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -44,6 +44,7 @@
     - cd $SPHERAL_BUILDS_DIR
     - source $CI_PROJECT_DIR/$SCRIPT_DIR/gitlab/clean_spheral_builds.sh 50
   extends: [.toss_resource_general]
+  when: always
 
 .update_tpls:
   stage: update_tpls


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Always runs the clean-dir job for gitlab. This stops our sphapp user workspace from filling up when a series of CI runs fail and do not reach the clean-dir job stage.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#24)
- [x] LLNLSpheral PR has passed all tests.

