### PR TITLE
Reduce CI resource use

### DIFF
--- a/.gitlab/machines.yml
+++ b/.gitlab/machines.yml
@@ -7,10 +7,10 @@
     - flux
   variables:
     JACAMAR_SCHEDULER_ACTION: default
-    SCHEDULER_PARAMETERS: "--exclusive -N 2 -t 120"
-    NPROC: 128
+    SCHEDULER_PARAMETERS: "--exclusive -N 1 -t 60"
+    NPROC: 64
     HOSTNAME: 'tioga'
-  timeout: 120 minutes
+  timeout:  24 hours
   extends: [.on_toss_4_x86_cray]
 
 .tioga_shell:
@@ -27,10 +27,10 @@
     - batch
   variables:
     JACAMAR_SCHEDULER_ACTION: default
-    SCHEDULER_PARAMETERS: "--reservation=ci --exclusive -N 2 -t 120"
-    NPROC: 112
+    SCHEDULER_PARAMETERS: "--reservation=ci --exclusive -N 1 -t 120"
+    NPROC: 56
     HOSTNAME: 'ruby'
-  timeout: 120 minutes
+  timeout: 24 hours
   extends: [.on_toss_4_x86]
 
 .ruby_shell:
@@ -61,6 +61,7 @@
   extends: [.tioga_shell]
 
 .cray_shell2:
+  resource_group: cray2
   extends: [.tioga_shell]
 
 # ------------------------------------------------------------------------------

--- a/.gitlab/scripts.yml
+++ b/.gitlab/scripts.yml
@@ -93,7 +93,7 @@
     - CI_BUILD_DIR=$(cat ci-dir.txt)
     - cd $CI_BUILD_DIR && cat job-name.txt
 
-    - ./build_gitlab/install/spheral-ats --ciRun --numNodes 2 --logs perf_logs ./build_gitlab/install/$PERF_ATS_FILE || exit_code=$?
+    - ./build_gitlab/install/spheral-ats --ciRun --numNodes 2 --delay --logs perf_logs ./build_gitlab/install/$PERF_ATS_FILE || exit_code=$?
     - exit $exit_code
   artifacts:
     when: always

--- a/scripts/spheral_ats.py
+++ b/scripts/spheral_ats.py
@@ -131,6 +131,8 @@ def main():
                         help="Print the help output for ATS. Useful for seeing ATS options.")
     parser.add_argument("--threads", type=int, default=None,
                         help="Set number of threads per rank to use. Only used by performance.py")
+    parser.add_argument("--delay", action="store_true",
+                        help="Defer running job until after 7 pm.")
     options, unknown_options = parser.parse_known_args()
     if (options.atsHelp):
         subprocess.run(f"{ats_exe} --help", shell=True, check=True, text=True)
@@ -151,16 +153,20 @@ def main():
     if hostname:
         mac_args = [] # Machine specific arguments to give to ATS
         if any(x in hostname for x in toss_machine_names):
-            numNodes = numNodes if numNodes else 2
+            numNodes = numNodes if numNodes else 1
             timeLimit = timeLimit if timeLimit else 120
             inAllocVars = ["SLURM_JOB_NUM_NODES", "SLURM_NNODES"]
             launch_cmd = f"salloc --exclusive -N {numNodes} -t {timeLimit} "
+            if (options.delay):
+                launch_cmd += "--begin=19:10:00 "
             mac_args.append(f"--numNodes {numNodes}")
         elif any(x in hostname for x in toss_cray_machine_names):
-            numNodes = numNodes if numNodes else 2
+            numNodes = numNodes if numNodes else 1
             timeLimit = timeLimit if timeLimit else 120
             inAllocVars = ["FLUX_JOB_ID", "FLUX_CONNECTOR_PATH", "FLUX_TERMINUS_SESSION"]
             launch_cmd = f"flux alloc -xN {numNodes} -t {timeLimit} "
+            if (options.delay):
+                launch_cmd += "--begin-time='7 pm' "
             mac_args.append(f"--npMax {np_max_dict[hostname]}")
         if (options.ciRun):
             for i, j in ci_launch_flags.items():


### PR DESCRIPTION

# Summary

- This PR is a bug fix to limit the resources used by the CI
- It does the following:
  - Adds a `--delay` option to spheral_ats to prevent performance CI jobs from running until after 7 pm.
  - Adds resource groups to all stages.
  - Makes the default number of nodes 1.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#144)
- [x] LLNLSpheral PR has passed all tests.

