### PR TITLE
Gitlab CI cleanup strategy

### DIFF
--- a/.gitlab/jobs-mpi.yml
+++ b/.gitlab/jobs-mpi.yml
@@ -8,6 +8,10 @@ toss_gcc_mvapich2_cxxonly_build:
   extends: [.toss_resource1, .gcc_mvapich2_cxxonly, .build]
   needs: [toss_gcc_mvapich2_cxxonly_tpls]
 
+toss_gcc_mvapich2_cxxonly_cleanup:
+  extends: [.toss_resource1, .gcc_mvapich2_cxxonly, .cleanup_dir]
+  needs: [toss_gcc_mvapich2_cxxonly_build]
+
 
 
 toss_gcc_mvapich2_tpls:
@@ -21,6 +25,10 @@ toss_gcc_mvapich2_test:
   extends: [.toss_resource2, .gcc_mvapich2, .run_ats]
   needs: [toss_gcc_mvapich2_build]
 
+toss_gcc_mvapich2_cleanup:
+  extends: [.toss_resource2, .gcc_mvapich2, .cleanup_dir]
+  needs: [toss_gcc_mvapich2_test]
+
 
 
 toss_clang_mvapich2_tpls:
@@ -33,6 +41,10 @@ toss_clang_mvapich2_build:
 toss_clang_mvapich2_test:
   extends: [.toss_resource2, .clang_mvapich2, .run_ats]
   needs: [toss_clang_mvapich2_build]
+
+toss_clang_mvapich2_cleanup:
+  extends: [.toss_resource2, .clang_mvapich2, .cleanup_dir]
+  needs: [toss_clang_mvapich2_test]
 
 
 
@@ -52,6 +64,10 @@ blueos_gcc_spectrum_test:
   extends: [.blueos_resource1, .gcc_spectrum, .run_ats]
   needs: [blueos_gcc_spectrum_build]
 
+blueos_gcc_spectrum_cleanup:
+  extends: [.blueos_resource1, .gcc_spectrum, .cleanup_dir]
+  needs: [blueos_gcc_spectrum_test]
+
 
 
 blueos_cuda_11_gcc_spectrum_tpls:
@@ -65,6 +81,10 @@ blueos_cuda_11_gcc_spectrum_test:
   extends: [.blueos_resource2, .cuda_11_gcc_spectrum, .run_ats]
   needs: [blueos_cuda_11_gcc_spectrum_build]
   allow_failure: true
+
+blueos_cuda_11_gcc_spectrum_cleanup:
+  extends: [.blueos_resource2, .cuda_11_gcc_spectrum, .cleanup_dir]
+  needs: [blueos_cuda_11_gcc_spectrum_test]
 
 
 

--- a/.gitlab/jobs-prod.yml
+++ b/.gitlab/jobs-prod.yml
@@ -34,6 +34,9 @@ toss_release_permissions:
 # ------------------------------------------------------------------------------
 # CLEAN OLD BUILD DIRS
 
-cleanup_build_dirs:
-  extends: [.clean_dirs]
+cleanup_old_dirs_toss:
+  extends: [.toss_resource_general, .clean_old_dirs]
+
+cleanup_old_dirs_blueos:
+  extends: [.blueos_resource_general, .clean_old_dirs]
 

--- a/.gitlab/jobs-seq.yml
+++ b/.gitlab/jobs-seq.yml
@@ -12,6 +12,10 @@ toss_gcc_~mpi_test:
   extends: [.gcc_~mpi, .run_ats, .toss_resource1]
   needs: [toss_gcc_~mpi_build]
 
+toss_gcc_~mpi_cleanup:
+  extends: [.gcc_~mpi, .cleanup_dir, .toss_resource1]
+  needs: [toss_gcc_~mpi_test]
+
 
 blueos_cuda_11_gcc_~mpi_tpls:
   extends: [.blueos_resource2, .cuda_11_gcc_~mpi, .tpls]
@@ -24,6 +28,10 @@ blueos_cuda_11_gcc_~mpi_test:
   extends: [.blueos_resource2, .cuda_11_gcc_~mpi, .run_ats]
   needs: [blueos_cuda_11_gcc_~mpi_build]
 
+blueos_cuda_11_gcc_~mpi_cleanup:
+  extends: [.blueos_resource2, .cuda_11_gcc_~mpi, .cleanup_dir]
+  needs: [blueos_cuda_11_gcc_~mpi_test]
+
 
 blueos_gcc_~mpi_Debug_tpls:
   extends: [.blueos_resource1, .gcc_~mpi_Debug, .tpls]
@@ -35,3 +43,7 @@ blueos_gcc_~mpi_Debug_build:
 blueos_gcc_~mpi_Debug_test:
   extends: [.blueos_resource1, .gcc_~mpi_Debug, .run_ats]
   needs: [blueos_gcc_~mpi_Debug_build]
