### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/src/DEM/LinearSpringDEM.hh
+++ b/src/DEM/LinearSpringDEM.hh
@@ -174,8 +174,8 @@ public:
   //****************************************************************************
   // Methods required for restarting.
   virtual std::string label() const override { return "LinearSpringDEM" ; }
-  virtual void dumpState(FileIO& file, const std::string& pathName) const;
-  virtual void restoreState(const FileIO& file, const std::string& pathName);
+  virtual void dumpState(FileIO& file, const std::string& pathName) const override;
+  virtual void restoreState(const FileIO& file, const std::string& pathName) override;
   //****************************************************************************
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/DEM/SolidBoundary/CircularPlaneSolidBoundary.hh
+++ b/src/DEM/SolidBoundary/CircularPlaneSolidBoundary.hh
@@ -53,7 +53,7 @@ public:
   const Vector& velocity() const;
   void velocity(const Vector& value);
 
-  virtual std::string label() const { return "CircularPlaneSolidBoundary" ; }
+  virtual std::string label() const override { return "CircularPlaneSolidBoundary" ; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const override;
   virtual void restoreState(const FileIO& file, const std::string& pathName) override;
 

--- a/src/DEM/SolidBoundary/ClippedSphereSolidBoundary.hh
+++ b/src/DEM/SolidBoundary/ClippedSphereSolidBoundary.hh
@@ -60,7 +60,7 @@ public:
 
   void setClipIntersectionRadius();
 
-  virtual std::string label() const { return "ClippedSphereSolidBoundary" ; }
+  virtual std::string label() const override { return "ClippedSphereSolidBoundary" ; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const override;
   virtual void restoreState(const FileIO& file, const std::string& pathName) override;
 protected:

--- a/src/DEM/SolidBoundary/CylinderSolidBoundary.hh
+++ b/src/DEM/SolidBoundary/CylinderSolidBoundary.hh
@@ -57,7 +57,7 @@ public:
   const Vector& velocity() const;
   void velocity(const Vector& value);
 
-  virtual std::string label() const { return "CylinderSolidBoundary" ; }
+  virtual std::string label() const override { return "CylinderSolidBoundary" ; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const override;
   virtual void restoreState(const FileIO& file, const std::string& pathName) override;
 

--- a/src/DEM/SolidBoundary/InfinitePlaneSolidBoundary.hh
+++ b/src/DEM/SolidBoundary/InfinitePlaneSolidBoundary.hh
@@ -48,7 +48,7 @@ public:
   const Vector& velocity() const;
   void velocity(const Vector& value);
 
-  virtual std::string label() const { return "InfinitePlaneSolidBoundary" ; }
+  virtual std::string label() const override { return "InfinitePlaneSolidBoundary" ; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const override;
   virtual void restoreState(const FileIO& file, const std::string& pathName) override;
 

--- a/src/DEM/SolidBoundary/RectangularPlaneSolidBoundary.hh
+++ b/src/DEM/SolidBoundary/RectangularPlaneSolidBoundary.hh
@@ -54,7 +54,7 @@ public:
   const Vector& velocity() const;
   void velocity(const Vector& value);
 
-  virtual std::string label() const { return "RectangularPlaneSolidBoundary" ; }
+  virtual std::string label() const override { return "RectangularPlaneSolidBoundary" ; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const override;
   virtual void restoreState(const FileIO& file, const std::string& pathName) override;
 

--- a/src/DEM/SolidBoundary/SphereSolidBoundary.hh
+++ b/src/DEM/SolidBoundary/SphereSolidBoundary.hh
@@ -54,7 +54,7 @@ public:
   const RotationType& angularVelocity() const;
   void angularVelocity(const RotationType& value);
 
-  virtual std::string label() const { return "SphereSolidBoundary" ; }
+  virtual std::string label() const override { return "SphereSolidBoundary" ; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const override;
   virtual void restoreState(const FileIO& file, const std::string& pathName) override;
 

--- a/src/ExternalForce/PointPotential.hh
+++ b/src/ExternalForce/PointPotential.hh
@@ -101,7 +101,7 @@ public:
 
   //****************************************************************************
   // Methods required for restarting.
-  virtual std::string label() const { return "PointPotential"; }
+  virtual std::string label() const override { return "PointPotential"; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const;
   virtual void restoreState(const FileIO& file, const std::string& pathName);
   //****************************************************************************

--- a/src/Field/Field.hh
+++ b/src/Field/Field.hh
@@ -12,7 +12,7 @@
 #define __Spheral_Field_hh__
 
 #include "FieldBase.hh"
-#include "axom/sidre.hpp"
+#include "axom/sidre/core/SidreTypes.hpp"
 
 #include <vector>
 

--- a/src/Field/Field.hh
+++ b/src/Field/Field.hh
@@ -12,7 +12,7 @@
 #define __Spheral_Field_hh__
 
 #include "FieldBase.hh"
-#include "axom/sidre/core/SidreTypes.hpp"
+#include "axom/sidre.hpp"
 
 #include <vector>
 

--- a/src/FileIO/SidreFileIO.cc
+++ b/src/FileIO/SidreFileIO.cc
@@ -4,7 +4,8 @@
 // Created by Mikhail Zakharchanka, 11/4/2021
 //----------------------------------------------------------------------------//
 #include "SidreFileIO.hh"
-#include "axom/core/Path.hpp"
+
+#include "axom/sidre.hpp"
 
 namespace Spheral
 {

--- a/src/FileIO/SidreFileIO.hh
+++ b/src/FileIO/SidreFileIO.hh
@@ -10,6 +10,14 @@
 
 #include <vector>
 
+// Forward declarations
+namespace axom {
+  namespace sidre {
+    class DataStore;
+    class Group;
+  }
+}
+
 namespace Spheral
 {
 

--- a/src/Geometry/GeomPolyhedron.cc
+++ b/src/Geometry/GeomPolyhedron.cc
@@ -17,9 +17,7 @@
 #include "Utilities/pointInPolyhedron.hh"
 #include "Utilities/safeInv.hh"
 
-#include "axom/mint/mesh/CellTypes.hpp"
-#include "axom/mint/mesh/UnstructuredMesh.hpp"
-#include "axom/mint/utils/vtk_utils.hpp"
+#include "axom/mint.hpp"
 
 #include <algorithm>
 #include <iterator>

--- a/src/Geometry/GeomPolyhedron.cc
+++ b/src/Geometry/GeomPolyhedron.cc
@@ -17,7 +17,9 @@
 #include "Utilities/pointInPolyhedron.hh"
 #include "Utilities/safeInv.hh"
 
-#include "axom/mint.hpp"
+#include "axom/mint/mesh/CellTypes.hpp"
+#include "axom/mint/mesh/UnstructuredMesh.hpp"
+#include "axom/mint/utils/vtk_utils.hpp"
 
 #include <algorithm>
 #include <iterator>

--- a/src/Geometry/GeomPolyhedron.cc
+++ b/src/Geometry/GeomPolyhedron.cc
@@ -17,9 +17,14 @@
 #include "Utilities/pointInPolyhedron.hh"
 #include "Utilities/safeInv.hh"
 
-#include <vector>
-#include <map>
+#include "axom/mint.hpp"
+
 #include <algorithm>
+#include <iterator>
+#include <limits>
+#include <map>
+#include <vector>
+
 using std::vector;
 using std::map;
 using std::pair;
@@ -34,12 +39,6 @@ extern "C" {
 }
 
 #include "Utilities/Timer.hh"
-
-#include <algorithm>
-#include <numeric>
-#include <map>
-#include <limits>
-#include <iterator>
 
 namespace Spheral {
 

--- a/src/Geometry/GeomPolyhedron.hh
+++ b/src/Geometry/GeomPolyhedron.hh
@@ -12,8 +12,7 @@
 #include "GeomTensor.hh"
 #include "GeomFacet3d.hh"
 
-#include "axom/quest/InOutOctree.hpp"
-#include "axom/quest/SignedDistance.hpp"
+#include "axom/quest.hpp"
 
 #include <vector>
 #include <utility>

--- a/src/Geometry/GeomPolyhedron.hh
+++ b/src/Geometry/GeomPolyhedron.hh
@@ -12,13 +12,10 @@
 #include "GeomTensor.hh"
 #include "GeomFacet3d.hh"
 
-#include "axom/config.hpp"                          // compile time definitions
-#include "axom/core.hpp"                            // for execution_space traits
-#include "axom/mint.hpp"                            // for mint classes and functions
-#include "axom/quest.hpp"                           // axom surface queries (containment)
+#include "axom/quest.hpp"
 
 #include <vector>
-#include <memory>
+#include <utility>
 
 namespace Spheral {
 

--- a/src/Geometry/GeomPolyhedron.hh
+++ b/src/Geometry/GeomPolyhedron.hh
@@ -12,7 +12,8 @@
 #include "GeomTensor.hh"
 #include "GeomFacet3d.hh"
 
-#include "axom/quest.hpp"
+#include "axom/quest/InOutOctree.hpp"
+#include "axom/quest/SignedDistance.hpp"
 
 #include <vector>
 #include <utility>

--- a/src/Gravity/PolyGravity.hh
+++ b/src/Gravity/PolyGravity.hh
@@ -53,7 +53,7 @@ public:
 
   //! We augment the generic body force state.
   virtual void registerState(DataBase<Dimension>& dataBase,
-                             State<Dimension>& state);
+                             State<Dimension>& state) override;
 
   //! This is the derivative method that all BodyForce classes must provide.
   virtual 
@@ -61,13 +61,13 @@ public:
                            const Scalar /*dt*/,
                            const DataBase<Dimension>& dataBase,
                            const State<Dimension>& state,
-                           StateDerivatives<Dimension>& derivs) const;
+                           StateDerivatives<Dimension>& derivs) const override;
 
   //! Vote on the timestep.  This uses a velocity-limiting rule.
   virtual TimeStepType dt(const DataBase<Dimension>& /*dataBase*/, 
                           const State<Dimension>& state,
                           const StateDerivatives<Dimension>& /*derivs*/,
-                          const Scalar /*currentTime*/) const;
+                          const Scalar /*currentTime*/) const override;
 
   // An optional hook to initialize once when the problem is starting up.
   // Typically this is used to size arrays once all the materials and NodeLists have
@@ -84,10 +84,10 @@ public:
                                                     StateDerivatives<Dimension>& derivs) override;
 
   //! This package opts out of building connectivity.
-  virtual bool requireConnectivity() const { return false; }
+  virtual bool requireConnectivity() const override { return false; }
 
   //! Return the total energy contribution due to the gravitational potential.
-  virtual Scalar extraEnergy() const;
+  virtual Scalar extraEnergy() const override;
 
   //! Return the gravitational potential created by the particle distribution.
   const FieldList<Dimension, Scalar>& potential() const;
@@ -117,7 +117,7 @@ public:
 
   //****************************************************************************
   // Methods required for restarting.
-  virtual std::string label() const { return "PolyGravity"; }
+  virtual std::string label() const override { return "PolyGravity"; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const;
   virtual void restoreState(const FileIO& file, const std::string& pathName);
   //****************************************************************************

--- a/src/Gravity/TreeGravity.hh
+++ b/src/Gravity/TreeGravity.hh
@@ -54,7 +54,7 @@ public:
 
   //! We augment the generic body force state.
   virtual void registerState(DataBase<Dimension>& dataBase,
-                             State<Dimension>& state);
+                             State<Dimension>& state) override;
 
   //! This is the derivative method that all BodyForce classes must provide.
   virtual 
@@ -62,13 +62,13 @@ public:
                            const Scalar /*dt*/,
                            const DataBase<Dimension>& dataBase,
                            const State<Dimension>& state,
-                           StateDerivatives<Dimension>& derivs) const;
+                           StateDerivatives<Dimension>& derivs) const override;
 
   //! Vote on the timestep.  This uses a velocity-limiting rule.
   virtual TimeStepType dt(const DataBase<Dimension>& /*dataBase*/, 
                           const State<Dimension>& state,
                           const StateDerivatives<Dimension>& /*derivs*/,
-                          const Scalar /*currentTime*/) const;
+                          const Scalar /*currentTime*/) const override;
 
   // An optional hook to initialize once when the problem is starting up.
   // Typically this is used to size arrays once all the materials and NodeLists have
@@ -89,13 +89,13 @@ public:
                           const Scalar /*dt*/,
                           const DataBase<Dimension>& dataBase,
                           State<Dimension>& state,
-                          StateDerivatives<Dimension>& /*derivs*/);
+                          StateDerivatives<Dimension>& /*derivs*/) override;
                        
   //! This package opts out of building connectivity.
-  virtual bool requireConnectivity() const { return false; }
+  virtual bool requireConnectivity() const override { return false; }
 
   //! Return the total energy contribution due to the gravitational potential.
-  virtual Scalar extraEnergy() const;
+  virtual Scalar extraEnergy() const override;
 
   //! Return the gravitational potential created by the particle distribution.
   const FieldList<Dimension, Scalar>& potential() const;
@@ -133,7 +133,7 @@ public:
 
   //****************************************************************************
   // Methods required for restarting.
-  virtual std::string label() const { return "TreeGravity"; }
+  virtual std::string label() const override { return "TreeGravity"; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const;
   virtual void restoreState(const FileIO& file, const std::string& pathName);
   //****************************************************************************

--- a/src/Material/HelmholtzEquationOfState.hh
+++ b/src/Material/HelmholtzEquationOfState.hh
@@ -39,7 +39,7 @@ public:
   // We require any equation of state to define the following properties.
   virtual void setPressure(Field<Dimension, Scalar>& Pressure,
                            const Field<Dimension, Scalar>& massDensity,
-                           const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                           const Field<Dimension, Scalar>& specificThermalEnergy) const override;
           
   virtual void setPressureAndDerivs(Field<Dimension, Scalar>& Pressure,           // set pressure
                                     Field<Dimension, Scalar>& dPdu,               // set (\partial P)/(\partial u) (specific thermal energy)
@@ -49,31 +49,31 @@ public:
 
   virtual void setTemperature(Field<Dimension, Scalar>& temperature,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
           
   virtual void setSpecificThermalEnergy(Field<Dimension, Scalar>& specificThermalEnergy,
                                         const Field<Dimension, Scalar>& massDensity,
-                                        const Field<Dimension, Scalar>& temperature) const;
+                                        const Field<Dimension, Scalar>& temperature) const override;
           
   virtual void setSpecificHeat(Field<Dimension, Scalar>& specificHeat,
                                const Field<Dimension, Scalar>& massDensity,
-                               const Field<Dimension, Scalar>& temperature) const;
+                               const Field<Dimension, Scalar>& temperature) const override;
           
   virtual void setSoundSpeed(Field<Dimension, Scalar>& soundSpeed,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
           
   virtual void setGammaField(Field<Dimension, Scalar>& gamma,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
                       
   virtual void setBulkModulus(Field<Dimension, Scalar>& bulkModulus,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
           
   virtual void setEntropy(Field<Dimension, Scalar>& entropy,
                           const Field<Dimension, Scalar>& massDensity,
-                          const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                          const Field<Dimension, Scalar>& specificThermalEnergy) const override;
           
   // Some of the following methods are disabled
   virtual Scalar pressure(const Scalar /*massDensity*/,
@@ -109,7 +109,7 @@ public:
   bool getUpdateStatus() const;
   void setUpdateStatus(bool bSet);
           
-  virtual bool valid() const;
+  virtual bool valid() const override;
           
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/Material/IsothermalEquationOfState.hh
+++ b/src/Material/IsothermalEquationOfState.hh
@@ -33,7 +33,7 @@ public:
   // We require any equation of state to define the following properties.
   virtual void setPressure(Field<Dimension, Scalar>& Pressure,
                            const Field<Dimension, Scalar>& massDensity,
-                           const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                           const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setPressureAndDerivs(Field<Dimension, Scalar>& Pressure,           // set pressure
                                     Field<Dimension, Scalar>& dPdu,               // set (\partial P)/(\partial u) (specific thermal energy)
@@ -43,31 +43,31 @@ public:
 
   virtual void setTemperature(Field<Dimension, Scalar>& temperature,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setSpecificThermalEnergy(Field<Dimension, Scalar>& specificThermalEnergy,
                                         const Field<Dimension, Scalar>& massDensity,
-                                        const Field<Dimension, Scalar>& temperature) const;
+                                        const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSpecificHeat(Field<Dimension, Scalar>& specificHeat,
                                const Field<Dimension, Scalar>& massDensity,
-                               const Field<Dimension, Scalar>& temperature) const;
+                               const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSoundSpeed(Field<Dimension, Scalar>& soundSpeed,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setGammaField(Field<Dimension, Scalar>& gamma,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setBulkModulus(Field<Dimension, Scalar>& bulkModulus,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setEntropy(Field<Dimension, Scalar>& entropy,
                           const Field<Dimension, Scalar>& massDensity,
-                          const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                          const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   // We also want the equivalent functions for individual calculations.
   Scalar pressure(const Scalar massDensity,
@@ -96,9 +96,9 @@ public:
 
   // Access the member data.
   Scalar K() const;
-  virtual Scalar molecularWeight() const;
+  virtual Scalar molecularWeight() const override;
   
-  virtual bool valid() const;
+  virtual bool valid() const override;
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/Material/PolytropicEquationOfState.hh
+++ b/src/Material/PolytropicEquationOfState.hh
@@ -34,7 +34,7 @@ public:
   // We require any equation of state to define the following properties.
   virtual void setPressure(Field<Dimension, Scalar>& Pressure,
                            const Field<Dimension, Scalar>& massDensity,
-                           const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                           const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setPressureAndDerivs(Field<Dimension, Scalar>& Pressure,           // set pressure
                                     Field<Dimension, Scalar>& dPdu,               // set (\partial P)/(\partial u) (specific thermal energy)
@@ -44,31 +44,31 @@ public:
 
   virtual void setTemperature(Field<Dimension, Scalar>& temperature,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setSpecificThermalEnergy(Field<Dimension, Scalar>& specificThermalEnergy,
                                         const Field<Dimension, Scalar>& massDensity,
-                                        const Field<Dimension, Scalar>& temperature) const;
+                                        const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSpecificHeat(Field<Dimension, Scalar>& specificHeat,
                                const Field<Dimension, Scalar>& massDensity,
-                               const Field<Dimension, Scalar>& temperature) const;
+                               const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSoundSpeed(Field<Dimension, Scalar>& soundSpeed,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setGammaField(Field<Dimension, Scalar>& gamma,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setBulkModulus(Field<Dimension, Scalar>& bulkModulus,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setEntropy(Field<Dimension, Scalar>& entropy,
                           const Field<Dimension, Scalar>& massDensity,
-                          const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                          const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   // We also want the equivalent functions for individual calculations.
   Scalar pressure(const Scalar massDensity,
@@ -99,9 +99,9 @@ public:
   Scalar polytropicConstant() const;
   Scalar polytropicIndex() const;
   Scalar gamma() const;
-  virtual Scalar molecularWeight() const;
+  virtual Scalar molecularWeight() const override;
   
-  virtual bool valid() const;
+  virtual bool valid() const override;
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/Porosity/PorosityModel.hh
+++ b/src/Porosity/PorosityModel.hh
@@ -58,7 +58,7 @@ public:
 
   // Register the derivatives/change fields for updating state.
   virtual void registerDerivatives(DataBase<Dimension>& dataBase,
-                                   StateDerivatives<Dimension>& derivs);
+                                   StateDerivatives<Dimension>& derivs) override;
 
   // Do any required one-time initializations on problem start up.
   virtual void initializeProblemStartup(DataBase<Dimension>& dataBase) override;

--- a/src/RK/HVolumePolicy.hh
+++ b/src/RK/HVolumePolicy.hh
@@ -43,7 +43,7 @@ public:
                                  const double /*dt*/) override {}
 
   // Equivalence.
-  virtual bool operator==(const UpdatePolicyBase<Dimension>& rhs) const;
+  virtual bool operator==(const UpdatePolicyBase<Dimension>& rhs) const override;
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/SVPH/CompatibleFaceSpecificThermalEnergyPolicy.hh
+++ b/src/SVPH/CompatibleFaceSpecificThermalEnergyPolicy.hh
@@ -51,7 +51,7 @@ public:
                       const double dt) override;
 
   // Equivalence.
-  virtual bool operator==(const UpdatePolicyBase<Dimension>& rhs) const;
+  virtual bool operator==(const UpdatePolicyBase<Dimension>& rhs) const override;
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/SVPH/SVPHFacetedHydroBase.hh
+++ b/src/SVPH/SVPHFacetedHydroBase.hh
@@ -201,7 +201,7 @@ public:
 
   //****************************************************************************
   // Methods required for restarting.
-  virtual std::string label() const { return "SVPHFacetedHydroBase"; }
+  virtual std::string label() const override { return "SVPHFacetedHydroBase"; }
   virtual void dumpState(FileIO& file, const std::string& pathName) const;
   virtual void restoreState(const FileIO& file, const std::string& pathName);
   //****************************************************************************

--- a/src/SolidMaterial/ANEOS.hh
+++ b/src/SolidMaterial/ANEOS.hh
@@ -53,7 +53,7 @@ public:
   // We require any equation of state to define the following properties.
   virtual void setPressure(Field<Dimension, Scalar>& Pressure,
                            const Field<Dimension, Scalar>& massDensity,
-                           const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                           const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setPressureAndDerivs(Field<Dimension, Scalar>& Pressure,           // set pressure
                                     Field<Dimension, Scalar>& dPdu,               // set (\partial P)/(\partial u) (specific thermal energy)
@@ -63,31 +63,31 @@ public:
 
   virtual void setTemperature(Field<Dimension, Scalar>& temperature,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setSpecificThermalEnergy(Field<Dimension, Scalar>& specificThermalEnergy,
                                         const Field<Dimension, Scalar>& massDensity,
-                                        const Field<Dimension, Scalar>& temperature) const;
+                                        const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSpecificHeat(Field<Dimension, Scalar>& specificHeat,
                                const Field<Dimension, Scalar>& massDensity,
-                               const Field<Dimension, Scalar>& temperature) const;
+                               const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSoundSpeed(Field<Dimension, Scalar>& soundSpeed,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setGammaField(Field<Dimension, Scalar>& gamma,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setBulkModulus(Field<Dimension, Scalar>& bulkModulus,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setEntropy(Field<Dimension, Scalar>& entropy,
                           const Field<Dimension, Scalar>& massDensity,
-                          const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                          const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   // We also want the equivalent functions for individual calculations.
   Scalar pressure(const Scalar massDensity,
@@ -120,7 +120,7 @@ public:
                  const Scalar specificThermalEnergy) const;
 
   // The valid method.
-  virtual bool valid() const;
+  virtual bool valid() const override;
 
   // Access local variables used to lookup eps based on T.
   int materialNumber() const;

--- a/src/SolidMaterial/GruneisenEquationOfState.hh
+++ b/src/SolidMaterial/GruneisenEquationOfState.hh
@@ -50,7 +50,7 @@ public:
   // We require any equation of state to define the following methods for Fields.
   virtual void setPressure(Field<Dimension, Scalar>& Pressure,
                            const Field<Dimension, Scalar>& massDensity,
-                           const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                           const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setPressureAndDerivs(Field<Dimension, Scalar>& Pressure,           // set pressure
                                     Field<Dimension, Scalar>& dPdu,               // set (\partial P)/(\partial u) (specific thermal energy)
@@ -60,31 +60,31 @@ public:
 
   virtual void setTemperature(Field<Dimension, Scalar>& temperature,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setSpecificThermalEnergy(Field<Dimension, Scalar>& specificThermalEnergy,
                                         const Field<Dimension, Scalar>& massDensity,
-                                        const Field<Dimension, Scalar>& temperature) const;
+                                        const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSpecificHeat(Field<Dimension, Scalar>& specificHeat,
                                const Field<Dimension, Scalar>& massDensity,
-                               const Field<Dimension, Scalar>& temperature) const;
+                               const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSoundSpeed(Field<Dimension, Scalar>& soundSpeed,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setGammaField(Field<Dimension, Scalar>& gamma,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setBulkModulus(Field<Dimension, Scalar>& bulkModulus,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setEntropy(Field<Dimension, Scalar>& entropy,
                           const Field<Dimension, Scalar>& massDensity,
-                          const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                          const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   // We also want the equivalent functions for individual calculations.
   std::tuple<Scalar, Scalar, Scalar> pressureAndDerivs(const Scalar massDensity,
@@ -139,7 +139,7 @@ public:
                        const Scalar specificThermalEnergy) const;
 
   // Equations of state should have a valid test.
-  virtual bool valid() const;
+  virtual bool valid() const override;
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/SolidMaterial/LinearPolynomialEquationOfState.hh
+++ b/src/SolidMaterial/LinearPolynomialEquationOfState.hh
@@ -53,7 +53,7 @@ public:
   // We require any equation of state to define the following properties.
   virtual void setPressure(Field<Dimension, Scalar>& Pressure,
                            const Field<Dimension, Scalar>& massDensity,
-                           const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                           const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setPressureAndDerivs(Field<Dimension, Scalar>& Pressure,           // set pressure
                                     Field<Dimension, Scalar>& dPdu,               // set (\partial P)/(\partial u) (specific thermal energy)
@@ -63,31 +63,31 @@ public:
 
   virtual void setTemperature(Field<Dimension, Scalar>& temperature,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setSpecificThermalEnergy(Field<Dimension, Scalar>& specificThermalEnergy,
                                         const Field<Dimension, Scalar>& massDensity,
-                                        const Field<Dimension, Scalar>& temperature) const;
+                                        const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSpecificHeat(Field<Dimension, Scalar>& specificHeat,
                                const Field<Dimension, Scalar>& massDensity,
-                               const Field<Dimension, Scalar>& temperature) const;
+                               const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSoundSpeed(Field<Dimension, Scalar>& soundSpeed,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setGammaField(Field<Dimension, Scalar>& gamma,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setBulkModulus(Field<Dimension, Scalar>& bulkModulus,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setEntropy(Field<Dimension, Scalar>& entropy,
                           const Field<Dimension, Scalar>& massDensity,
-                          const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                          const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   // We also want the equivalent functions for individual calculations.
   std::tuple<Scalar, Scalar, Scalar> pressureAndDerivs(const Scalar massDensity,
@@ -137,7 +137,7 @@ public:
   double computeDPDrho(const Scalar massDensity,
                        const Scalar specificThermalEnergy) const;
 
-  virtual bool valid() const;
+  virtual bool valid() const override;
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/SolidMaterial/MurnaghanEquationOfState.hh
+++ b/src/SolidMaterial/MurnaghanEquationOfState.hh
@@ -42,7 +42,7 @@ public:
   // We require any equation of state to define the following properties.
   virtual void setPressure(Field<Dimension, Scalar>& Pressure,
                            const Field<Dimension, Scalar>& massDensity,
-                           const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                           const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setPressureAndDerivs(Field<Dimension, Scalar>& Pressure,           // set pressure
                                     Field<Dimension, Scalar>& dPdu,               // set (\partial P)/(\partial u) (specific thermal energy)
@@ -52,31 +52,31 @@ public:
 
   virtual void setTemperature(Field<Dimension, Scalar>& temperature,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setSpecificThermalEnergy(Field<Dimension, Scalar>& specificThermalEnergy,
                                         const Field<Dimension, Scalar>& massDensity,
-                                        const Field<Dimension, Scalar>& temperature) const;
+                                        const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSpecificHeat(Field<Dimension, Scalar>& specificHeat,
                                const Field<Dimension, Scalar>& massDensity,
-                               const Field<Dimension, Scalar>& temperature) const;
+                               const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSoundSpeed(Field<Dimension, Scalar>& soundSpeed,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setGammaField(Field<Dimension, Scalar>& gamma,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setBulkModulus(Field<Dimension, Scalar>& bulkModulus,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setEntropy(Field<Dimension, Scalar>& entropy,
                           const Field<Dimension, Scalar>& massDensity,
-                          const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                          const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   // We also want the equivalent functions for individual calculations.
   Scalar pressure(const Scalar massDensity,
@@ -116,7 +116,7 @@ public:
   double computeDPDrho(const Scalar massDensity,
                        const Scalar specificThermalEnergy) const;
 
-  virtual bool valid() const;
+  virtual bool valid() const override;
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/SolidMaterial/OsborneEquationOfState.hh
+++ b/src/SolidMaterial/OsborneEquationOfState.hh
@@ -52,7 +52,7 @@ public:
   // We require any equation of state to define the following methods for Fields.
   virtual void setPressure(Field<Dimension, Scalar>& pressure,
                            const Field<Dimension, Scalar>& massDensity,
-                           const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                           const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setPressureAndDerivs(Field<Dimension, Scalar>& Pressure,           // set pressure
                                     Field<Dimension, Scalar>& dPdu,               // set (\partial P)/(\partial u) (specific thermal energy)
@@ -62,31 +62,31 @@ public:
 
   virtual void setTemperature(Field<Dimension, Scalar>& temperature,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setSpecificThermalEnergy(Field<Dimension, Scalar>& specificThermalEnergy,
                                         const Field<Dimension, Scalar>& massDensity,
-                                        const Field<Dimension, Scalar>& temperature) const;
+                                        const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSpecificHeat(Field<Dimension, Scalar>& specificHeat,
                                const Field<Dimension, Scalar>& massDensity,
-                               const Field<Dimension, Scalar>& temperature) const;
+                               const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSoundSpeed(Field<Dimension, Scalar>& soundSpeed,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setGammaField(Field<Dimension, Scalar>& gamma,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setBulkModulus(Field<Dimension, Scalar>& bulkModulus,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setEntropy(Field<Dimension, Scalar>& entropy,
                           const Field<Dimension, Scalar>& massDensity,
-                          const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                          const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   // Access the member data.
   double a1() const;
@@ -123,7 +123,7 @@ public:
                 const double specificThermalEnergy) const;
 
   // Equations of state should have a valid test.
-  virtual bool valid() const;
+  virtual bool valid() const override;
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/SolidMaterial/TillotsonEquationOfState.hh
+++ b/src/SolidMaterial/TillotsonEquationOfState.hh
@@ -65,31 +65,31 @@ public:
 
   virtual void setTemperature(Field<Dimension, Scalar>& temperature,
                               const Field<Dimension, Scalar>& massDensity,
-                              const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                              const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setSpecificThermalEnergy(Field<Dimension, Scalar>& specificThermalEnergy,
                                         const Field<Dimension, Scalar>& massDensity,
-                                        const Field<Dimension, Scalar>& temperature) const;
+                                        const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSpecificHeat(Field<Dimension, Scalar>& specificHeat,
                                const Field<Dimension, Scalar>& massDensity,
-                               const Field<Dimension, Scalar>& temperature) const;
+                               const Field<Dimension, Scalar>& temperature) const override;
 
   virtual void setSoundSpeed(Field<Dimension, Scalar>& soundSpeed,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setGammaField(Field<Dimension, Scalar>& gamma,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setBulkModulus(Field<Dimension, Scalar>& bulkModulus,
                              const Field<Dimension, Scalar>& massDensity,
-                             const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                             const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   virtual void setEntropy(Field<Dimension, Scalar>& entropy,
                           const Field<Dimension, Scalar>& massDensity,
-                          const Field<Dimension, Scalar>& specificThermalEnergy) const;
+                          const Field<Dimension, Scalar>& specificThermalEnergy) const override;
 
   // Access the member data.
   double etamin_solid() const;

--- a/src/Utilities/DataTypeTraits.hh
+++ b/src/Utilities/DataTypeTraits.hh
@@ -20,7 +20,7 @@
 #include "Utilities/DomainNode.hh"
 #include "RK/RKCorrectionParams.hh"
 #include "RK/RKCoefficients.hh"
-#include "axom/sidre.hpp"
+#include "axom/sidre/core/SidreTypes.hpp"
 #include "Utilities/uniform_random.hh"
 
 #ifdef USE_MPI

--- a/src/Utilities/DataTypeTraits.hh
+++ b/src/Utilities/DataTypeTraits.hh
@@ -20,7 +20,7 @@
 #include "Utilities/DomainNode.hh"
 #include "RK/RKCorrectionParams.hh"
 #include "RK/RKCoefficients.hh"
-#include "axom/sidre/core/SidreTypes.hpp"
+#include "axom/sidre.hpp"
 #include "Utilities/uniform_random.hh"
 
 #ifdef USE_MPI


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes clang compiler warnings about inconsistent use of the "override" keyword
  - Cleans up Axom includes

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes. (N/A)
- [x] Create LLNLSpheral PR pointing at this branch. (PR# https://rzlc.llnl.gov/gitlab/owen/LLNLSpheral/-/merge_requests/102)
- [x] LLNLSpheral PR has passed all tests.

