### PR TITLE
SidreFileIO unit test fixes

### DIFF
--- a/tests/integration.ats
+++ b/tests/integration.ats
@@ -54,6 +54,7 @@ source("unit/FieldOperations/testSampleMultipleFields2Lattice3d.py")
 # FileIO tests
 source("unit/FileIO/testGzipFileIO.py")
 source("unit/FileIO/testSiloFileIO.py")
+source("unit/FileIO/testSidreFileIO.py")
 
 # Utilities tests
 source("unit/Utilities/testSegmentSegmentIntersection.py")

--- a/tests/unit/FileIO/testSidreFileIO.py
+++ b/tests/unit/FileIO/testSidreFileIO.py
@@ -35,10 +35,10 @@ class SidreFileIOTest(FileIOTestBase, unittest.TestCase):
     # If we are using MPI then we need to remove a directory because we are using Spio,
     # otherwise we remove a file as is the case with the other FileIO types.
     def removeFile(self, filename):
-        if mpi.comm:
-            shutil.rmtree(filename)
-        else:
+        if mpi.is_fake_mpi():
             os.remove(filename)
+        else:
+            shutil.rmtree(filename)
 
 #-------------------------------------------------------------------------------
 # Run those tests.

--- a/tests/unit/FileIO/testSidreFileIO.py
+++ b/tests/unit/FileIO/testSidreFileIO.py
@@ -4,6 +4,8 @@ from FileIOTestBase import *
 
 import os
 import unittest
+import mpi
+import shutil
 
 #-------------------------------------------------------------------------------
 # SidreFileIO tests.
@@ -30,8 +32,13 @@ class SidreFileIOTest(FileIOTestBase, unittest.TestCase):
     def tearDown(self):
         return
 
+    # If we are using MPI then we need to remove a directory because we are using Spio,
+    # otherwise we remove a file as is the case with the other FileIO types.
     def removeFile(self, filename):
-        os.remove(filename)
+        if mpi.comm:
+            shutil.rmtree(filename)
+        else:
+            os.remove(filename)
 
 #-------------------------------------------------------------------------------
 # Run those tests.


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Modifies SidreFileIO unit tests to work correctly without mpi (without Spio)
  - Adds SidreFileIO unit tests to the integration.ats file

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [x] LLNLSpheral PR has passed all tests.