+
+blueos_gcc_~mpi_Debug_cleanup:
+  extends: [.blueos_resource1, .gcc_~mpi_Debug, .cleanup_dir]
+  needs: [blueos_gcc_~mpi_Debug_test]

--- a/.gitlab/machines.yml
+++ b/.gitlab/machines.yml
@@ -10,6 +10,7 @@
     PARTITION: pdebug
     BUILD_ALLOC: srun -N 1 -c 36 -p pdebug -t 60
     TEST_ALLOC: ''
+    CLEAN_ALLOC: srun -n 20
   extends: [.on_toss_4_x86]
 
 .on_lassen:
@@ -20,6 +21,7 @@
     HOSTNAME: 'lassen'
     BUILD_ALLOC: lalloc 1 -W 60
     TEST_ALLOC: $BUILD_ALLOC
+    CLEAN_ALLOC: lalloc 1 lrun -n 20
     LC_MODULES: "cuda/11.1.0"
   extends: [.on_blueos_3_ppc64]
 

--- a/.gitlab/os.yml
+++ b/.gitlab/os.yml
@@ -12,6 +12,7 @@
     ARCH: 'toss_3_x86_64_ib'
     GCC_VERSION: '8.3.1'
     CLANG_VERSION: '9.0.0'
+    SPHERAL_BUILDS_DIR: /p/lustre1/sphapp/spheral-ci-builds
   extends: [.sys_config]
 
 .on_toss_4_x86:
@@ -19,6 +20,7 @@
     ARCH: 'toss_4_x86_64_ib'
     GCC_VERSION: '10.3.1'
     CLANG_VERSION: '14.0.6'
+    SPHERAL_BUILDS_DIR: /p/lustre1/sphapp/spheral-ci-builds
   extends: [.sys_config]
 
 .on_blueos_3_ppc64:
@@ -26,5 +28,6 @@
     ARCH: 'blueos_3_ppc64le_ib_p9'
     GCC_VERSION: '8.3.1'
     CLANG_VERSION: '9.0.0'
+    SPHERAL_BUILDS_DIR: /p/gpfs1/sphapp/spheral-ci-builds
   extends: [.sys_config]
 

--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -6,6 +6,7 @@
 .tpls:
   stage: tpls
   script:
+    - echo $USER
     - CI_BUILD_DIR=$SPHERAL_BUILDS_DIR/$CI_JOB_ID/project
     - echo $CI_BUILD_DIR &> ci-dir.txt && echo $CI_JOB_NAME &> job-name.txt
     - echo $CI_BUILD_DIR && echo $CI_PROJECT_DIR
@@ -61,6 +62,17 @@
   allow_failure:
     exit_codes:
       - 80
+
+.cleanup_dir:
+  stage: cleanup
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - CI_BUILD_DIR=$(cat ci-dir.txt)
+
+    - ml load mpifileutils
+    - cd $SPHERAL_BUILDS_DIR
+    - $CLEAN_ALLOC drm $CI_BUILD_DIR/..
 
 # ------------------------------------------------------------------------------
 # Shared TPL scripts.
@@ -153,15 +165,19 @@
 # This job searches our SPHERAL_BUILDS_DIR and deletes all but the N most recent builds.
 # This should be enough of a buffer that we likely won't delete a build mid pipeline,
 # and never fill the sphapp workspace storage.
-.clean_dirs:
+.clean_old_dirs:
   stage: cleanup
   variables:
     GIT_STRATEGY: none
   script:
-    - ml load mpifileutils
     - cd $SPHERAL_BUILDS_DIR
-    - source $CI_PROJECT_DIR/$SCRIPT_DIR/gitlab/clean_spheral_builds.sh 40
-  extends: [.toss_resource_general]
+
+    - MAX_DIR=30
+    - DIR_LIST=$(ls -ltd * | sed "1, $MAX_DIR d" | rev | cut -d ' ' -f1 | rev | paste -sd ' ' - )
+    - echo $DIR_LIST
+
+    - ml load mpifileutils
+    - if [[ $DIR_LIST ]]; then $CLEAN_ALLOC drm $DIR_LIST; else echo "No directories to remove at this time."; fi
   when: always
 
 .merge_pr_rule:


### PR DESCRIPTION
# Summary

- This PR is a bugfix / refactor.
- Our workspace for the CI user has been frequently running out of space. This PR alters the current cleanup strategy to immediately delete passing pipeline directories.
  - Failed pipeline jobs will not be immediately deleted. However, at the end of every pipeline a job `cleanup_old_<OS>` will run keeping only the 30 most recent build pipelines for a given OS. (This should give us enough buffer room to be able to re-run fairly recent failed tests still)
  - Pipelines will be run under `lustre` and `gpfs` as opposed to `WS2` directories.
------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

