### PR TITLE
Added toss_4 designation to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,8 @@ spack-build*
 *.logs
 rz*
 rz*
-toss_3*.cmake
-toss_4*.cmake
-blueos_3*.cmake
+toss_*.cmake
+blueos_*.cmake
 
 
 # These are files automatically generated in our configure process.

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ spack-build*
 rz*
 rz*
 toss_3*.cmake
+toss_4*.cmake
 blueos_3*.cmake
 
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Modifies the .gitignore file to accommodate Toss4. 

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [x] LLNLSpheral PR has passed all tests.

