### PR TITLE
CMake find_package Python bugfix.

### DIFF
--- a/cmake/InstallTPLs.cmake
+++ b/cmake/InstallTPLs.cmake
@@ -17,7 +17,6 @@ include(${SPHERAL_ROOT_DIR}/cmake/spheral/SpheralHandleTPL.cmake)
 
 if (NOT ENABLE_CXXONLY)
   # Find the appropriate Python
-  set(Python3_ROOT_DIR ${python_DIR})
   find_package(Python3 COMPONENTS Interpreter Development)
   set(PYTHON_EXE ${Python3_EXECUTABLE})
   list(APPEND SPHERAL_BLT_DEPENDS Python3::Python)

--- a/cmake/SetupSpheral.cmake
+++ b/cmake/SetupSpheral.cmake
@@ -20,6 +20,11 @@ include(Compilers)
 #-------------------------------------------------------------------------------
 # Configure and Include blt
 #-------------------------------------------------------------------------------
+
+# Need to define Python paths here as BLT finds it's own Python package.
+set(Python_EXECUTABLE ${python_DIR}/bin/python3)
+set(Python3_EXECUTABLE ${python_DIR}/bin/python3)
+
 set(ENABLE_MPI ON CACHE BOOL "")
 set(ENABLE_OPENMP ON CACHE BOOL "")
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Defines Python*_EXECUTABLE to ensure CMake uses the explicit spack installation passed in config files and doesn't try to pick up system installs.
  - Moves the definition of the python install paths before BLT to be consistent across the project submodules.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

