### PR TITLE
Set appropriate `amdgpu_target`

### DIFF
--- a/.gitlab/specs.yml
+++ b/.gitlab/specs.yml
@@ -55,8 +55,8 @@
 
 .hip_rocm_mpich:
   variables:
-    SPEC: '%rocmcc+mpi+rocm amdgpu_target=gfx942'
+    SPEC: '%rocmcc+mpi+rocm'
 
 .hip_rocm_~mpi:
   variables:
-    SPEC: '%rocmcc~mpi+rocm amdgpu_target=gfx942'
+    SPEC: '%rocmcc~mpi+rocm'

--- a/scripts/devtools/tpl-manager.py
+++ b/scripts/devtools/tpl-manager.py
@@ -29,10 +29,6 @@ if "spheral" in git_mod_out:
     package_dirs.update({"llnlspheral": base_dir})
 print(f"Managing {package_name} TPLs")
 
-dev_specs = {"gcc": "%gcc+mpi", "clang": "%clang+mpi", "gcc~mpi": "%gcc~mpi",
-             "rocmcc": "+mpi~rocm", "rocmcc+rocm": "+mpi+rocm amdgpu_target=gfx942",
-             "rocmcc+rocm~mpi": "~mpi+rocm amdgpu_target=gfx942"}
-
 class SpheralTPL:
     def parse_args(self):
         parser = argparse.ArgumentParser()
@@ -41,9 +37,6 @@ class SpheralTPL:
                            help="Install TPLs and create host config file for a given spec.\n"+\
                            "If no spec if given, TPLs for all env specs are installed and "+\
                            "no host config file is created.")
-        group.add_argument("--dev-spec", type=str, default=None,
-                           help="For use by developers to ease frequent TPL building.",
-                           choices=list(dev_specs.keys()))
         parser.add_argument("--show-specs", action="store_true",
                             help="Show the specs for the current environment and stop.")
         parser.add_argument("--show-info", action="store_true",
@@ -79,9 +72,6 @@ class SpheralTPL:
 
         if (not self.args.spec and self.args.ci_run):
             raise Exception("Must specify a --spec if doing --ci-run")
-
-        if (self.args.dev_spec):
-            self.args.spec = package_name + dev_specs[self.args.dev_spec]
 
         if (self.args.spec and not self.args.spec.startswith(package_name)):
             raise Exception(f"--spec must start with {package_name}")

--- a/scripts/spack/environments/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/environments/toss_4_x86_64_ib_cray/spack.yaml
@@ -21,7 +21,7 @@ spack:
   packages:
     spheral:
       require:
-        - spec: "amdgpu_targets=gfx90a"
+        - spec: "amdgpu_target=gfx90a"
           when: "+rocm arch=linux-rhel8-zen3"
-        - spec: "amdgpu_targets=gfx942"
+        - spec: "amdgpu_target=gfx942"
           when: "+rocm arch=linux-rhel8-zen4"

--- a/scripts/spack/environments/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/environments/toss_4_x86_64_ib_cray/spack.yaml
@@ -3,7 +3,7 @@ spack:
   - matrix:
       - [spheral]
       - ["+mpi", "~mpi"]
-      - ["+rocm amdgpu_target=gfx942", "~rocm"]
+      - ["+rocm", "~rocm"]
   view: false
   concretizer:
     unify: false
@@ -18,3 +18,10 @@ spack:
     - ../../configs/upstreams.yaml
   repos:
     - ../../
+  packages:
+    spheral:
+      require:
+        - spec: "amdgpu_targets=gfx90a"
+          when: "+rocm arch=linux-rhel8-zen3"
+        - spec: "amdgpu_targets=gfx942"
+          when: "+rocm arch=linux-rhel8-zen4"


### PR DESCRIPTION
# Summary

- This PR is a bugfix for the AMD GPU/Cray Spack environments
- It does the following:
  - Removes any explicit setting of `amdgpu_target` in a spec.
  - Lets the environment determine what to set `amdgpu_target` to based on the system architecture.
  - Removes the `dev_spec` input for tpl-manager.py as it was not useful.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#135)
- [x] LLNLSpheral PR has passed all tests.

