### PR TITLE
cmake logic switch for cmake v3.21+

### DIFF
--- a/.gitlab/jobs-prod.yml
+++ b/.gitlab/jobs-prod.yml
@@ -17,20 +17,6 @@ shared_tpls_update_permissions:
 # ------------------------------------------------------------------------------
 # PROD BUILD JOBS
 
-### DEV ###
-toss_build_dev_pkg_dev:
-  extends: [.toss_resource_general, .gcc_mvapich2, .build_dev_pkg, .merge_pr_rule]
-
-toss_install_dev_pkg_dev:
-  extends: [.toss_resource_general, .gcc_mvapich2, .install_dev_pkg, .merge_pr_rule]
-  needs: [toss_build_dev_pkg_dev]
-
-toss_dev_permissions:
-  variables:
-    ALIAS: 'dev'
-  extends: [.toss_resource_general, .prod_permissions, .merge_pr_rule]
-  needs: [toss_install_dev_pkg_dev]
-
 ### TAG RELEASE ###
 toss_build_dev_pkg_release:
   extends: [.toss_resource_general, .gcc_mvapich2, .build_dev_pkg, .tag_release_rule]
@@ -44,6 +30,7 @@ toss_release_permissions:
     ALIAS: $CI_COMMIT_TAG
   extends: [.toss_resource_general, .prod_permissions, .tag_release_rule]
   needs: [toss_install_dev_pkg_release]
+
 # ------------------------------------------------------------------------------
 # CLEAN OLD BUILD DIRS
 

--- a/cmake/spheral/SpheralHandleTPL.cmake
+++ b/cmake/spheral/SpheralHandleTPL.cmake
@@ -94,7 +94,14 @@ function(Spheral_Handle_TPL lib_name dep_list target_type)
     else()
       message("Found: ${temp_abs_path}")
     endif()
-    unset(temp_abs_path CACHE) # Remove this line when using cmake 3.21+, same as find_file(NO_CACHE)
+
+    # find_file treats output as a standard variable from 3.21+ We get different behavior on later CMake versions.
+    if(${CMAKE_VERSION} VERSION_LESS "3.21.0")
+      unset(temp_abs_path CACHE)
+    else()
+      unset(temp_abs_path)
+    endif()
+
   endforeach()
 
   # Register any libs/includes under a blt dir for later use/depends


### PR DESCRIPTION
# Summary

- This PR is a bugfix
  -  Fixes find_file logic for builds configured with cmake 3.21+

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#49)
- [x] LLNLSpheral PR has passed all tests.

