### PR TITLE
Pip Managed Runtime Dependencies

### DIFF
--- a/cmake/InstallTPLs.cmake
+++ b/cmake/InstallTPLs.cmake
@@ -11,6 +11,7 @@ set(TPL_SPHERAL_CMAKE_DIR ${SPHERAL_ROOT_DIR}/cmake/tpl)
 # Initialize TPL options
 include(${SPHERAL_ROOT_DIR}/cmake/spheral/SpheralHandleTPL.cmake)
 include(${SPHERAL_ROOT_DIR}/cmake/spheral/SpheralHandleExt.cmake)
+include(${SPHERAL_ROOT_DIR}/cmake/spheral/SpheralPRT.cmake)
 
 #-----------------------------------------------------------------------------------
 # Submodules
@@ -37,6 +38,10 @@ if (NOT ENABLE_CXXONLY)
     EXPORT spheral_cxx-targets
     DESTINATION lib/cmake)
   set_target_properties(pybind11_headers PROPERTIES EXPORT_NAME spheral::pybind11_headers)
+
+  # Install Spheral Python Runtime Dependencies to virtual env in build tree.
+  Spheral_Python_Env(python_build_env build-requirements.txt ${CMAKE_BINARY_DIR})
+
 endif()
 
 # This is currently unfilled in spheral

