### PR TITLE
Reduce reinstall times

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -65,11 +65,6 @@ if (NOT ENABLE_CXXONLY)
     DESTINATION "${CMAKE_INSTALL_PREFIX}/scripts"
   )
 
-  install(FILES
-      "${CMAKE_CURRENT_BINARY_DIR}/performance/performance.py"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/tests"
-  )
-
   install(CODE "execute_process( \
     COMMAND env PYTHONPATH=${SPACK_PYTHONPATH} ${PYTHON_EXE} -m venv .venv --without-pip --prompt \
     'Spheral>')"

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,12 +1,12 @@
 if (NOT ENABLE_CXXONLY)
 
-  # We Use the spack generated build time python path to
+  # We use the spack generated build time python path to
   # pick up all of the python modules needed for our runtime.
-  # Some modules need to install from directories other that
-  # site-packages so we strip away site-packages pack and 
+  # Since some modules need to install from directories other than
+  # site-packages, we strip away site-packages and pack and
   # copy the full contents of the python library prefix to
   # our virtual env in spheral-setup-venv.sh
-  string(REGEX REPLACE "lib\/python3.9\/site-packages\/?[A-Za-z]*:" "* " VIRTUALENV_PYTHONPATH_COPY "${SPACK_PYTHONPATH}:")
+  string(REGEX REPLACE "lib\/python3.9\/site-packages\/?[A-Za-z]*:" ";" VIRTUALENV_PYTHONPATH_COPY "${SPACK_PYTHONPATH}:")
 
   set(SPHERAL_ATS_BUILD_CONFIG_ARGS )
 
@@ -35,7 +35,7 @@ if (NOT ENABLE_CXXONLY)
   endif()
 
   string(REPLACE ";" " " SPHERAL_ATS_BUILD_CONFIG_ARGS_STRING "${SPHERAL_ATS_BUILD_CONFIG_ARGS}")
-  
+
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/spheral-setup-venv.in"
     "${CMAKE_CURRENT_BINARY_DIR}/spheral-setup-venv.sh"
@@ -54,18 +54,41 @@ if (NOT ENABLE_CXXONLY)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/lcatstest.in"
     "${CMAKE_CURRENT_BINARY_DIR}/lcatstest.sh"
-    )
+  )
 
-  install(FILES 
+  install(FILES
       "${CMAKE_CURRENT_BINARY_DIR}/spheral-setup-venv.sh"
       "${CMAKE_CURRENT_BINARY_DIR}/spheral-env.sh"
       "${CMAKE_CURRENT_BINARY_DIR}/atstest.sh"
       "${CMAKE_CURRENT_BINARY_DIR}/lcatstest.sh"
       "${CMAKE_CURRENT_SOURCE_DIR}/lc/lcats"
     DESTINATION "${CMAKE_INSTALL_PREFIX}/scripts"
-    )
+  )
+
+  install(FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/performance/performance.py"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/tests"
+  )
 
   install(CODE "execute_process( \
-    COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/spheral-setup-venv.sh \ 
-    )")
+    COMMAND env PYTHONPATH=${SPACK_PYTHONPATH} ${PYTHON_EXE} -m venv .venv --without-pip --prompt \
+    'Spheral>')"
+  )
+
+  foreach(_venv_dir ${VIRTUALENV_PYTHONPATH_COPY})
+    if(NOT ${_venv_dir} MATCHES "sphinx")
+      install(DIRECTORY ${_venv_dir}
+        USE_SOURCE_PERMISSIONS
+        MESSAGE_NEVER
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/.venv"
+        PATTERN "*\/.spack*" EXCLUDE
+        PATTERN "*\/tests\/*" EXCLUDE
+        PATTERN "*.pyc" EXCLUDE
+      )
+    endif()
+  endforeach()
+
+  install(CODE "execute_process( \
+    COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/spheral-setup-venv.sh)"
+  )
 endif()

--- a/scripts/spheral-setup-venv.in
+++ b/scripts/spheral-setup-venv.in
@@ -1,9 +1,4 @@
 cd @CMAKE_INSTALL_PREFIX@
-echo "Creating Spheral virtual python environment ..."
-env PYTHONPATH=@SPACK_PYTHONPATH@ @PYTHON_EXE@ -m venv .venv --without-pip --prompt "Spheral>"
-
-echo "Installing runtime python libraries ..."
-cp -r @VIRTUALENV_PYTHONPATH_COPY@ .venv/ &> /dev/null
 
 echo "Setup Spheral libraries ..."
 cp @SPHERAL_SITE_PACKAGES_PATH@/Spheral.pth .venv/@SPHERAL_SITE_PACKAGES_PATH@/


### PR DESCRIPTION

# Summary

- This PR is a refactoring of the Spheral virtual environment creation routines.
- It does the following:
  - Removes the python venv and package file copy calls from spheral-setup-env.in.
  - Perform the python venv directly from CMake.
  - Make package file copy function a CMake install to avoid unnecessary copies.
  - Properly exclude unnecessary files from the TPL python packages.
  - Reduces reinstall times by 5x.

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

