### PR TITLE
hdf5 lib issue

### DIFF
--- a/.github/workflows/test-tpls.yml
+++ b/.github/workflows/test-tpls.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     paths:
       - .uberenv_config.json
-      - src/scripts/spack/**
-      - src/devtools/**
+      - scripts/spack/**
+      - scripts/devtools/**
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/test-tpls.yml
+++ b/.github/workflows/test-tpls.yml
@@ -1,0 +1,37 @@
+name: Test external build.
+
+on:
+  pull_request:
+    paths:
+      - .uberenv_config.json
+      - src/scripts/spack/**
+      - src/devtools/**
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: llnl/spheral
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: build env image
+      run: docker build --target spheral-build-env-local --tag spheral-build-env .
+
+    - name: build spheral image
+      run: docker build --target spheral --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest --network none .
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,20 +10,20 @@ This release contains ...
 Notable changes include:
 
   * New features/ API changes:
-    * New Discrete Element Model (DEM) physics package with linear-damped spring approach
+    * New Discrete Element Model (DEM) physics package with linear-damped spring approach.
     * Adding a CUDA smoke test that can be called from the Spheral python API.
     * NVCC / CUDA 11 gitlab-ci jobs.
     * ATS default filters for non-MPI, debug and CUDA builds are injected into spheral-atstest script.
-    * Latest Develop docker containers hosted on ghcr.io/llnl/spheral:latest
+    * Latest Develop docker containers hosted on ghcr.io/llnl/spheral:latest.
     * External / offline builds are tested through github actions.
-    * New polyhedral gravity solver
-    * Improved DEM timestep choice, so that points that do not overlap do not overly constrain the timestep
-    * Point potential gravity solver can now have non-unit metrics
-    * Pair-max damage algorithm now decouples points in different NodeLists or with different fragmentIDs
-    * Added direct support for FacetedVolumes to FileIO interface
-    * ANEOS now allows shallow copies to be made
-    * Polyhedron contain method can now optionally use Axom methods to test for containment
-    * Adding user specified functions for shear modulus and yield strength as a function of damage    
+    * New polyhedral gravity solver.
+    * Improved DEM timestep choice, so that points that do not overlap do not overly constrain the timestep.
+    * Point potential gravity solver can now have non-unit metrics.
+    * Pair-max damage algorithm now decouples points in different NodeLists or with different fragmentIDs.
+    * Added direct support for FacetedVolumes to FileIO interface.
+    * ANEOS now allows shallow copies to be made.
+    * Polyhedron contain method can now optionally use Axom methods to test for containment.
+    * Adding user specified functions for shear modulus and yield strength as a function of damage.
 
   * Build changes / improvements:
     * The C++ library interface is compiled into a single Spheral_CXX library. 
@@ -32,19 +32,20 @@ Notable changes include:
     * Eigen bumped to 3.4.0 for NVCC compatiblity.
     * C++ flag suppression is gaurded with build time CMake generators to only apply to C++ compilers.
     * Python runtime libraries are now managed through Spack / tpl-manager.
-    * Added ENABLE_NAN_EXCEPTIONS (default OFF) Cmake flag to raise an exception when a NAN occurs (Gnu only)
-    * Byte-compiling python installed in virtual spheral environment
-    * Invoking spheral no longer byte-compiles Python imported in a spheral script
+    * Added ENABLE_NAN_EXCEPTIONS (default OFF) Cmake flag to raise an exception when a NAN occurs (Gnu only).
+    * Byte-compiling python installed in virtual spheral environment.
+    * Invoking spheral no longer byte-compiles Python imported in a spheral script.
+    * HDF5 links as a shared library. Static lib usage can be forced with ENABLE_STATIC_TPL.
 
   * Bug Fixes / improvements:
     * spheral-atstest scripts always point to locally installed ATS instance.
     * gitlab-ci report-results script for analyzing ATS CI runs.
     * Support for offline Spheral builds (provided TPLs are installed).
-    * Fixes for restarting without regenerating the original node positions in the Python script
-    * Protected from division by zero in DEM when points coincide
-    * Corrected support for minimum pressure (intact and damaged) with porous materials
-    * Removed term driving damaged material to the reference density in solid hydros
-    * Added verbose flag to EquationOfState::specificThermalEnergyForPressure so users can see how the iterative search proceeds
+    * Fixes for restarting without regenerating the original node positions in the Python script.
+    * Protected from division by zero in DEM when points coincide.
+    * Corrected support for minimum pressure (intact and damaged) with porous materials.
+    * Removed term driving damaged material to the reference density in solid hydros.
+    * Added verbose flag to EquationOfState::specificThermalEnergyForPressure so users can see how the iterative search proceeds.
 
 Version v2022.06.1 -- Release date 2022-06-24
 =============================================

--- a/cmake/spheral/SpheralAddLibs.cmake
+++ b/cmake/spheral/SpheralAddLibs.cmake
@@ -113,7 +113,7 @@ function(spheral_add_cxx_library
 
   # Set the r-path of the C++ lib such that it is independent of the build dir when installed
   set_target_properties(Spheral_${package_name} PROPERTIES
-                        INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${conduit_DIR}/lib;${axom_DIR}/lib;${boost_DIR}/lib"
+                        INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${conduit_DIR}/lib;${axom_DIR}/lib;${boost_DIR}/lib;${hdf5_DIR}/lib"
                         )
 endfunction()
 
@@ -161,7 +161,7 @@ function(spheral_add_pybind11_library package_name)
 
   # Set the r-path of the C++ lib such that it is independent of the build dir when installed
   set_target_properties(${MODULE_NAME} PROPERTIES
-                        INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${conduit_DIR}/lib;${axom_DIR}/lib;${boost_DIR}/lib;${python_DIR}/lib"
+    INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${conduit_DIR}/lib;${axom_DIR}/lib;${boost_DIR}/lib;${python_DIR}/lib;${hdf5_DIR}/lib"
                         )
 
 endfunction()

--- a/cmake/tpl/hdf5.cmake
+++ b/cmake/tpl/hdf5.cmake
@@ -1,1 +1,5 @@
-set(${lib_name}_libs libhdf5.a libhdf5_hl.a)
+set(${lib_name}_libs libhdf5.so libhdf5_hl.so)
+
+if(ENABLE_STATIC_TPL)
+  string(REPLACE ".so" ".a;" ${lib_name}_libs ${${lib_name}_libs})
+endif()

--- a/docs/build_guide/include/appendecies/cmake_config.rst.inc
+++ b/docs/build_guide/include/appendecies/cmake_config.rst.inc
@@ -83,6 +83,9 @@ In this section we list the CMake variables that can be tweaked for a Spheral bu
 ``<TPL-Name-Here>_DIR``
   Directory of previously built TPL.
 
+``ENABLE_STATIC_TPL`` (On, *Off*)
+  Link static libraries instead of shared for HDF5 and Conduit.
+
 ``ENABLE_OPENMP`` (*On*, Off)
   Support for OpenMP.
 

--- a/scripts/devtools/tpl-manager.py
+++ b/scripts/devtools/tpl-manager.py
@@ -35,6 +35,9 @@ def parse_args():
   parser.add_argument('--upstream-dir', type=str, default=default_upstream_dir,
       help='Dir of upstream spack installation.')
 
+  parser.add_argument('--no-upstream', action="store_true",
+      help='Do not use an upstream spack instance.')
+
   parser.add_argument('--spack-url', type=str, default="",
       help='URL of spack to use.')
 
@@ -96,7 +99,7 @@ def build_deps(args):
     spack_config_dir_opt="--spack-config-dir={0}".format(os.path.join(project_dir, "scripts/spack/configs/x86_64"))
 
   spack_upstream_opt=""
-  if os.path.isdir(args.upstream_dir):
+  if os.path.isdir(args.upstream_dir) and not args.no_upstream:
     spack_upstream_opt="--upstream {0}".format(args.upstream_dir)
 
   uberenv_spack_url_opt=""

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -7,7 +7,7 @@ from spack import *
 import socket
 import os
 
-class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
+class Spheral(CachedCMakePackage, CudaPackage):
     """Spheral++ provides a steerable parallel environment for performing coupled hydrodynamical and gravitational numerical simulations."""
 
     homepage = "https://spheral.readthedocs.io/"
@@ -44,14 +44,14 @@ class Spheral(CachedCMakePackage, CudaPackage, PythonPackage):
     depends_on('m-aneos')
     depends_on('py-polyclipper')
     depends_on('eigen@3.4.0', type='build')
-    depends_on('hdf5@1.8.19 ~shared ~mpi +hl', type='build', when='~mpi')
-    depends_on('hdf5@1.8.19 ~shared +mpi +hl', type='build', when='+mpi')
+    depends_on('hdf5@1.8.19 ~mpi +hl', type='build', when='~mpi')
+    depends_on('hdf5@1.8.19 +mpi +hl', type='build', when='+mpi')
 
     depends_on('silo@4.10.2 +hdf5', type='build')
 
     # Zlib fix has been merged into conduit, using develop until next release.
-    depends_on('conduit@0.8.2 +shared +mpi +hdf5 -test', type='build', when='+mpi')
-    depends_on('conduit@0.8.2 +shared ~mpi +hdf5 -test', type='build', when='~mpi')
+    depends_on('conduit@0.8.2 +shared +mpi +hdf5 -test ~parmetis', type='build', when='+mpi')
+    depends_on('conduit@0.8.2 +shared ~mpi +hdf5 -test ~parmetis', type='build', when='~mpi')
 
     depends_on('axom@0.5.0 ~shared +mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='+mpi')
     depends_on('axom@0.5.0 ~shared ~mpi +hdf5 -lua -examples -python -fortran -umpire -raja', type='build', when='~mpi')


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Links Spheral to the shared version of HDF5 when building the python interface. This is to ensure consistent linking across all Spheral TPLs and h5py python module. (static libs can be forced for C++ only builds with ENABLE_STATIC_TPL).
  - Adds a github action to run workflows when changes are made in uberenv or spack related files of Spheral.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [x] LLNLSpheral PR has passed all tests.

