### PR TITLE
bugfix FSISPH and constant boundaries

### DIFF
--- a/src/FSISPH/SolidFSISPHHydroBase.cc
+++ b/src/FSISPH/SolidFSISPHHydroBase.cc
@@ -295,8 +295,6 @@ initializeProblemStartupDependencies(DataBase<Dimension>& dataBase,
   updateStateFields(SolidFieldNames::shearModulus, state, derivs);
   updateStateFields(SolidFieldNames::yieldStrength, state, derivs);
 
-  mDamagedPressure+=this->pressure();
-
   const auto& mass = dataBase.fluidMass();
   const auto& massDensity = dataBase.fluidMassDensity();
   computeSPHVolume(mass,massDensity,mVolume);


### PR DESCRIPTION
# Summary

- the damaged pressure was being initialized at 2x. This would cause issues for problems w/ constant boundaries.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [x] LLNLSpheral PR has passed all tests.

