### PR TITLE
Removing pandas version requirement

### DIFF
--- a/.github/workflows/test-tpls.yml
+++ b/.github/workflows/test-tpls.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - scripts/spack/**
       - scripts/devtools/**
+      - scripts/runtime-requirements.txt.in
+      - scripts/build-requirements.txt
 
 env:
   REGISTRY: ghcr.io

--- a/scripts/runtime-requirements.txt.in
+++ b/scripts/runtime-requirements.txt.in
@@ -7,7 +7,6 @@ mpi4py == 4.0.3
 cffi == 1.17.1
 pyyaml == 6.0.2
 llnl-thicket == 2024.2.1
-pandas == 2.2.3
 ipython >= 8.12.3, <= 8.18.1
 ats @ file://@SPHERAL_ROOT_DIR@/extern/ATS
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- It does the following:
  - Removes the pandas runtime requirement.
  - Makes the github docker test run if the python build and run requirement files are modified.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#143)
- [x] LLNLSpheral PR has passed all tests.

