### PR TITLE
CMake min version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists to build the Spheral library.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.18)
 include(cmake/SpheralVersion.cmake)
 project(spheral LANGUAGES C CXX Fortran VERSION ${SPHERAL_VERSION})
 

--- a/scripts/spack/configs/x86_64/packages.yaml
+++ b/scripts/spack/configs/x86_64/packages.yaml
@@ -10,11 +10,11 @@ packages:
   #    prefix: /usr/
   #  buildable: false
 
-  cmake:
-    externals:
-    - spec: cmake@3.16.3
-      prefix: /usr
-    buildable: false
+  #cmake:
+  #  externals:
+  #  - spec: cmake@3.16.3
+  #    prefix: /usr
+  #  buildable: false
 
 # ------ SYSTEM LIBS -------
   ncurses:


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Bumps the minimum CMake version requirement. This is needed for the move to C++17 when configuring CMake with nvcc as the compiler.
  - This can be merged into #246 instead of develop once passed.

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

