### PR TITLE
Add make_policy.hh to the DataBase CMakeList.txt

### DIFF
--- a/src/DataBase/CMakeLists.txt
+++ b/src/DataBase/CMakeLists.txt
@@ -20,6 +20,7 @@ set(DataBase_headers
     FieldUpdatePolicyInline.hh
     CopyState.hh
     CopyStateInline.hh
+    make_policy.hh
     IncrementState.hh
     IncrementStateInline.hh
     IncrementBoundedState.hh


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Adds the make_policy.hh file to CMakeList.txt in DataBase.

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

