### PR TITLE
Fix ENABLE_DEV_BUILD

### DIFF
--- a/.gitlab/specs.yml
+++ b/.gitlab/specs.yml
@@ -9,7 +9,7 @@
 .gcc_mvapich2:
   variables:
     SPEC: 'gcc@$GCC_VERSION^mvapich2'
-    EXTRA_CMAKE_ARGS: '-DENABLE_DOCS=On -DENABLE_WARNINGS_AS_ERRORS=On'
+    EXTRA_CMAKE_ARGS: '-DENABLE_DOCS=On -DENABLE_WARNINGS_AS_ERRORS=On -DENABLE_DEV_BUILD=On'
 
 .gcc_~mpi:
   variables:

--- a/.gitlab/specs.yml
+++ b/.gitlab/specs.yml
@@ -9,7 +9,7 @@
 .gcc_mvapich2:
   variables:
     SPEC: 'gcc@$GCC_VERSION^mvapich2'
-    EXTRA_CMAKE_ARGS: '-DENABLE_DOCS=On -DENABLE_WARNINGS_AS_ERRORS=On -DENABLE_DEV_BUILD=On'
+    EXTRA_CMAKE_ARGS: '-DENABLE_DOCS=On -DENABLE_WARNINGS_AS_ERRORS=On'
 
 .gcc_~mpi:
   variables:
@@ -23,7 +23,7 @@
 
 .gcc_spectrum:
   variables:
-    SPEC: 'gcc@$GCC_VERSION^spectrum-mpi'
+    SPEC: 'gcc@$GCC_VERSION^spectrum-mpi -DENABLE_DEV_BUILD=On'
 
 .clang_mvapich2:
   variables:

--- a/.gitlab/specs.yml
+++ b/.gitlab/specs.yml
@@ -23,7 +23,8 @@
 
 .gcc_spectrum:
   variables:
-    SPEC: 'gcc@$GCC_VERSION^spectrum-mpi -DENABLE_DEV_BUILD=On'
+    SPEC: 'gcc@$GCC_VERSION^spectrum-mpi'
+    EXTRA_CMAKE_ARGS: '-DENABLE_DEV_BUILD=On'
 
 .clang_mvapich2:
   variables:

--- a/cmake/spheral/SpheralAddLibs.cmake
+++ b/cmake/spheral/SpheralAddLibs.cmake
@@ -224,14 +224,7 @@ function(spheral_add_pybind11_library package_name module_list_name)
 
   # Get the TPL dependencies
   get_property(SPHERAL_BLT_DEPENDS GLOBAL PROPERTY SPHERAL_BLT_DEPENDS)
-  # If building shared libraries, use the SPHERAL_OBJ_LIBS global list
-  # Note, LLNLSpheral has appended any local targets to this list as well
-  if(ENABLE_DEV_BUILD)
-    get_property(SPHERAL_DEPENDS GLOBAL PROPERTY SPHERAL_OBJ_LIBS)
-  else()
-    # Otherwise, provide target names
-    list(APPEND SPHERAL_DEPENDS Spheral_CXX ${${package_name}_DEPENDS})
-  endif()
+  list(APPEND SPHERAL_DEPENDS Spheral_CXX ${${package_name}_DEPENDS})
 
   set(MODULE_NAME Spheral${package_name})
   PYB11Generator_add_module(${package_name}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,12 +83,7 @@ endforeach()
 # For dev builds, we must call LLNLSpheralInstallObjs.cmake
 # to ensure LLNLSpheral libraries are added to the Spheral_CXX
 # target
-if(ENABLE_DEV_BUILD)
-  # This calls LLNLSpheralInstallObjs.cmake
-  if(EXISTS ${EXTERNAL_SPHERAL_OBJ_CMAKE})
-    include(${EXTERNAL_SPHERAL_OBJ_CMAKE})
-  endif()
-else()
+if(NOT ENABLE_DEV_BUILD)
   set(CXX_sources spheralCXX.cc)
 endif()
 # Retrieve the global list populated in spheral_obj_add_library
@@ -97,8 +92,6 @@ get_property(SPHERAL_OBJ_LIBS GLOBAL PROPERTY SPHERAL_OBJ_LIBS)
 spheral_add_cxx_library(CXX "${SPHERAL_OBJ_LIBS}")
 
 # This calls LLNLSpheralInstallObjs.cmake
-if(NOT ENABLE_DEV_BUILD)
-  if(EXISTS ${EXTERNAL_SPHERAL_OBJ_CMAKE})
-    include(${EXTERNAL_SPHERAL_OBJ_CMAKE})
-  endif()
+if(EXISTS ${EXTERNAL_SPHERAL_OBJ_CMAKE})
+  include(${EXTERNAL_SPHERAL_OBJ_CMAKE})
 endif()


### PR DESCRIPTION
# Summary

- This PR is fixes `ENABLE_DEV_BUILD`
- It does the following:
  - Removes any hacks that were in `ENABLE_DEV_BUILD` that prevented it from exporting or required special lists/logic
  - Changes one of the CI tests to use `ENABLE_DEV_BUILD` to ensure it will not break as often

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#108)
- [x] LLNLSpheral PR has passed all tests.

