### PR TITLE
exposing DEM variable to python

### DIFF
--- a/src/PYB11/DEM/LinearSpringDEM.py
+++ b/src/PYB11/DEM/LinearSpringDEM.py
@@ -88,3 +88,5 @@ class LinearSpringDEM(DEMBase):
     collisionDuration = PYB11property("Scalar", "collisionDuration", "collisionDuration", doc="duration of a contact")
 
     momentOfInertia = PYB11property("const FieldList<%(Dimension)s, Scalar>&","momentOfInertia", returnpolicy="reference_internal")
+    maximumOverlap = PYB11property("const FieldList<%(Dimension)s, Scalar>&","maximumOverlap", returnpolicy="reference_internal")
+    newMaximumOverlap = PYB11property("const FieldList<%(Dimension)s, Scalar>&","newMaximumOverlap", returnpolicy="reference_internal")


### PR DESCRIPTION
# Summary

- This PR is a bug fix
- It does the following:
  - LinearSpringDEM variable maxOverlap wasn't implemented in PYB11 

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

