### PR TITLE
Feature/precompile python packages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,8 @@ Notable changes include:
     * C++ flag suppression is gaurded with build time CMake generators to only apply to C++ compilers.
     * Python runtime libraries are now managed through Spack / tpl-manager.
     * Added ENABLE_NAN_EXCEPTIONS (default OFF) Cmake flag to raise an exception when a NAN occurs (Gnu only)
+    * Byte-compiling python installed in virtual spheral environment
+    * Invoking spheral no longer byte-compiles Python imported in a spheral script
 
   * Bug Fixes / improvements:
     * spheral-atstest scripts always point to locally installed ATS instance.
@@ -42,6 +44,7 @@ Notable changes include:
     * Protected from division by zero in DEM when points coincide
     * Corrected support for minimum pressure (intact and damaged) with porous materials
     * Removed term driving damaged material to the reference density in solid hydros
+    * Added verbose flag to EquationOfState::specificThermalEnergyForPressure so users can see how the iterative search proceeds
 
 Version v2022.06.1 -- Release date 2022-06-24
 =============================================

--- a/scripts/spheral-env.in
+++ b/scripts/spheral-env.in
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-@CMAKE_INSTALL_PREFIX@/.venv/bin/python "$@"
+# Adding -B to prevent byte-compiling
+@CMAKE_INSTALL_PREFIX@/.venv/bin/python -B "$@"
 exit_result=$?
 exit $exit_result

--- a/scripts/spheral-setup-venv.in
+++ b/scripts/spheral-setup-venv.in
@@ -27,4 +27,7 @@ cp --symbolic-link scripts/atstest.sh spheral-atstest &> /dev/null
 cp --symbolic-link scripts/lcatstest.sh spheral-lcatstest &> /dev/null
 cd - > /dev/null 
 
+echo "Byte-compiling packages in install path ..."
+@CMAKE_INSTALL_PREFIX@ -m compileall @CMAKE_INSTALL_PREFIX@/.venv/lib/python2.7
+
 echo "Done."

--- a/src/Material/EquationOfState.cc
+++ b/src/Material/EquationOfState.cc
@@ -71,9 +71,10 @@ specificThermalEnergyForPressure(const typename Dimension::Scalar Ptarget,
                                  const typename Dimension::Scalar epsMax,
                                  const typename Dimension::Scalar epsTol,
                                  const typename Dimension::Scalar /* Ptol */,
-                                 const unsigned maxIterations) const {
+                                 const unsigned maxIterations,
+                                 const bool verbose) const {
   const Pfunctor<Dimension> pfunc(*this, rho, Ptarget);
-  return bisectRoot(pfunc, epsMin, epsMax, epsTol, maxIterations);
+  return bisectRoot(pfunc, epsMin, epsMax, epsTol, maxIterations, verbose);
 }
 
 }

--- a/src/Material/EquationOfState.hh
+++ b/src/Material/EquationOfState.hh
@@ -79,7 +79,8 @@ public:
                                                   const Scalar epsMax,
                                                   const Scalar epsTol,
                                                   const Scalar Ptol,
-                                                  const unsigned maxIterations) const;
+                                                  const unsigned maxIterations,
+                                                  const bool verbose = false) const;
 
   // Optionally provide a molecular weight.
   virtual Scalar molecularWeight() const;

--- a/src/Pybind11Wraps/Material/EquationOfState.py
+++ b/src/Pybind11Wraps/Material/EquationOfState.py
@@ -33,7 +33,8 @@ class EquationOfState:
                                          epsMax = "const Scalar",
                                          epsTol = "const Scalar",
                                          Ptol = "const Scalar",
-                                         maxIterations = ("const unsigned", "100")):
+                                         maxIterations = ("const unsigned", "100"),
+                                         verbose = ("const bool", "false")):
         return "Scalar"
 
     @PYB11virtual


### PR DESCRIPTION
# Summary

- This PR has a few changes for how Python byte-compilation is handled, and a minor feature  improvement for the EquationOfState.
  - During the install phase of the Spheral build we explicitly byte-compile all python code in the virtual environment.
  - When running the spheral executable, spheral will no longer btye-compile imported Python code itself by default.  This should only marginally affect startup times, and avoids race condition problems when running in parallel.
  - Added a verbose parameter to the EquationOfState::specificThermalEnergyForPressure when the user would like to see the details of how the iterative solution proceeds.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [x] LLNLSpheral PR has passed all tests.

