### PR TITLE
Bugfix/initialize problem startup dependencies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+Version vX.Y.Z -- Release date xxxx-xx-xx
+==============================================
+  * Important Notes:
+    * 
+
+Notable changes include:
+
+  * New features/ API changes:
+    * Adding an optional second-stage problem start-up hook to the Physics package interface: Physics::initializeProblemStartupDependencies.  The idea is to keep basic sizing
+      of arrays and such in the first stage (Physics::initializeProblemStartup), while this new hook is used for updating any initial Physics state (and therefore provides a
+      State and StateDerivatives object).
+
+  * Build changes / improvements:
+    * 
+
+  * Bug Fixes / improvements:
+    * Fixed bug with ConstantBoundary in the presence of porosity with the new porosity models introduced in v2024.01.00.
+
 Version v2024.01.00 -- Release date 2024-01-19
 ==============================================
   * Important Notes:

--- a/src/ArtificialViscosity/CullenDehnenViscosity.cc
+++ b/src/ArtificialViscosity/CullenDehnenViscosity.cc
@@ -90,8 +90,8 @@ initializeProblemStartup(DataBase<Dimension>& dataBase) {
   mR = dataBase.newFluidFieldList(0.0, "mR");
   mVsig = dataBase.newFluidFieldList(0.0, "mVsig");
 
-  FieldList<Dimension, Scalar>& rvQ = myq.CqMultiplier();
-  FieldList<Dimension, Scalar>& rvL = myq.ClMultiplier();
+  auto& rvQ = myq.CqMultiplier();
+  auto& rvL = myq.ClMultiplier();
   rvQ = dataBase.newFluidFieldList(malphMin, HydroFieldNames::ArtificialViscousCqMultiplier);  // This will override the Q initializer intializing these to unity.
   rvL = dataBase.newFluidFieldList(malphMin, HydroFieldNames::ArtificialViscousClMultiplier);
 }
@@ -104,17 +104,17 @@ void
 CullenDehnenViscosity<Dimension>::
 registerState(DataBase<Dimension>& dataBase,
               State<Dimension>& state) {
-  dataBase.resizeFluidFieldList(mPrevDvDt, Vector::zero, "mPrevDvDt", false);
-  dataBase.resizeFluidFieldList(mPrevDivV, 0.0, "mPrevDivV", false);
-  dataBase.resizeFluidFieldList(mCullAlpha, 1.0, "mCullAlpha", false);
+  CHECK(mPrevDvDt.numFields() == dataBase.numFluidNodeLists());
+  CHECK(mPrevDivV.numFields() == dataBase.numFluidNodeLists());
+  CHECK(mCullAlpha.numFields() == dataBase.numFluidNodeLists());
   state.enroll(mPrevDvDt);
   state.enroll(mPrevDivV);
   state.enroll(mCullAlpha);
 
-  FieldList<Dimension, Scalar>& rvAlphaQ = myq.CqMultiplier();
-  FieldList<Dimension, Scalar>& rvAlphaL = myq.ClMultiplier();
-  state.enroll(rvAlphaQ, std::make_shared<IncrementCullenMultipliers<Dimension>>(malphMin, malphMax, mboolHopkins));
-  state.enroll(rvAlphaL);
+  auto& rvQ = myq.CqMultiplier();
+  auto& rvL = myq.ClMultiplier();
+  state.enroll(rvQ, make_policy<IncrementCullenMultipliers<Dimension>>(malphMin, malphMax, mboolHopkins));
+  state.enroll(rvL);
 }
     
 //------------------------------------------------------------------------------