--- a/cmake/spheral/SpheralAddLibs.cmake
+++ b/cmake/spheral/SpheralAddLibs.cmake
@@ -175,7 +175,6 @@ function(spheral_add_pybind11_library package_name module_list_name)
   # List directories in which spheral .py files can be found.
   set(PYTHON_ENV 
       ${EXTRA_PYB11_SPHERAL_ENV_VARS}
-      "${BUILDTIME_PYTHONENV_STR}:"
       "${SPHERAL_ROOT_DIR}/src/PYB11:"
       "${SPHERAL_ROOT_DIR}/src/PYB11/${PYB11_MODULE_NAME}:"
       "${SPHERAL_ROOT_DIR}/src/PYB11/polytope:"
@@ -226,11 +225,20 @@ function(spheral_add_pybind11_library package_name module_list_name)
   get_property(SPHERAL_BLT_DEPENDS GLOBAL PROPERTY SPHERAL_BLT_DEPENDS)
   list(APPEND SPHERAL_DEPENDS Spheral_CXX ${${package_name}_DEPENDS})
 
+  set(PYTHON_EXE_BAK ${PYTHON_EXE})
+
+  
+  get_target_property(PYTHON_EXE python_build_env EXECUTABLE)
+
+  message("---------")
+  message("${PYTHON_EXE}")
+
+
   set(MODULE_NAME Spheral${package_name})
   PYB11Generator_add_module(${package_name}
                             MODULE          ${MODULE_NAME}
                             SOURCE          ${package_name}_PYB11.py
-                            DEPENDS         ${SPHERAL_CXX_DEPENDS} ${EXTRA_BLT_DEPENDS} ${SPHERAL_DEPENDS}
+                            DEPENDS         ${SPHERAL_CXX_DEPENDS} ${EXTRA_BLT_DEPENDS} ${SPHERAL_DEPENDS} #python_build_env
                             PYTHONPATH      ${PYTHON_ENV_STR}
                             INCLUDES        ${CMAKE_CURRENT_SOURCE_DIR} ${${package_name}_INCLUDES} ${PYBIND11_ROOT_DIR}/include
                             COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${SPHERAL_PYB11_TARGET_FLAGS}>"
@@ -239,6 +247,8 @@ function(spheral_add_pybind11_library package_name module_list_name)
                             INSTALL         OFF
                             )
   target_include_directories(${MODULE_NAME} SYSTEM PRIVATE ${SPHERAL_EXTERN_INCLUDES})
+
+  set(PYTHON_EXE ${PYTHON_EXE_BAK})
 
   install(TARGETS     ${MODULE_NAME}
           DESTINATION ${SPHERAL_SITE_PACKAGES_PATH}/Spheral

--- a/cmake/spheral/SpheralPRT.cmake
+++ b/cmake/spheral/SpheralPRT.cmake
@@ -1,0 +1,17 @@
+#----------------------------------------------------------------------------------------
+#                                   Spheral_Python_Runtime_Env
+#----------------------------------------------------------------------------------------
+
+function(Spheral_Python_Env target_name requirements_file prefix)
+  add_custom_target(${target_name} ALL
+    COMMAND ${Python3_EXECUTABLE} -m venv ${prefix}/.venv;
+    COMMAND . ${prefix}/.venv/bin/activate &&
+            python -m pip install --upgrade pip &&
+            python -m pip install -r ${SPHERAL_ROOT_DIR}/scripts/${requirements_file}
+    VERBATIM
+    DEPENDS Python3::Python
+  )
+  set_property(TARGET ${target_name} PROPERTY EXECUTABLE python)
+  set_property(TARGET ${target_name} PROPERTY ACTIVATE_VENV . ${prefix}/.venv/bin/activate)
+endfunction()
+

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -75,23 +75,34 @@ if (NOT ENABLE_CXXONLY)
     DESTINATION "${CMAKE_INSTALL_PREFIX}/tests"
   )
 
-  install(CODE "execute_process( \
-    COMMAND env PYTHONPATH=${SPACK_PYTHONPATH} ${PYTHON_EXE} -m venv .venv --without-pip --prompt \
-    'Spheral>')"
-  )
+  Spheral_Python_Env(python_runtime_env runtime-requirements.txt ${CMAKE_INSTALL_PREFIX})
 
-  foreach(_venv_dir ${VIRTUALENV_PYTHONPATH_COPY})
-    if(NOT ${_venv_dir} MATCHES "sphinx")
-      install(DIRECTORY ${_venv_dir}
-        USE_SOURCE_PERMISSIONS
-        MESSAGE_NEVER
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/.venv"
-        PATTERN "*\/.spack*" EXCLUDE
-        PATTERN "*\/tests\/*" EXCLUDE
-        PATTERN "*.pyc" EXCLUDE
-      )
-    endif()
-  endforeach()
+  install(FILES ${polytope_DIR}/${SPHERAL_SITE_PACKAGES_PATH}/polytope/polytope.so
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/.venv/${SPHERAL_SITE_PACKAGES_PATH}/polytope/
+    #install(DIRECTORY ${polytope_DIR}/${SPHERAL_SITE_PACKAGES_PATH}/polytope
+    #DESTINATION ${CMAKE_INSTALL_PREFIX}/.venv/${SPHERAL_SITE_PACKAGES_PATH}
+    )
+
+  #install(CODE "execute_process( \
+  #  COMMAND ${Python3_EXECUTABLE} -m venv ${CMAKE_INSTALL_PREFIX}/.venv --prompt 'Spheral>';
+  #  COMMAND . ${CMAKE_INSTALL_PREFIX}/.venv/bin/activate &&
+  #          python -m pip install --upgrade pip &&
+  #          python -m pip install -r ${SPHERAL_ROOT_DIR}/scripts/requirements.txt
+  #  )"
+  #)
+
+  #foreach(_venv_dir ${VIRTUALENV_PYTHONPATH_COPY})
+  #  if(NOT ${_venv_dir} MATCHES "sphinx")
+  #    install(DIRECTORY ${_venv_dir}
+  #      USE_SOURCE_PERMISSIONS
+  #      MESSAGE_NEVER
+  #      DESTINATION "${CMAKE_INSTALL_PREFIX}/.venv"
+  #      PATTERN "*\/.spack*" EXCLUDE
+  #      PATTERN "*\/tests\/*" EXCLUDE
+  #      PATTERN "*.pyc" EXCLUDE
+  #    )
+  #  endif()
+  #endforeach()
 
   install(CODE "execute_process( \
     COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/spheral-setup-venv.sh)"

--- a/scripts/runtime-requirements.txt
+++ b/scripts/runtime-requirements.txt
@@ -1,0 +1,8 @@
+numpy == 1.23.4
+numpy-stl == 3.0.0
+matplotlib ==3.7.4
+h5py == 3.9.0
+scipy == 1.12.0
+mpi4py == 3.1.5
+ats @ git+https://github.com/LLNL/ATS@7.0.116
+

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -29,6 +29,7 @@ class Spheral(CachedCMakePackage, CudaPackage):
     variant('openmp', default=True, description='Enable OpenMP Support.')
     variant('docs', default=False, description='Enable building Docs.')
     variant('shared', default=True, description='Build C++ libs as shared.')
+    variant('python', default=True, description='Build Python Dependencies.')
 
     # -------------------------------------------------------------------------
     # DEPENDS
@@ -71,24 +72,24 @@ class Spheral(CachedCMakePackage, CudaPackage):
             depends_on(f"{ctpl} ~cuda", type='build')
 
     depends_on('opensubdiv@3.4.3', type='build')
-    depends_on('polytope@0.7.3 +python', type='build')
-
-    extends('python@3.9.10 +zlib +shared +ssl +tkinter', type='build')
-
-    depends_on('py-numpy@1.23.4', type='build')
-    depends_on('py-numpy-stl@3.0.0', type='build')
-    depends_on('py-pillow@9.5.0', type='build')
-    depends_on('py-matplotlib@3.7.4 backend=tkagg +fonts', type='build')
-    depends_on('py-h5py@3.9.0', type='build')
-    depends_on('py-docutils@0.18.1', type='build')
-    depends_on('py-scipy@1.12.0', type='build')
-    depends_on('py-ats@exit', type='build')
-    depends_on('py-mpi4py@3.1.5', type='build', when='+mpi')
-
-    depends_on('py-sphinx', type='build')
-    depends_on('py-sphinx-rtd-theme', type='build')
-
     depends_on('netlib-lapack', type='build')
+
+    with when("+python"):
+        extends('python@3.9.10 +zlib +shared +ssl +tkinter', type='build')
+        depends_on('polytope@0.7.3 +python', type='build', when='+python')
+
+        #depends_on('py-numpy@1.23.4', type='build')
+        #depends_on('py-numpy-stl@3.0.0', type='build')
+        #depends_on('py-pillow@9.5.0', type='build')
+        #depends_on('py-matplotlib@3.7.4 backend=tkagg +fonts', type='build')
+        #depends_on('py-h5py@3.9.0', type='build')
+        #depends_on('py-docutils@0.18.1', type='build')
+        #depends_on('py-scipy@1.12.0', type='build')
+        #depends_on('py-ats@exit', type='build')
+        #depends_on('py-mpi4py@3.1.5', type='build', when='+mpi')
+
+        #depends_on('py-sphinx', type='build')
+        #depends_on('py-sphinx-rtd-theme', type='build')
 
     # -------------------------------------------------------------------------
     # DEPENDS
@@ -168,8 +169,6 @@ class Spheral(CachedCMakePackage, CudaPackage):
 
         entries.append(cmake_cache_path('adiak_DIR', spec['adiak'].prefix))
 
-        entries.append(cmake_cache_path('python_DIR', spec['python'].prefix))
-
         entries.append(cmake_cache_path('boost_DIR', spec['boost'].prefix))
 
         entries.append(cmake_cache_path('qhull_DIR', spec['qhull'].prefix))
@@ -206,7 +205,9 @@ class Spheral(CachedCMakePackage, CudaPackage):
         entries.append(cmake_cache_option('ENABLE_OPENMP', '+openmp' in spec))
         entries.append(cmake_cache_option('ENABLE_DOCS', '+docs' in spec))
 
-        entries.append(cmake_cache_path('SPACK_PYTHONPATH', os.environ.get('PYTHONPATH')))
+        if "+python" in spec:
+            entries.append(cmake_cache_path('python_DIR', spec['python'].prefix))
+        #    entries.append(cmake_cache_path('SPACK_PYTHONPATH', os.environ.get('PYTHONPATH')))
 
         return entries
 

--- a/scripts/spheral-setup-venv.in
+++ b/scripts/spheral-setup-venv.in
@@ -8,9 +8,9 @@ cp --symbolic-link @CMAKE_INSTALL_PREFIX@/@SPHERAL_SITE_PACKAGES_PATH@/Spheral/*
 cd - > /dev/null 
 
 # We need to reconfigure ATS to use our virtual env python otherwise ats will not be able to launch properly.
-echo "Reconfigure ATS executing python to virtual env python..."
-sed -i '2s/.*/XXXXXX/' .venv/bin/ats
-sed -i 's|XXXXXX|\x27\x27\x27exec\x27 @CMAKE_INSTALL_PREFIX@/.venv/bin/python "$0" "$@"|' .venv/bin/ats
+# echo "Reconfigure ATS executing python to virtual env python..."
+# sed -i '2s/.*/XXXXXX/' .venv/bin/ats
+# sed -i 's|XXXXXX|\x27\x27\x27exec\x27 @CMAKE_INSTALL_PREFIX@/.venv/bin/python "$0" "$@"|' .venv/bin/ats
 
 echo "Creating spheral symlink to spheral-env script ..."
 cd @CMAKE_INSTALL_PREFIX@


### PR DESCRIPTION
# Summary

- This PR is a refactoring of our package management system for python packages in the Spheral build pipeline.

### Spheral +python variant
- The spheral spack package will default to `+python`. This will add python as a dependency for building spheral. It will also enable `+python` for polytope.
- We no longer need any of our pip package dependencies in spacke. This significantly cuts down our build tree.

#### Build Time Deps
- We still need spack to build python for us :( . 
  - The defaults on LC fails to build `mpi4py` correctly. 
  - CMake complains abour missing development targets from many of the python modules on LC. 
- We need `decorator` (for `PYB11Generator`), as well as `sphinx` and `sphinx-rtd-theme`. 
	- These are stored in `scripts/build-requirements.txt`
- Using the new `Spheral_Python_Env` function we build a virtual environment in the build tree with these dependencies. All `pybind11` code and documentation is generated from this environment.
	- **TODO**: PYB11Generators CMake call needs to take the name of a virtual environment target for the c++ generation to depend on. It will need to extract the *activation* command and change out the *python_exe* variable provided from the venv target properties.
#### Runtime Deps
- Using the same `Spheral_Python_Env` function we can generate a Virtual Env in the Install directory from `runtime-requirements.txt`.
- `spheral-setup-venv` will now copy only the necessary Spheral libraries into this environment at the install time.

The build and runtime environment target scripts will be run on every `make` call. However after the initial installation on the first `make` this only takes a few seconds as pip will check each time to ensure the environments satisfy their respective requirements.txt files.

### Caching Builds for LC
It seems as if all pip packages install from a local Livermore pypi repo. This could be very advantageous and might mean we may not have to manage cached tars ourselves.
- ATS will be a problem on air-gapped systems, currently it needs to pull ATS from the github repo.

### C++ Only Builds
- When building Spheral w/o the python interface we no longer need spack to build python.
	- Note: It will still try as caliper has a hard dependency on python.
	- **TODO**: Remove Caliper python dependency in caliper package? (this will get rid of python from our spack build tree entirely for `~python` specs).
------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

