### PR TITLE
Adding Taylor-anvil to standard integration tests

### DIFF
--- a/src/CRKSPH/CRKSPHHydros.py
+++ b/src/CRKSPH/CRKSPHHydros.py
@@ -86,13 +86,16 @@ def CRKSPH(dataBase,
     if nsolid > 0:
         kwargs.update({"damageRelieveRubble" : damageRelieveRubble})
 
-    if GeometryRegistrar.coords() == CoordinateType.RZ:
-        kwargs.update({"etaMinAxis" : etaMinAxis})
-
     # Build the thing.
     result = constructor(**kwargs)
     result.Q = Q
     result._smoothingScaleMethod = smoothingScaleMethod
+
+    # If we're using area-weighted RZ, we need to reflect from the axis
+    if GeometryRegistrar.coords() == CoordinateType.RZ:
+        result.zaxisBC = AxisBoundaryRZ(etaMinAxis)
+        result.appendBoundary(result.zaxisBC)
+
     return result
 
 #-------------------------------------------------------------------------------

--- a/tests/functional/Strength/TaylorImpact/TaylorImpact.py
+++ b/tests/functional/Strength/TaylorImpact/TaylorImpact.py
@@ -47,8 +47,6 @@ import mpi
 
 from Spheral import *
 from SpheralTestUtilities import *
-from SpheralGnuPlotUtilities import *
-from SpheralController import *
 
 #-------------------------------------------------------------------------------
 # Identify ourselves!

--- a/tests/functional/Strength/TaylorImpact/TaylorImpact.py
+++ b/tests/functional/Strength/TaylorImpact/TaylorImpact.py
@@ -82,7 +82,7 @@ commandLine(geometry = "2d",         # one of (2d, 3d, RZ)
             fsisph = False,
 
             # general hydro options
-            asph = False,                         # Only for H evolution, not hydro algorithm
+            asph = True,                         # Only for H evolution, not hydro algorithm
             HUpdate = IdealH,
             densityUpdate = IntegrateDensity,
             compatibleEnergy = True,

--- a/tests/integration.ats
+++ b/tests/integration.ats
@@ -92,6 +92,7 @@ source("functional/Gravity/ApproximatePolyhedralGravityModel.py")
 
 # Strength tests.
 #source("functional/Strength/PlateImpact/PlateImpact-1d.py")
+source("functional/Strength/TaylorImpact/TaylorImpact.py")
 source("functional/Strength/CollidingPlates/CollidingPlates-1d.py")
 source("functional/Strength/DiametralCompression/DiametralCompression.py")
 source("functional/Strength/Verney/Verney-spherical.py")


### PR DESCRIPTION
# Summary

- This PR is part bugfix, part testing addition
- It does the following:
  - The CRKSPH frontend was using an outdated option for RZ geometry, which needed to be removed
  - Updates the Taylor-anvil test case, and adds it to our standard integration test suite

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [x] LLNLSpheral PR has passed all tests.