@@ -125,12 +125,12 @@ void
 CullenDehnenViscosity<Dimension>::
 registerDerivatives(DataBase<Dimension>& dataBase,
                     StateDerivatives<Dimension>& derivs) {
-  dataBase.resizeFluidFieldList(mPrevDivV2, 0.0, "mPrevDivV2", false);
-  dataBase.resizeFluidFieldList(mCullAlpha2, 1.0, "mCullAlpha2", false);
-  dataBase.resizeFluidFieldList(mDalphaDt, 0.0, "mDalphaDt", false);
-  dataBase.resizeFluidFieldList(mAlphaLocal, 0.0, "mAlphaLocal", false);
-  dataBase.resizeFluidFieldList(mR, 0.0, "mR", false);
-  dataBase.resizeFluidFieldList(mVsig, 0.0, "mVsig", false);
+  CHECK(mPrevDivV2.numFields() == dataBase.numFluidNodeLists());
+  CHECK(mCullAlpha2.numFields() == dataBase.numFluidNodeLists());
+  CHECK(mDalphaDt.numFields() == dataBase.numFluidNodeLists());
+  CHECK(mAlphaLocal.numFields() == dataBase.numFluidNodeLists());
+  CHECK(mR.numFields() == dataBase.numFluidNodeLists());
+  CHECK(mVsig.numFields() == dataBase.numFluidNodeLists());
   derivs.enroll(mPrevDivV2);
   derivs.enroll(mCullAlpha2);
   derivs.enroll(mDalphaDt);

--- a/src/ArtificialViscosity/MorrisMonaghanReducingViscosity.cc
+++ b/src/ArtificialViscosity/MorrisMonaghanReducingViscosity.cc
@@ -129,8 +129,8 @@ template<typename Dimension>
 void
 MorrisMonaghanReducingViscosity<Dimension>::
 initializeProblemStartup(DataBase<Dimension>& dataBase) {
-  FieldList<Dimension, Scalar>& rvQ = myq.CqMultiplier();
-  FieldList<Dimension, Scalar>& rvL = myq.ClMultiplier();
+  auto& rvQ = myq.CqMultiplier();
+  auto& rvL = myq.ClMultiplier();
   rvQ = dataBase.newFluidFieldList(0.0, HydroFieldNames::ArtificialViscousCqMultiplier);  // This will override the Q initializer intializing these to unity.
   rvL = dataBase.newFluidFieldList(0.0, HydroFieldNames::ArtificialViscousClMultiplier);
   mDrvAlphaDtQ = dataBase.newFluidFieldList(0.0, IncrementBoundedState<Dimension, Scalar>::prefix() + HydroFieldNames::ArtificialViscousCqMultiplier);
@@ -145,10 +145,10 @@ void
 MorrisMonaghanReducingViscosity<Dimension>::
 registerState(DataBase<Dimension>& /*dataBase*/,
               State<Dimension>& state) {
-  FieldList<Dimension, Scalar>& rvQ = myq.CqMultiplier();
-  FieldList<Dimension, Scalar>& rvL = myq.ClMultiplier();
-  state.enroll(rvQ, std::make_shared<IncrementBoundedState<Dimension, Scalar>>(maMin,maMax));
-  state.enroll(rvL, std::make_shared<IncrementBoundedState<Dimension, Scalar>>(maMin,maMax));
+  auto& rvQ = myq.CqMultiplier();
+  auto& rvL = myq.ClMultiplier();
+  state.enroll(rvQ, make_policy<IncrementBoundedState<Dimension, Scalar>>(maMin,maMax));
+  state.enroll(rvL, make_policy<IncrementBoundedState<Dimension, Scalar>>(maMin,maMax));
 }
     
 //------------------------------------------------------------------------------

--- a/src/CRKSPH/CRKSPHHydroBase.cc
+++ b/src/CRKSPH/CRKSPHHydroBase.cc
@@ -18,6 +18,7 @@
 #include "DataBase/IncrementBoundedState.hh"
 #include "DataBase/ReplaceState.hh"
 #include "DataBase/ReplaceBoundedState.hh"
+#include "DataBase/updateStateFields.hh"
 #include "Hydro/SpecificThermalEnergyPolicy.hh"
 #include "Hydro/SpecificFromTotalThermalEnergyPolicy.hh"
 #include "Hydro/PressurePolicy.hh"
@@ -149,12 +150,14 @@ CRKSPHHydroBase<Dimension>::
 template<typename Dimension>
 void
 CRKSPHHydroBase<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
 
   // Initialize the pressure, sound speed, and entropy.
-  dataBase.fluidPressure(mPressure);
-  dataBase.fluidSoundSpeed(mSoundSpeed);
-  dataBase.fluidEntropy(mEntropy);
+  updateStateFields<Dimension>(HydroFieldNames::pressure, state, derivs);
+  updateStateFields<Dimension>(HydroFieldNames::soundSpeed, state, derivs);
+  updateStateFields<Dimension>(HydroFieldNames::entropy, state, derivs);
 }
 
 //------------------------------------------------------------------------------
@@ -168,8 +171,6 @@ registerState(DataBase<Dimension>& dataBase,
 
   // Create the local storage for time step mask, pressure, sound speed, and correction fields.
   dataBase.resizeFluidFieldList(mTimeStepMask, 1, HydroFieldNames::timeStepMask);
-  // dataBase.fluidPressure(mPressure);
-  // dataBase.fluidSoundSpeed(mSoundSpeed);
   dataBase.resizeFluidFieldList(mEntropy,    0.0,                   HydroFieldNames::entropy, false);
   dataBase.resizeFluidFieldList(mPressure,   0.0,                   HydroFieldNames::pressure, false);
   dataBase.resizeFluidFieldList(mSoundSpeed, 0.0,                   HydroFieldNames::soundSpeed, false);

--- a/src/CRKSPH/CRKSPHHydroBase.hh
+++ b/src/CRKSPH/CRKSPHHydroBase.hh
@@ -63,7 +63,9 @@ public:
 
   // Tasks we do once on problem startup.
   virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                            State<Dimension>& state,
+                                            StateDerivatives<Dimension>& derivs) override;
 
   // Register the state Hydro expects to use and evolve.
   virtual 

--- a/src/CRKSPH/CRKSPHHydroBaseRZ.cc
+++ b/src/CRKSPH/CRKSPHHydroBaseRZ.cc
@@ -104,10 +104,19 @@ CRKSPHHydroBaseRZ::
 //------------------------------------------------------------------------------
 void
 CRKSPHHydroBaseRZ::
-initializeProblemStartup(DataBase<Dim<2> >& dataBase) {
-  
+initializeProblemStartup(DataBase<Dim<2>>& dataBase) {
   GeometryRegistrar::coords(CoordinateType::RZ);
+}
 
+//------------------------------------------------------------------------------
+// On problem start up some dependent state needs to be calculated
+//------------------------------------------------------------------------------
+void
+CRKSPHHydroBaseRZ::
+initializeProblemStartupDependencies(DataBase<Dim<2>>& dataBase,
+                                     State<Dim<2>>& state,
+                                     StateDerivatives<Dim<2>>& derivs) {
+  
   // Correct the mass to mass/r.
   auto mass = dataBase.fluidMass();
   const auto pos = dataBase.fluidPosition();
@@ -121,7 +130,7 @@ initializeProblemStartup(DataBase<Dim<2> >& dataBase) {
   }
 
   // Do general initializations.
-  CRKSPHHydroBase<Dim<2> >::initializeProblemStartup(dataBase);
+  CRKSPHHydroBase<Dim<2> >::initializeProblemStartupDependencies(dataBase, state, derivs);
 
   // Convert back to mass.
   for (unsigned nodeListi = 0; nodeListi != numNodeLists; ++nodeListi) {
@@ -138,8 +147,8 @@ initializeProblemStartup(DataBase<Dim<2> >& dataBase) {
 //------------------------------------------------------------------------------
 void
 CRKSPHHydroBaseRZ::
-registerState(DataBase<Dim<2> >& dataBase,
-              State<Dim<2> >& state) {
+registerState(DataBase<Dim<2>>& dataBase,
+              State<Dim<2>>& state) {
 
   // The base class does most of it.
   CRKSPHHydroBase<Dim<2> >::registerState(dataBase, state);

--- a/src/CRKSPH/CRKSPHHydroBaseRZ.hh
+++ b/src/CRKSPH/CRKSPHHydroBaseRZ.hh
@@ -62,9 +62,19 @@ public:
   // Destructor.
   virtual ~CRKSPHHydroBaseRZ();
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
+  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Register the state Hydro expects to use and evolve.
   virtual 

--- a/src/CRKSPH/CRKSPHVariant.hh
+++ b/src/CRKSPH/CRKSPHVariant.hh
@@ -63,9 +63,19 @@ public:
   // Destructor.
   virtual ~CRKSPHVariant() override;
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
+  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Initialize the Hydro before we start a derivative evaluation.
   virtual

--- a/src/CRKSPH/SolidCRKSPHHydroBase.cc
+++ b/src/CRKSPH/SolidCRKSPHHydroBase.cc
@@ -25,6 +25,7 @@
 #include "DataBase/IncrementBoundedState.hh"
 #include "DataBase/ReplaceState.hh"
 #include "DataBase/ReplaceBoundedState.hh"
+#include "DataBase/updateStateFields.hh"
 #include "ArtificialViscosity/ArtificialViscosity.hh"
 #include "DataBase/DataBase.hh"
 #include "Field/FieldList.hh"
@@ -161,20 +162,17 @@ SolidCRKSPHHydroBase<Dimension>::
 template<typename Dimension>
 void
 SolidCRKSPHHydroBase<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
 
   // Call the ancestor.
-  CRKSPHHydroBase<Dimension>::initializeProblemStartup(dataBase);
+  CRKSPHHydroBase<Dimension>::initializeProblemStartupDependencies(dataBase, state, derivs);
 
   // Set the moduli.
-  size_t nodeListi = 0;
-  for (auto itr = dataBase.solidNodeListBegin();
-       itr < dataBase.solidNodeListEnd();
-       ++itr, ++nodeListi) {
-    (*itr)->bulkModulus(*mBulkModulus[nodeListi]);
-    (*itr)->shearModulus(*mShearModulus[nodeListi]);
-    (*itr)->yieldStrength(*mYieldStrength[nodeListi]);
-  }
+  updateStateFields(SolidFieldNames::bulkModulus, state, derivs);
+  updateStateFields(SolidFieldNames::shearModulus, state, derivs);
+  updateStateFields(SolidFieldNames::yieldStrength, state, derivs);
 
   // Copy the initial H field to apply to nodes as they become damaged.
   const auto H = dataBase.fluidHfield();

--- a/src/CRKSPH/SolidCRKSPHHydroBase.hh
+++ b/src/CRKSPH/SolidCRKSPHHydroBase.hh
@@ -61,7 +61,9 @@ public:
 
   // Tasks we do once on problem startup.
   virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                            State<Dimension>& state,
+                                            StateDerivatives<Dimension>& derivatives) override;
 
   // Register the state Hydro expects to use and evolve.
   virtual 

--- a/src/CRKSPH/SolidCRKSPHHydroBaseRZ.cc
+++ b/src/CRKSPH/SolidCRKSPHHydroBaseRZ.cc
@@ -148,9 +148,18 @@ SolidCRKSPHHydroBaseRZ::
 //------------------------------------------------------------------------------
 void
 SolidCRKSPHHydroBaseRZ::
-initializeProblemStartup(DataBase<Dim<2> >& dataBase) {
-
+initializeProblemStartup(DataBase<Dim<2>>& dataBase) {
   GeometryRegistrar::coords(CoordinateType::RZ);
+}
+
+//------------------------------------------------------------------------------
+// On problem start up, we need to initialize our internal data.
+//------------------------------------------------------------------------------
+void
+SolidCRKSPHHydroBaseRZ::
+initializeProblemStartupDependencies(DataBase<Dim<2>>& dataBase,
+                                     State<Dim<2>>& state,
+                                     StateDerivatives<Dim<2>>& derivs) {
 
   // Correct the mass to mass/r.
   auto mass = dataBase.fluidMass();
@@ -165,7 +174,7 @@ initializeProblemStartup(DataBase<Dim<2> >& dataBase) {
   }
 
   // Call the ancestor.
-  SolidCRKSPHHydroBase<Dimension>::initializeProblemStartup(dataBase);
+  SolidCRKSPHHydroBase<Dimension>::initializeProblemStartupDependencies(dataBase, state, derivs);
 
   // Convert back to mass.
   for (unsigned nodeListi = 0; nodeListi != numNodeLists; ++nodeListi) {

--- a/src/CRKSPH/SolidCRKSPHHydroBaseRZ.hh
+++ b/src/CRKSPH/SolidCRKSPHHydroBaseRZ.hh
@@ -61,9 +61,19 @@ public:
   // Destructor.
   virtual ~SolidCRKSPHHydroBaseRZ();
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
+  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Register the state Hydro expects to use and evolve.
   virtual 

--- a/src/Damage/IvanoviSALEDamageModel.cc
+++ b/src/Damage/IvanoviSALEDamageModel.cc
@@ -32,6 +32,7 @@
 #include "DataBase/State.hh"
 #include "DataBase/StateDerivatives.hh"
 #include "DataBase/ReplaceState.hh"
+#include "DataBase/updateStateFields.hh"
 #include "Hydro/HydroFieldNames.hh"
 #include "Field/FieldList.hh"
 #include "Boundary/Boundary.hh"
@@ -249,30 +250,22 @@ enforceBoundaries(State<Dimension>& state,
 }
 
 //------------------------------------------------------------------------------
-// Stuff to do on problem startup
+// On problem start up, we need to initialize our internal data.
 //------------------------------------------------------------------------------
 template<typename Dimension>
 void
 IvanoviSALEDamageModel<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
 
-  // We need a bunch of state to set the Youngs modulus and longitudinal sound speed
-  const auto& nodes = this->nodeList();
-  const auto& rho = nodes.massDensity();
-  const auto& eps = nodes.specificThermalEnergy();
-  const auto& D = nodes.damage();
-  Field<Dimension, Scalar> P("P", nodes), K("K", nodes), mu("mu", nodes);
-  nodes.equationOfState().setPressure(P, rho, eps);
-  if (nodes.strengthModel().providesBulkModulus()) {
-    nodes.strengthModel().bulkModulus(K, rho, eps);
-  } else {
-    nodes.equationOfState().setBulkModulus(K, rho, eps);
-  }
-  nodes.strengthModel().shearModulus(mu, rho, eps, P, D);
-
-  // Set the initial values for Youngs modulus and the longitudinal sound speed
-  nodes.YoungsModulus(mYoungsModulus, K, mu);
-  nodes.longitudinalSoundSpeed(mLongitudinalSoundSpeed, rho, K, mu);
+  // Set the moduli.
+  updateStateFields(HydroFieldNames::pressure, state, derivs);
+  updateStateFields(SolidFieldNames::bulkModulus, state, derivs);
+  updateStateFields(SolidFieldNames::shearModulus, state, derivs);
+  updateStateFields(SolidFieldNames::yieldStrength, state, derivs);
+  updateStateFields(SolidFieldNames::YoungsModulus, state, derivs);
+  updateStateFields(SolidFieldNames::longitudinalSoundSpeed, state, derivs);
 }
 
 //------------------------------------------------------------------------------

--- a/src/Damage/IvanoviSALEDamageModel.hh
+++ b/src/Damage/IvanoviSALEDamageModel.hh
@@ -83,9 +83,13 @@ public:
   virtual void enforceBoundaries(State<Dimension>& state,
                                  StateDerivatives<Dimension>& derivs) override;
 
-  // An optional hook to initialize once when the problem is starting up.
-  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
-
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
   //............................................................................
   // Accessors for state
   double minPlasticFailure() const;

--- a/src/Damage/ProbabilisticDamageModel.hh
+++ b/src/Damage/ProbabilisticDamageModel.hh
@@ -50,8 +50,19 @@ public:
   //............................................................................
   // Override the Physics package interface.
 
-  // Initialize once when the problem is starting up.
+  // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
   virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Compute the derivatives.
   virtual void evaluateDerivatives(const Scalar time,

--- a/src/Damage/TensorDamageModel.cc
+++ b/src/Damage/TensorDamageModel.cc
@@ -24,6 +24,7 @@
 #include "DataBase/State.hh"
 #include "DataBase/StateDerivatives.hh"
 #include "DataBase/ReplaceState.hh"
+#include "DataBase/updateStateFields.hh"
 #include "Hydro/HydroFieldNames.hh"
 #include "Field/FieldList.hh"
 #include "Boundary/Boundary.hh"
@@ -225,30 +226,22 @@ enforceBoundaries(State<Dimension>& state,
 }
 
 //------------------------------------------------------------------------------
-// Stuff to do on problem startup
+// On problem start up, we need to initialize our internal data.
 //------------------------------------------------------------------------------
 template<typename Dimension>
 void
 TensorDamageModel<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
 
-  // We need a bunch of state to set the Youngs modulus and longitudinal sound speed
-  const auto& nodes = this->nodeList();
-  const auto& rho = nodes.massDensity();
-  const auto& eps = nodes.specificThermalEnergy();
-  const auto& D = nodes.damage();
-  Field<Dimension, Scalar> P("P", nodes), K("K", nodes), mu("mu", nodes);
-  nodes.equationOfState().setPressure(P, rho, eps);
-  if (nodes.strengthModel().providesBulkModulus()) {
-    nodes.strengthModel().bulkModulus(K, rho, eps);
-  } else {
-    nodes.equationOfState().setBulkModulus(K, rho, eps);
-  }
-  nodes.strengthModel().shearModulus(mu, rho, eps, P, D);
-
-  // Set the initial values for Youngs modulus and the longitudinal sound speed
-  nodes.YoungsModulus(mYoungsModulus, K, mu);
-  nodes.longitudinalSoundSpeed(mLongitudinalSoundSpeed, rho, K, mu);
+  // Set the moduli.
+  updateStateFields(HydroFieldNames::pressure, state, derivs);
+  updateStateFields(SolidFieldNames::bulkModulus, state, derivs);
+  updateStateFields(SolidFieldNames::shearModulus, state, derivs);
+  updateStateFields(SolidFieldNames::yieldStrength, state, derivs);
+  updateStateFields(SolidFieldNames::YoungsModulus, state, derivs);
+  updateStateFields(SolidFieldNames::longitudinalSoundSpeed, state, derivs);
 }
 
 //------------------------------------------------------------------------------

--- a/src/Damage/TensorDamageModel.hh
+++ b/src/Damage/TensorDamageModel.hh
@@ -106,8 +106,13 @@ public:
   virtual void enforceBoundaries(State<Dimension>& state,
                                  StateDerivatives<Dimension>& derivs) override;
 
-  // An optional hook to initialize once when the problem is starting up.
-  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   //...........................................................................
   // Optional method to cull the set of flaws to the single weakest one on

--- a/src/DataBase/CMakeLists.txt
+++ b/src/DataBase/CMakeLists.txt
@@ -38,6 +38,8 @@ set(DataBase_headers
     StateDerivatives.hh
     StateDerivativesInline.hh
     StateInline.hh
+    applyPolicyToFieldList.hh
+    updateStateFields.hh
     )
 
 spheral_add_obj_library(DataBase SPHERAL_OBJ_LIBS)

--- a/src/DataBase/State.cc
+++ b/src/DataBase/State.cc
@@ -195,9 +195,7 @@ update(StateDerivatives<Dimension>& derivs,
 
     // Walk the remaining state to be completed.
     vector<KeyType> stateToRemove;
-    for (auto& fieldKey_KeysAndPolicies: stateToBeCompleted) {
-      const KeyType& fieldKey = fieldKey_KeysAndPolicies.first;
-      const set<KeyType>& remainingKeys = stateToBeCompleted[fieldKey];
+    for (auto& [fieldKey, remainingKeys]: stateToBeCompleted) { // (fieldKey, set<full_fieldKeys>)
 
       // Walk the remaining individual keys for this fieldKey.
       for (auto& key: remainingKeys) {

--- a/src/DataBase/applyPolicyToFieldList.hh
+++ b/src/DataBase/applyPolicyToFieldList.hh
@@ -1,0 +1,42 @@
+//---------------------------------Spheral++----------------------------------//
+// Convenience function to apply a policy to all the Fields in a FieldList
+//
+// Created by JMO, Thu Aug 26 14:28:07 2004
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_applyPolicyToFieldList_hh__
+#define __Spheral_applyPolicyToFieldList_hh__
+
+#include "Field/FieldList.hh"
+#include "DataBase/UpdatePolicyBase.hh"
+#include "DataBase/State.hh"
+#include "DataBase/StateDerivatives.hh"
+
+namespace Spheral {
+
+template<typename FieldListType>
+inline
+void applyPolicyToFieldList(FieldListType& fieldList,
+                            std::shared_ptr<UpdatePolicyBase<typename FieldListType::FieldDimension>> policyPtr,
+                            State<typename FieldListType::FieldDimension>& state,
+                            StateDerivatives<typename FieldListType::FieldDimension>& derivs,
+                            const double multiplier = 1.0,
+                            const double t = 0.0,
+                            const double dt = 0.0) {
+  using Dimension = typename FieldListType::FieldDimension;
+  if (policyPtr->clonePerField()) {
+    for (auto* fieldPtr: fieldList) {
+      const auto key = StateBase<Dimension>::key(*fieldPtr);
+      policyPtr->update(key, state, derivs, multiplier, t, dt);
+    }
+  } else {
+    if (fieldList.numFields() > 0) {
+      const auto key = StateBase<Dimension>::buildFieldKey(fieldList[0]->name(), policyPtr->wildcard());
+      policyPtr->update(key, state, derivs, multiplier, t, dt);
+    }
+  }
+}
+
+}
+
+#endif
+

--- a/src/DataBase/updateStateFields.hh
+++ b/src/DataBase/updateStateFields.hh
@@ -1,0 +1,34 @@
+//---------------------------------Spheral++----------------------------------//
+// Convenience function to use policies to update a FieldList
+//
+// Created by JMO, Wed Jan 31 13:52:31 PST 2024
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_updateStateFields_hh__
+#define __Spheral_updateStateFields_hh__
+
+#include "Field/FieldBase.hh"
+#include "DataBase/UpdatePolicyBase.hh"
+#include "DataBase/State.hh"
+#include "DataBase/StateDerivatives.hh"
+
+namespace Spheral {
+
+template<typename Dimension>
+inline
+void updateStateFields(const typename FieldBase<Dimension>::FieldName& fieldName,
+                       State<Dimension>& state,
+                       StateDerivatives<Dimension>& derivs,
+                       const double multiplier = 1.0,
+                       const double t = 0.0,
+                       const double dt = 0.0) {
+  const auto policies = state.policies(fieldName);
+  CHECK(not policies.empty());
+  for (auto& [key, policy]: policies) {
+    policy->update(key, state, derivs, multiplier, t, dt);
+  }
+}
+
+}
+
+#endif
+

--- a/src/ExternalForce/PointPotential.cc
+++ b/src/ExternalForce/PointPotential.cc
@@ -114,12 +114,20 @@ void
 PointPotential<Dimension>::
 initializeProblemStartup(DataBase<Dimension>& db) {
   mPotential = db.newGlobalFieldList(0.0, "gravitational potential");
+}
 
+//------------------------------------------------------------------------------
+// Do start of the problem type tasks.
+//------------------------------------------------------------------------------
+template<typename Dimension>
+void 
+PointPotential<Dimension>::
+initializeProblemStartupDependencies(DataBase<Dimension>& db,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
   // We need to make a dry run through setting derivatives and such
   // to set our initial vote on the time step.
   vector<Physics<Dimension>*> packages(1, this);
-  State<Dimension> state(db, packages);
-  StateDerivatives<Dimension> derivs(db, packages);
   this->initialize(0.0, 1.0, db, state, derivs);
   this->evaluateDerivatives(0.0, 1.0, db, state, derivs);
 }

--- a/src/ExternalForce/PointPotential.hh
+++ b/src/ExternalForce/PointPotential.hh
@@ -36,27 +36,38 @@ public:
 
   // We augment the generic body force state.
   virtual void registerState(DataBase<Dimension>& dataBase,
-                             State<Dimension>& state);
+                             State<Dimension>& state) override;
 
   // This is the derivative method that all BodyPotential classes must provide.
   virtual void evaluateDerivatives(const Scalar time,
                                    const Scalar dt,
                                    const DataBase<Dimension>& dataBase,
                                    const State<Dimension>& state,
-                                   StateDerivatives<Dimension>& derivs) const;
+                                   StateDerivatives<Dimension>& derivs) const override;
 
   // Provide the timestep appropriate for this package.
   virtual TimeStepType dt(const DataBase<Dimension>& dataBase, 
                           const State<Dimension>& state,
                           const StateDerivatives<Dimension>& derivs,
-                          const Scalar currentTime) const;
+                          const Scalar currentTime) const override;
 
-  //! Initializations on problem start up.
-  virtual void initializeProblemStartup(DataBase<Dimension>& db);
+  // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
+  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Get the cumulative potential energy calculated in the last 
   // evaluateDerivatives.
-  virtual Scalar extraEnergy() const;
+  virtual Scalar extraEnergy() const override;
 
   // The specific potential.
   Scalar specificPotential(const Vector& r) const;

--- a/src/FSISPH/SolidFSISPHHydroBase.cc
+++ b/src/FSISPH/SolidFSISPHHydroBase.cc
@@ -38,6 +38,7 @@
 #include "DataBase/IncrementBoundedState.hh"
 #include "DataBase/ReplaceBoundedState.hh"
 #include "DataBase/PureReplaceState.hh"
+#include "DataBase/updateStateFields.hh"
 
 #include "ArtificialViscosity/ArtificialViscosity.hh"
 #include "Field/FieldList.hh"
@@ -278,30 +279,27 @@ SolidFSISPHHydroBase<Dimension>::
 }
 
 //------------------------------------------------------------------------------
-// initialization on problem start up
+// On problem start up, we need to initialize our internal data.
 //------------------------------------------------------------------------------
 template<typename Dimension>
 void
 SolidFSISPHHydroBase<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase){
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
 
-  dataBase.fluidPressure(mPressure);
-  dataBase.fluidSoundSpeed(mSoundSpeed);
+  // Set the moduli.
+  updateStateFields(HydroFieldNames::pressure, state, derivs);
+  updateStateFields(HydroFieldNames::soundSpeed, state, derivs);
+  updateStateFields(SolidFieldNames::bulkModulus, state, derivs);
+  updateStateFields(SolidFieldNames::shearModulus, state, derivs);
+  updateStateFields(SolidFieldNames::yieldStrength, state, derivs);
+
   mDamagedPressure+=this->pressure();
 
   const auto& mass = dataBase.fluidMass();
   const auto& massDensity = dataBase.fluidMassDensity();
   computeSPHVolume(mass,massDensity,mVolume);
-
-  // Set the moduli.
-  auto nodeListi = 0;
-  for (auto itr = dataBase.solidNodeListBegin();
-       itr != dataBase.solidNodeListEnd();
-       ++itr, ++nodeListi) {
-    (*itr)->bulkModulus(*mBulkModulus[nodeListi]);
-    (*itr)->shearModulus(*mShearModulus[nodeListi]);
-    (*itr)->yieldStrength(*mYieldStrength[nodeListi]);
-  } 
 }
 
 //------------------------------------------------------------------------------

--- a/src/FSISPH/SolidFSISPHHydroBase.hh
+++ b/src/FSISPH/SolidFSISPHHydroBase.hh
@@ -88,8 +88,13 @@ public:
 
   virtual ~SolidFSISPHHydroBase();
 
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   virtual
   void registerState(DataBase<Dimension>& dataBase,

--- a/src/Field/FieldList.hh
+++ b/src/Field/FieldList.hh
@@ -247,6 +247,7 @@ public:
   // The number of fields in the FieldList.
   unsigned numFields() const;
   unsigned size() const;
+  bool empty() const;
 
   // The number of nodes in the FieldList.
   unsigned numNodes() const;

--- a/src/Field/FieldListInline.hh
+++ b/src/Field/FieldListInline.hh
@@ -1630,6 +1630,13 @@ FieldList<Dimension, DataType>::size() const {
 
 template<typename Dimension, typename DataType>
 inline
+bool
+FieldList<Dimension, DataType>::empty() const {
+  return mFieldPtrs.empty();
+}
+
+template<typename Dimension, typename DataType>
+inline
 unsigned 
 FieldList<Dimension, DataType>::numNodes() const {
   unsigned numberOfNodes = 0;

--- a/src/GSPH/GSPHHydroBase.cc
+++ b/src/GSPH/GSPHHydroBase.cc
@@ -103,9 +103,11 @@ GSPHHydroBase<Dimension>::
 template<typename Dimension>
 void
 GSPHHydroBase<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
   TIME_BEGIN("GSPHinitializeStartup");
-  GenericRiemannHydro<Dimension>::initializeProblemStartup(dataBase);
+  GenericRiemannHydro<Dimension>::initializeProblemStartupDependencies(dataBase, state, derivs);
   TIME_END("GSPHinitializeStartup");
 }
 

--- a/src/GSPH/GSPHHydroBase.hh
+++ b/src/GSPH/GSPHHydroBase.hh
@@ -60,9 +60,13 @@ public:
   // Destructor.
   virtual ~GSPHHydroBase();
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Register the state Hydro expects to use and evolve.
   virtual 

--- a/src/GSPH/GenericRiemannHydro.cc
+++ b/src/GSPH/GenericRiemannHydro.cc
@@ -16,6 +16,7 @@
 #include "DataBase/ReplaceState.hh"
 #include "DataBase/IncrementBoundedState.hh"
 #include "DataBase/ReplaceBoundedState.hh"
+#include "DataBase/updateStateFields.hh"
 
 #include "Hydro/HydroFieldNames.hh"
 #include "Hydro/CompatibleDifferenceSpecificThermalEnergyPolicy.hh"
@@ -169,9 +170,13 @@ GenericRiemannHydro<Dimension>::
 template<typename Dimension>
 void
 GenericRiemannHydro<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
-  dataBase.fluidPressure(mPressure);
-  dataBase.fluidSoundSpeed(mSoundSpeed);
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
+
+  // Set the moduli.
+  updateStateFields(HydroFieldNames::pressure, state, derivs);
+  updateStateFields(HydroFieldNames::soundSpeed, state, derivs);
 
   // for now initialize with SPH volume to make sure things are defined
   const auto mass = dataBase.fluidMass();

--- a/src/GSPH/GenericRiemannHydro.hh
+++ b/src/GSPH/GenericRiemannHydro.hh
@@ -77,9 +77,13 @@ public:
                           const StateDerivatives<Dimension>& derivs,
                           const Scalar currentTime) const override;
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Register the state Hydro expects to use and evolve.
   virtual 

--- a/src/GSPH/MFMHydroBase.cc
+++ b/src/GSPH/MFMHydroBase.cc
@@ -104,8 +104,10 @@ MFMHydroBase<Dimension>::
 template<typename Dimension>
 void
 MFMHydroBase<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
-  GenericRiemannHydro<Dimension>::initializeProblemStartup(dataBase);
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
+  GenericRiemannHydro<Dimension>::initializeProblemStartupDependencies(dataBase, state, derivs);
 }
 
 //------------------------------------------------------------------------------

--- a/src/GSPH/MFMHydroBase.hh
+++ b/src/GSPH/MFMHydroBase.hh
@@ -62,9 +62,13 @@ public:
   // Destructor.
   virtual ~MFMHydroBase();
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Register the state Hydro expects to use and evolve.
   virtual 

--- a/src/Gravity/NBodyGravity.cc
+++ b/src/Gravity/NBodyGravity.cc
@@ -245,12 +245,18 @@ initializeProblemStartup(DataBase<Dimension>& db) {
   mPotential.copyFields();
   mPotential0.copyFields();
   mVel02.copyFields();
+}
 
-  // We need to make a dry run through setting derivatives and such
-  // to set our initial vote on the time step.
+//------------------------------------------------------------------------------
+// Do start of the problem type tasks.
+//------------------------------------------------------------------------------
+template<typename Dimension>
+void 
+NBodyGravity<Dimension>::
+initializeProblemStartupDependencies(DataBase<Dimension>& db,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
   vector<Physics<Dimension>*> packages(1, this);
-  State<Dimension> state(db, packages);
-  StateDerivatives<Dimension> derivs(db, packages);
   this->initialize(0.0, 1.0, db, state, derivs);
   this->evaluateDerivatives(0.0, 1.0, db, state, derivs);
 }

--- a/src/Gravity/NBodyGravity.hh
+++ b/src/Gravity/NBodyGravity.hh
@@ -59,9 +59,19 @@ public:
                           const StateDerivatives<Dimension>& derivs,
                           const Scalar currentTime) const override;
 
-  //! Initializations on problem start up.
-  virtual void initializeProblemStartup(DataBase<Dimension>& db) override;
+  // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
+  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
 
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
   //! Beginning of timestep work.
   virtual void preStepInitialize(const DataBase<Dimension>& dataBase, 
                                  State<Dimension>& state,

--- a/src/Gravity/PolyGravity.cc
+++ b/src/Gravity/PolyGravity.cc
@@ -228,12 +228,20 @@ initializeProblemStartup(DataBase<Dimension>& db) {
 
   // Allocate space for the gravitational potential FieldList.
   mPotential = db.newGlobalFieldList(0.0, "gravitational potential");
+}
 
+//------------------------------------------------------------------------------
+// Do start of the problem type tasks.
+//------------------------------------------------------------------------------
+template<typename Dimension>
+void 
+PolyGravity<Dimension>::
+initializeProblemStartupDependencies(DataBase<Dimension>& db,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
   // We need to make a dry run through setting derivatives and such
   // to set our initial vote on the time step.
   vector<Physics<Dimension>*> packages(1, this);
-  State<Dimension> state(db, packages);
-  StateDerivatives<Dimension> derivs(db, packages);
   this->initialize(0.0, 1.0, db, state, derivs);
   this->evaluateDerivatives(0.0, 1.0, db, state, derivs);
 }

--- a/src/Gravity/PolyGravity.hh
+++ b/src/Gravity/PolyGravity.hh
@@ -69,8 +69,19 @@ public:
                           const StateDerivatives<Dimension>& /*derivs*/,
                           const Scalar /*currentTime*/) const;
 
-  //! Initializations on problem start up.
-  virtual void initializeProblemStartup(DataBase<Dimension>& db);
+  // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
+  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   //! This package opts out of building connectivity.
   virtual bool requireConnectivity() const { return false; }

--- a/src/Gravity/TreeGravity.cc
+++ b/src/Gravity/TreeGravity.cc
@@ -342,12 +342,20 @@ initializeProblemStartup(DataBase<Dimension>& db) {
 
   // Allocate space for the gravitational potential FieldList.
   mPotential = db.newGlobalFieldList(0.0, "gravitational potential");
+}
 
+//------------------------------------------------------------------------------
+// Do start of the problem type tasks.
+//------------------------------------------------------------------------------
+template<typename Dimension>
+void 
+TreeGravity<Dimension>::
+initializeProblemStartupDependencies(DataBase<Dimension>& db,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
   // We need to make a dry run through setting derivatives and such
   // to set our initial vote on the time step.
   vector<Physics<Dimension>*> packages(1, this);
-  State<Dimension> state(db, packages);
-  StateDerivatives<Dimension> derivs(db, packages);
   this->initialize(0.0, 1.0, db, state, derivs);
   this->evaluateDerivatives(0.0, 1.0, db, state, derivs);
 }

--- a/src/Gravity/TreeGravity.hh
+++ b/src/Gravity/TreeGravity.hh
@@ -70,8 +70,19 @@ public:
                           const StateDerivatives<Dimension>& /*derivs*/,
                           const Scalar /*currentTime*/) const;
 
-  //! Initializations on problem start up.
-  virtual void initializeProblemStartup(DataBase<Dimension>& db);
+  // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
+  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   //! Initialize before we start a derivative evaluation.
   virtual void initialize(const Scalar /*time*/,

--- a/src/PYB11/CRKSPH/CRKSPHHydroBase.py
+++ b/src/PYB11/CRKSPH/CRKSPHHydroBase.py
@@ -43,8 +43,14 @@ class CRKSPHHydroBase(GenericHydro):
     #...........................................................................
     # Virtual methods
     @PYB11virtual
-    def initializeProblemStartup(self, dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/CRKSPH/CRKSPHHydroBaseRZ.py
+++ b/src/PYB11/CRKSPH/CRKSPHHydroBaseRZ.py
@@ -42,8 +42,24 @@ class CRKSPHHydroBaseRZ(CRKSPHHydroBase):
     #...........................................................................
     # Virtual methods
     @PYB11virtual
-    def initializeProblemStartup(self, dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartup(self,
+                                 dataBase = "DataBase<%(Dimension)s>&"):
+        """An optional hook to initialize once when the problem is starting up.
+Typically this is used to size arrays once all the materials and NodeLists have
+been created.  It is assumed after this method has been called it is safe to
+call Physics::registerState for instance to create full populated State objects."""
+
+        return "void"
+
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/CRKSPH/CRKSPHVariant.py
+++ b/src/PYB11/CRKSPH/CRKSPHVariant.py
@@ -44,8 +44,24 @@ class CRKSPHVariant(CRKSPHHydroBase):
     #...........................................................................
     # Virtual methods
     @PYB11virtual
-    def initializeProblemStartup(self, dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartup(self,
+                                 dataBase = "DataBase<%(Dimension)s>&"):
+        """An optional hook to initialize once when the problem is starting up.
+Typically this is used to size arrays once all the materials and NodeLists have
+been created.  It is assumed after this method has been called it is safe to
+call Physics::registerState for instance to create full populated State objects."""
+
+        return "void"
+
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual

--- a/src/PYB11/CRKSPH/SolidCRKSPHHydroBase.py
+++ b/src/PYB11/CRKSPH/SolidCRKSPHHydroBase.py
@@ -43,8 +43,14 @@ class SolidCRKSPHHydroBase(CRKSPHHydroBase):
     #...........................................................................
     # Virtual methods
     @PYB11virtual
-    def initializeProblemStartup(self, dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/CRKSPH/SolidCRKSPHHydroBaseRZ.py
+++ b/src/PYB11/CRKSPH/SolidCRKSPHHydroBaseRZ.py
@@ -44,8 +44,24 @@ class SolidCRKSPHHydroBaseRZ(CRKSPHHydroBase):
     #...........................................................................
     # Virtual methods
     @PYB11virtual
-    def initializeProblemStartup(self, dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartup(self,
+                                 dataBase = "DataBase<%(Dimension)s>&"):
+        """An optional hook to initialize once when the problem is starting up.
+Typically this is used to size arrays once all the materials and NodeLists have
+been created.  It is assumed after this method has been called it is safe to
+call Physics::registerState for instance to create full populated State objects."""
+
+        return "void"
+
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/Damage/IvanoviSALEDamageModel.py
+++ b/src/PYB11/Damage/IvanoviSALEDamageModel.py
@@ -96,9 +96,14 @@ Lundborg, N. (1967). The strength-size relation of granite. International Journa
         return "void"
 
     @PYB11virtual
-    def initializeProblemStartup(self,
-                                 dataBase = "DataBase<%(Dimension)s>&"):
-        "An optional hook to initialize once when the problem is starting up."
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     #...........................................................................

--- a/src/PYB11/Damage/ProbabilisticDamageModel.py
+++ b/src/PYB11/Damage/ProbabilisticDamageModel.py
@@ -45,7 +45,22 @@ resolution materials."""
     @PYB11virtual
     def initializeProblemStartup(self,
                                  dataBase = "DataBase<%(Dimension)s>&"):
-        "Initialize once when the problem is starting up."
+        """An optional hook to initialize once when the problem is starting up.
+Typically this is used to size arrays once all the materials and NodeLists have
+been created.  It is assumed after this method has been called it is safe to
+call Physics::registerState for instance to create full populated State objects."""
+
+        return "void"
+
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/Damage/TensorDamageModel.py
+++ b/src/PYB11/Damage/TensorDamageModel.py
@@ -84,9 +84,14 @@ required of descendant classes."""
         return "void"
 
     @PYB11virtual
-    def initializeProblemStartup(self,
-                                 dataBase = "DataBase<%(Dimension)s>&"):
-        "An optional hook to initialize once when the problem is starting up."
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     #...........................................................................

--- a/src/PYB11/ExternalForce/PointPotential.py
+++ b/src/PYB11/ExternalForce/PointPotential.py
@@ -59,7 +59,22 @@ class PointPotential(GenericBodyForce):
     @PYB11virtual
     def initializeProblemStartup(self,
                                  dataBase = "DataBase<%(Dimension)s>&"):
-        "An optional hook to initialize once when the problem is starting up."
+        """An optional hook to initialize once when the problem is starting up.
+Typically this is used to size arrays once all the materials and NodeLists have
+been created.  It is assumed after this method has been called it is safe to
+call Physics::registerState for instance to create full populated State objects."""
+
+        return "void"
+
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual

--- a/src/PYB11/FSISPH/SolidFSISPHHydroBase.py
+++ b/src/PYB11/FSISPH/SolidFSISPHHydroBase.py
@@ -62,10 +62,15 @@ mass density, velocity, and specific thermal energy."""
         return "void"
 
     @PYB11virtual
-    def initializeProblemStartup(dataBase = "DataBase<%(Dimension)s>&"):
-        "register the surface normals w/ the database"
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
-
 
     @PYB11virtual
     def initialize(time = "const Scalar",

--- a/src/PYB11/GSPH/GSPHHydroBase.py
+++ b/src/PYB11/GSPH/GSPHHydroBase.py
@@ -41,8 +41,14 @@ class GSPHHydroBase(GenericRiemannHydro):
     # Virtual methods
 
     @PYB11virtual
-    def initializeProblemStartup(dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/GSPH/GenericRiemannHydro.py
+++ b/src/PYB11/GSPH/GenericRiemannHydro.py
@@ -50,8 +50,14 @@ class GenericRiemannHydro(Physics):
         return "TimeStepType"
 
     @PYB11virtual
-    def initializeProblemStartup(dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/GSPH/MFMHydroBase.py
+++ b/src/PYB11/GSPH/MFMHydroBase.py
@@ -41,8 +41,14 @@ class MFMHydroBase(GenericRiemannHydro):
     # Virtual methods
 
     @PYB11virtual
-    def initializeProblemStartup(dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/Gravity/NBodyGravity.py
+++ b/src/PYB11/Gravity/NBodyGravity.py
@@ -57,7 +57,22 @@ class NBodyGravity(GenericBodyForce):
     @PYB11virtual
     def initializeProblemStartup(self,
                                  dataBase = "DataBase<%(Dimension)s>&"):
-        "An optional hook to initialize once when the problem is starting up."
+        """An optional hook to initialize once when the problem is starting up.
+Typically this is used to size arrays once all the materials and NodeLists have
+been created.  It is assumed after this method has been called it is safe to
+call Physics::registerState for instance to create full populated State objects."""
+
+        return "void"
+
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual

--- a/src/PYB11/Gravity/PolyGravity.py
+++ b/src/PYB11/Gravity/PolyGravity.py
@@ -60,7 +60,22 @@ class PolyGravity(GenericBodyForce):
     @PYB11virtual
     def initializeProblemStartup(self,
                                  dataBase = "DataBase<%(Dimension)s>&"):
-        "An optional hook to initialize once when the problem is starting up."
+        """An optional hook to initialize once when the problem is starting up.
+Typically this is used to size arrays once all the materials and NodeLists have
+been created.  It is assumed after this method has been called it is safe to
+call Physics::registerState for instance to create full populated State objects."""
+
+        return "void"
+
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual

--- a/src/PYB11/Gravity/TreeGravity.py
+++ b/src/PYB11/Gravity/TreeGravity.py
@@ -59,7 +59,22 @@ class TreeGravity(GenericBodyForce):
     @PYB11virtual
     def initializeProblemStartup(self,
                                  dataBase = "DataBase<%(Dimension)s>&"):
-        "An optional hook to initialize once when the problem is starting up."
+        """An optional hook to initialize once when the problem is starting up.
+Typically this is used to size arrays once all the materials and NodeLists have
+been created.  It is assumed after this method has been called it is safe to
+call Physics::registerState for instance to create full populated State objects."""
+
+        return "void"
+
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual

--- a/src/PYB11/Physics/Physics.py
+++ b/src/PYB11/Physics/Physics.py
@@ -41,7 +41,22 @@ class Physics:
     @PYB11virtual
     def initializeProblemStartup(self,
                                  dataBase = "DataBase<%(Dimension)s>&"):
-        "An optional hook to initialize once when the problem is starting up."
+        """An optional hook to initialize once when the problem is starting up.
+Typically this is used to size arrays once all the materials and NodeLists have
+been created.  It is assumed after this method has been called it is safe to
+call Physics::registerState for instance to create full populated State objects."""
+
+        return "void"
+
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual

--- a/src/PYB11/Porosity/PalphaPorosity.py
+++ b/src/PYB11/Porosity/PalphaPorosity.py
@@ -98,14 +98,6 @@ parameter (alpha) and gives it to the PorousEquationOfState.
         jutziStateUpdate: Optionally update the deviatoric stress and damage as described in Jutzi 2008"""
 
     #...........................................................................
-    # Virtual methods
-    @PYB11virtual
-    def initializeProblemStartup(self, 
-                                 dataBase = "DataBase<%(Dimension)s>&"):
-        "Do any required one-time initializations on problem start up."
-        return "void"
-
-    #...........................................................................
     # Methods
     @PYB11const
     def phi(self):

--- a/src/PYB11/SPH/PSPHHydroBase.py
+++ b/src/PYB11/SPH/PSPHHydroBase.py
@@ -40,6 +40,17 @@ class PSPHHydroBase(SPHHydroBase):
 
     #...........................................................................
     # Virtual methods
+    @PYB11virtual
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
+        return "void"
+
     @PYB11virtual 
     def registerState(dataBase = "DataBase<%(Dimension)s>&",
                       state = "State<%(Dimension)s>&"):

--- a/src/PYB11/SPH/SPHHydroBase.py
+++ b/src/PYB11/SPH/SPHHydroBase.py
@@ -43,8 +43,14 @@ class SPHHydroBase(GenericHydro):
     #...........................................................................
     # Virtual methods
     @PYB11virtual
-    def initializeProblemStartup(dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/SPH/SPHHydroBaseRZ.py
+++ b/src/PYB11/SPH/SPHHydroBaseRZ.py
@@ -42,11 +42,6 @@ class SPHHydroBaseRZ(SPHHydroBase):
 
     #...........................................................................
     # Virtual methods
-    @PYB11virtual
-    def initializeProblemStartup(dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
-        return "void"
-
     @PYB11virtual 
     def registerState(dataBase = "DataBase<%(Dimension)s>&",
                       state = "State<%(Dimension)s>&"):

--- a/src/PYB11/SPH/SolidSPHHydroBase.py
+++ b/src/PYB11/SPH/SolidSPHHydroBase.py
@@ -47,8 +47,14 @@ class SolidSPHHydroBase(SPHHydroBase):
     #...........................................................................
     # Virtual methods
     @PYB11virtual
-    def initializeProblemStartup(dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
+    def initializeProblemStartupDependencies(self,
+                                             dataBase = "DataBase<%(Dimension)s>&",
+                                             state = "State<%(Dimension)s>&",
+                                             derivs = "StateDerivatives<%(Dimension)s>&"):
+        """A second optional method to be called on startup, after Physics::initializeProblemStartup has
+been called.
+One use for this hook is to fill in dependendent state using the State object, such as
+temperature or pressure."""
         return "void"
 
     @PYB11virtual 

--- a/src/PYB11/SPH/SolidSPHHydroBaseRZ.py
+++ b/src/PYB11/SPH/SolidSPHHydroBaseRZ.py
@@ -46,11 +46,6 @@ class SolidSPHHydroBaseRZ(SolidSPHHydroBase):
 
     #...........................................................................
     # Virtual methods
-    @PYB11virtual
-    def initializeProblemStartup(dataBase = "DataBase<%(Dimension)s>&"):
-        "Tasks we do once on problem startup."
-        return "void"
-
     @PYB11virtual 
     def registerState(dataBase = "DataBase<%(Dimension)s>&",
                       state = "State<%(Dimension)s>&"):

--- a/src/Physics/Physics.cc
+++ b/src/Physics/Physics.cc
@@ -114,6 +114,17 @@ initializeProblemStartup(DataBase<Dimension>& /*dataBase*/) {
 }
 
 //------------------------------------------------------------------------------
+// Provide a default no-op problem startup initialization dependencies method.
+//------------------------------------------------------------------------------
+template<typename Dimension>
+void
+Physics<Dimension>::
+initializeProblemStartupDependencies(DataBase<Dimension>& /*dataBase*/,
+                                     State<Dimension>& /*state*/,
+                                     StateDerivatives<Dimension>& /*derivs*/) {
+}
+
+//------------------------------------------------------------------------------
 // Provide a default no-op pre-step initialization method.
 //------------------------------------------------------------------------------
 template<typename Dimension>

--- a/src/Physics/Physics.hh
+++ b/src/Physics/Physics.hh
@@ -100,7 +100,18 @@ public:
 
   //******************************************************************************//
   // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
   virtual void initializeProblemStartup(DataBase<Dimension>& dataBase);
+
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs);
 
   // Optional hook to be called at the beginning of a time step.
   virtual void preStepInitialize(const DataBase<Dimension>& dataBase, 

--- a/src/Physics/Physics.hh
+++ b/src/Physics/Physics.hh
@@ -100,15 +100,19 @@ public:
 
   //******************************************************************************//
   // An optional hook to initialize once when the problem is starting up.
-  // Typically this is used to size arrays once all the materials and NodeLists have
-  // been created.  It is assumed after this method has been called it is safe to
-  // call Physics::registerState for instance to create full populated State objects.
+  // This is called after the materials and NodeLists are created. This method
+  // should set the sizes of all arrays owned by the physics package and initialize
+  // independent variables.
+  // It is assumed after this method has been called it is safe to call
+  // Physics::registerState to create full populated State objects.
   virtual void initializeProblemStartup(DataBase<Dimension>& dataBase);
 
-  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
-  // been called.
-  // One use for this hook is to fill in dependendent state using the State object, such as
-  // temperature or pressure.
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup
+  // has been called.
+  // This method is called after independent variables have been initialized and put into
+  // the state and derivatives. During this method, the dependent state, such as
+  // temperature and pressure, is initialized so that all the fields in the initial
+  // state and derivatives objects are valid.
   virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
                                                     State<Dimension>& state,
                                                     StateDerivatives<Dimension>& derivs);

--- a/src/Porosity/PalphaPorosity.cc
+++ b/src/Porosity/PalphaPorosity.cc
@@ -233,29 +233,6 @@ registerState(DataBase<Dimension>& dataBase,
 }
 
 //------------------------------------------------------------------------------
-// One time initializations at problem set up.
-//------------------------------------------------------------------------------
-template<typename Dimension>
-void
-PalphaPorosity<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
-
-  // Base initialization
-  PorosityModel<Dimension>::initializeProblemStartup(dataBase);
-
-  // Get some state from the DataBase we're gonna need
-  const auto  rhoFL = dataBase.fluidMassDensity();
-  const auto  epsFL = dataBase.fluidSpecificThermalEnergy();
-  const auto& rho = **rhoFL.fieldForNodeList(mNodeList);
-  const auto& eps = **epsFL.fieldForNodeList(mNodeList);
-
-  // We also need the partial derivatives of the pressure.
-  Field<Dimension, Scalar> P("tmp pressure", mNodeList);
-  const auto& eos = mNodeList.equationOfState();
-  eos.setPressureAndDerivs(P, mdPdU, mdPdR, rho, eps);
-}
-
-//------------------------------------------------------------------------------
 // Dump the current state to the given file.
 //------------------------------------------------------------------------------
 template<typename Dimension>

--- a/src/Porosity/PalphaPorosity.hh
+++ b/src/Porosity/PalphaPorosity.hh
@@ -82,9 +82,6 @@ public:
   // Register our state.
   virtual void registerState(DataBase<Dimension>& dataBase,
                              State<Dimension>& state) override;
-
-  // Do any required one-time initializations on problem start up.
-  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
   //............................................................................
 
   //............................................................................

--- a/src/SPH/PSPHHydroBase.cc
+++ b/src/SPH/PSPHHydroBase.cc
@@ -15,7 +15,10 @@
 #include "DataBase/IncrementState.hh"
 #include "DataBase/ReplaceState.hh"
 #include "DataBase/ReplaceBoundedState.hh"
+#include "DataBase/applyPolicyToFieldList.hh"
 #include "Hydro/GammaPolicy.hh"
+#include "Hydro/PressurePolicy.hh"
+#include "Hydro/SoundSpeedPolicy.hh"
 #include "Mesh/generateMesh.hh"
 #include "ArtificialViscosity/ArtificialViscosity.hh"
 #include "DataBase/DataBase.hh"
@@ -109,6 +112,23 @@ PSPHHydroBase(const SmoothingScaleBase<Dimension>& smoothingScaleMethod,
 template<typename Dimension>
 PSPHHydroBase<Dimension>::
 ~PSPHHydroBase() {
+}
+
+//------------------------------------------------------------------------------
+// On problem start up, we need to initialize our internal data.
+//------------------------------------------------------------------------------
+template<typename Dimension>
+void
+PSPHHydroBase<Dimension>::
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
+
+  // The SPH class tries to update these using the policies, but since PSPH
+  // handles them differently we have to override that behavior here and do
+  // it differently.
+  applyPolicyToFieldList(this->mPressure, make_policy<PressurePolicy<Dimension>>(), state, derivs);
+  applyPolicyToFieldList(this->mSoundSpeed, make_policy<SoundSpeedPolicy<Dimension>>(), state, derivs);
 }
 
 //------------------------------------------------------------------------------

--- a/src/SPH/PSPHHydroBase.hh
+++ b/src/SPH/PSPHHydroBase.hh
@@ -62,6 +62,14 @@ public:
   void registerState(DataBase<Dimension>& dataBase,
                      State<Dimension>& state) override;
 
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
+
   // Pre-step initializations.
   virtual 
   void preStepInitialize(const DataBase<Dimension>& dataBase, 

--- a/src/SPH/SPHHydroBase.cc
+++ b/src/SPH/SPHHydroBase.cc
@@ -17,6 +17,7 @@
 #include "DataBase/ReplaceState.hh"
 #include "DataBase/IncrementBoundedState.hh"
 #include "DataBase/ReplaceBoundedState.hh"
+#include "DataBase/updateStateFields.hh"
 #include "Hydro/VolumePolicy.hh"
 #include "Hydro/VoronoiMassDensityPolicy.hh"
 #include "Hydro/SumVoronoiMassDensityPolicy.hh"
@@ -180,12 +181,15 @@ SPHHydroBase<Dimension>::
 template<typename Dimension>
 void
 SPHHydroBase<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
-
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
   TIME_BEGIN("SPHinitializeStartup");
-  // Initialize the pressure and sound speed.
-  dataBase.fluidPressure(mPressure);
-  dataBase.fluidSoundSpeed(mSoundSpeed);
+
+  // Set the moduli.
+  updateStateFields(HydroFieldNames::pressure, state, derivs);
+  updateStateFields(HydroFieldNames::soundSpeed, state, derivs);
+
   // dataBase.fluidEntropy(mEntropy);
 
   // // In some cases we need the volume per node as well.

--- a/src/SPH/SPHHydroBase.hh
+++ b/src/SPH/SPHHydroBase.hh
@@ -59,9 +59,13 @@ public:
   // Destructor.
   virtual ~SPHHydroBase();
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Register the state Hydro expects to use and evolve.
   virtual 

--- a/src/SPH/SPHHydroBaseRZ.cc
+++ b/src/SPH/SPHHydroBaseRZ.cc
@@ -112,16 +112,6 @@ SPHHydroBaseRZ::
 }
 
 //------------------------------------------------------------------------------
-// On problem start up, we set the RZ flag on the DataBase.
-//------------------------------------------------------------------------------
-void
-SPHHydroBaseRZ::
-initializeProblemStartup(DataBase<Dim<2> >& dataBase) {
-  GeometryRegistrar::coords(CoordinateType::RZ);
-  SPHHydroBase<Dim<2> >::initializeProblemStartup(dataBase);
-}
-
-//------------------------------------------------------------------------------
 // Register the state we need/are going to evolve.
 //------------------------------------------------------------------------------
 void

--- a/src/SPH/SPHHydroBaseRZ.hh
+++ b/src/SPH/SPHHydroBaseRZ.hh
@@ -57,10 +57,6 @@ public:
   // Destructor.
   virtual ~SPHHydroBaseRZ();
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
-
   // Register the state Hydro expects to use and evolve.
   virtual 
   void registerState(DataBase<Dimension>& dataBase,

--- a/src/SPH/SolidSPHHydroBase.cc
+++ b/src/SPH/SolidSPHHydroBase.cc
@@ -20,6 +20,7 @@
 #include "DataBase/IncrementState.hh"
 #include "DataBase/ReplaceState.hh"
 #include "DataBase/ReplaceBoundedState.hh"
+#include "DataBase/updateStateFields.hh"
 #include "ArtificialViscosity/ArtificialViscosity.hh"
 #include "DataBase/DataBase.hh"
 #include "Field/FieldList.hh"
@@ -201,25 +202,21 @@ SolidSPHHydroBase<Dimension>::
 template<typename Dimension>
 void
 SolidSPHHydroBase<Dimension>::
-initializeProblemStartup(DataBase<Dimension>& dataBase) {
-
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
   TIME_BEGIN("SolidSPHinitializeStartup");
 
   // Call the ancestor.
   SPHHydroBase<Dimension>::initializeProblemStartup(dataBase);
 
   // Set the moduli.
-  auto nodeListi = 0;
-  for (auto itr = dataBase.solidNodeListBegin();
-       itr != dataBase.solidNodeListEnd();
-       ++itr, ++nodeListi) {
-    (*itr)->bulkModulus(*mBulkModulus[nodeListi]);
-    (*itr)->shearModulus(*mShearModulus[nodeListi]);
-    (*itr)->yieldStrength(*mYieldStrength[nodeListi]);
-  }
+  updateStateFields(SolidFieldNames::bulkModulus, state, derivs);
+  updateStateFields(SolidFieldNames::shearModulus, state, derivs);
+  updateStateFields(SolidFieldNames::yieldStrength, state, derivs);
 
   // Copy the initial H field to apply to nodes as they become damaged.
-  const FieldList<Dimension, SymTensor> H = dataBase.fluidHfield();
+  const auto H = dataBase.fluidHfield();
   mHfield0.assignFields(H);
 
   TIME_END("SolidSPHinitializeStartup");

--- a/src/SPH/SolidSPHHydroBase.hh
+++ b/src/SPH/SolidSPHHydroBase.hh
@@ -63,10 +63,13 @@ public:
   // Destructor.
   virtual ~SolidSPHHydroBase();
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
-
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
   // Register the state Hydro expects to use and evolve.
   virtual 
   void registerState(DataBase<Dimension>& dataBase,

--- a/src/SPH/SolidSPHHydroBaseRZ.cc
+++ b/src/SPH/SolidSPHHydroBaseRZ.cc
@@ -130,16 +130,6 @@ SolidSPHHydroBaseRZ::
 }
 
 //------------------------------------------------------------------------------
-// On problem start up, we need to initialize our internal data.
-//------------------------------------------------------------------------------
-void
-SolidSPHHydroBaseRZ::
-initializeProblemStartup(DataBase<Dim<2> >& dataBase) {
-  GeometryRegistrar::coords(CoordinateType::RZ);
-  SolidSPHHydroBase<Dim<2> >::initializeProblemStartup(dataBase);
-}
-
-//------------------------------------------------------------------------------
 // Register the state we need/are going to evolve.
 //------------------------------------------------------------------------------
 void

--- a/src/SPH/SolidSPHHydroBaseRZ.hh
+++ b/src/SPH/SolidSPHHydroBaseRZ.hh
@@ -71,10 +71,6 @@ public:
   // Destructor.
   virtual ~SolidSPHHydroBaseRZ();
 
-  // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
-
   // Register the state Hydro expects to use and evolve.
   virtual 
   void registerState(DataBase<Dimension>& dataBase,

--- a/src/SVPH/SVPHHydroBase.cc
+++ b/src/SVPH/SVPHHydroBase.cc
@@ -122,10 +122,21 @@ initializeProblemStartup(DataBase<Dimension>& dataBase) {
   // Create storage for the pressure and sound speed.
   mPressure = dataBase.newFluidFieldList(0.0, HydroFieldNames::pressure);
   mSoundSpeed = dataBase.newFluidFieldList(0.0, HydroFieldNames::soundSpeed);
+  mVolume = dataBase.newFluidFieldList(0.0, HydroFieldNames::volume);
 
-  // Initialize the pressure and sound speed.
-  dataBase.fluidPressure(mPressure);
-  dataBase.fluidSoundSpeed(mSoundSpeed);
+//------------------------------------------------------------------------------
+// Second stage of problem start up: initialize values
+//------------------------------------------------------------------------------
+template<typename Dimension>
+void
+SVPHHydroBase<Dimension>::
+initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                     State<Dimension>& state,
+                                     StateDerivatives<Dimension>& derivs) {
+
+  // Set the moduli.
+  updateStateFields(HydroFieldNames::pressure, state, derivs);
+  updateStateFields(HydroFieldNames::soundSpeed, state, derivs);
 
   // Construct the mesh and volumes.
   NodeList<Dimension> voidNodes("internal void", 0, 0);
@@ -148,7 +159,6 @@ initializeProblemStartup(DataBase<Dimension>& dataBase) {
      2.0,               // voidThreshold
      *mMeshPtr,
      voidNodes);
-  mVolume = dataBase.newFluidFieldList(0.0, HydroFieldNames::volume);
   for (unsigned nodeListi = 0; nodeListi != dataBase.numFluidNodeLists(); ++nodeListi) {
     const unsigned n = mVolume[nodeListi]->numInternalElements();
     const unsigned offset = mMeshPtr->offset(nodeListi);

--- a/src/SVPH/SVPHHydroBase.hh
+++ b/src/SVPH/SVPHHydroBase.hh
@@ -53,18 +53,29 @@ public:
   virtual ~SVPHHydroBase();
 
   // Tasks we do once on problem startup.
-  virtual
-  void initializeProblemStartup(DataBase<Dimension>& dataBase);
+  // An optional hook to initialize once when the problem is starting up.
+  // Typically this is used to size arrays once all the materials and NodeLists have
+  // been created.  It is assumed after this method has been called it is safe to
+  // call Physics::registerState for instance to create full populated State objects.
+  virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;
+
+  // A second optional method to be called on startup, after Physics::initializeProblemStartup has
+  // been called.
+  // One use for this hook is to fill in dependendent state using the State object, such as
+  // temperature or pressure.
+  virtual void initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
+                                                    State<Dimension>& state,
+                                                    StateDerivatives<Dimension>& derivs) override;
 
   // Register the state Hydro expects to use and evolve.
   virtual 
   void registerState(DataBase<Dimension>& dataBase,
-                     State<Dimension>& state);
+                     State<Dimension>& state) override;
 
   // Register the derivatives/change fields for updating state.
   virtual
   void registerDerivatives(DataBase<Dimension>& dataBase,
-                           StateDerivatives<Dimension>& derivs);
+                           StateDerivatives<Dimension>& derivs) override;
 
   // Initialize the Hydro before we start a derivative evaluation.
   virtual
@@ -72,7 +83,7 @@ public:
                   const Scalar dt,
                   const DataBase<Dimension>& dataBase,
                   State<Dimension>& state,
-                  StateDerivatives<Dimension>& derivs);
+                  StateDerivatives<Dimension>& derivs) override;
                        
   // Evaluate the derivatives for the principle hydro variables:
   // mass density, velocity, and specific thermal energy.
@@ -81,7 +92,7 @@ public:
                            const Scalar dt,
                            const DataBase<Dimension>& dataBase,
                            const State<Dimension>& state,
-                           StateDerivatives<Dimension>& derivatives) const;
+                           StateDerivatives<Dimension>& derivatives) const override;
 
   // Finalize the derivatives.
   virtual
@@ -89,7 +100,7 @@ public:
                            const Scalar dt,
                            const DataBase<Dimension>& dataBase,
                            const State<Dimension>& state,
-                           StateDerivatives<Dimension>& derivs) const;
+                           StateDerivatives<Dimension>& derivs) const override;
 
   // Finalize the hydro at the completion of an integration step.
   virtual
@@ -97,17 +108,17 @@ public:
                 const Scalar dt,
                 DataBase<Dimension>& dataBase,
                 State<Dimension>& state,
-                StateDerivatives<Dimension>& derivs);
+                StateDerivatives<Dimension>& derivs) override;
                
   // Apply boundary conditions to the physics specific fields.
   virtual
   void applyGhostBoundaries(State<Dimension>& state,
-                            StateDerivatives<Dimension>& derivs);
+                            StateDerivatives<Dimension>& derivs) override;
 
   // Enforce boundary conditions for the physics specific fields.
   virtual
   void enforceBoundaries(State<Dimension>& state,
-                         StateDerivatives<Dimension>& derivs);
+                         StateDerivatives<Dimension>& derivs) override;
 
   // Flag to choose whether we want to sum for density, or integrate
   // the continuity equation.

--- a/src/SimulationControl/SpheralController.py
+++ b/src/SimulationControl/SpheralController.py
@@ -216,6 +216,8 @@ class SpheralController:
             package.initializeProblemStartup(db)
         state = eval("State%s(db, packages)" % (self.dim))
         derivs = eval("StateDerivatives%s(db, packages)" % (self.dim))
+        for package in packages:
+            package.initializeProblemStartupDependencies(db, state, derivs)
         db.reinitializeNeighbors()
         self.integrator.setGhostNodes()
         db.updateConnectivityMap(False)


### PR DESCRIPTION
# Summary

- This PR is a bugfix (via an interface improvement)
- It does the following:
  - We have added a new optional initialization method for Physics packages: 
       Physics::initializeProblemStartupDependencies.
  - This optional hook is called once after Physics::initializeProblemStartup.
  - initializeProblemStartupDependencies is called with fully constructed State and StateDerivative objects, unlike initializeProblemStartup which is only called with a DataBase.
  - initializeProblemStartupDependencies is intended to be used to properly initialize dependent state (such as pressures and temperatures), which may depend on multiple physics packages and be non-trivial to update.
  - This corrects a bug whereby the ConstantBoundary could take a snapshot of incorrect initial state, freezing that incorrect state for all times thereafter.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [x] LLNLSpheral PR has passed all tests.

