### PR TITLE
Bugfix : Executable Build Env github workflow.

### DIFF
--- a/.github/workflows/test-tpls.yml
+++ b/.github/workflows/test-tpls.yml
@@ -7,6 +7,7 @@ on:
       - scripts/devtools/**
       - scripts/runtime-requirements.txt.in
       - scripts/build-requirements.txt
+      - Dockerfile
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,8 +99,8 @@ WORKDIR ../install
 # If it did, we would need some of the following commands
 #RUN export OMP_NUM_THREADS=1
 #RUN export MACHINE_TYPE="winParallel"
-#RUN ./spheral-ats --level 99 --mpiexe mpiexec --npMax $JCXX tests/integration.ats
+#RUN ./bin/spheral-ats --level 99 --mpiexe mpiexec --npMax $JCXX tests/integration.ats
 
 # Instead, we will just run it normally
-RUN ./spheral-ats --level 99 tests/integration.ats
+RUN ./bin/spheral-ats --level 99 tests/integration.ats
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- This PR is a bugfix
  - Fixes the path used to execute `spheral-ats` in our dockerfile with the recent build dir structure changes.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

