### PR TITLE
[GPU] Squashing Warnings

### DIFF
--- a/src/ArtificialConduction/ArtificialConduction.cc
+++ b/src/ArtificialConduction/ArtificialConduction.cc
@@ -242,7 +242,7 @@ evaluateDerivatives(const typename Dimension::Scalar /*time*/,
 
               // get some differentials
               const Vector rij        = ri - rj; /* this is sign flipped but it's ok! */
-              const Vector rji        = rj - ri;
+              //const Vector rji        = rj - ri;
               const Vector etai       = Hi*rij;
               const Vector etaj       = Hj*rij;
               const Vector etaiNorm   = etai.unitVector();

--- a/src/ArtificialViscosity/ArtificialViscosityHandle.cc
+++ b/src/ArtificialViscosity/ArtificialViscosityHandle.cc
@@ -225,7 +225,6 @@ updateVelocityGradient(const DataBase<Dimension>& dataBase,
     int i, j, nodeListi, nodeListj;
     Scalar Hdeti, Hdetj, etaMagi, etaMagj;
     Vector rij, vij, etai, etaj, etaiUnit, etajUnit, gradWi, gradWj;
-    Tensor QPiij, QPiji;
 
     typename SpheralThreads<Dimension>::FieldListStack threadStack;
     auto DvDx_thread = DvDx_Q.threadCopy(threadStack);

--- a/src/ArtificialViscosity/FiniteVolumeViscosity.cc
+++ b/src/ArtificialViscosity/FiniteVolumeViscosity.cc
@@ -89,7 +89,6 @@ QPiij(Scalar& QPiij, Scalar& QPiji,      // result for QPi (Q/rho^2)
   const auto Cqij = 0.5*(fCqi + fCqj)*fshear * mCquadratic;
 
   // Compute the pair QPi
-  const auto vij = vi - vj;
   const auto xji = xj - xi;
   const auto xjihat = xji.unitVector();
   const auto hi = 1.0/(Hi*xjihat).magnitude();

--- a/src/Boundary/Boundary.cc
+++ b/src/Boundary/Boundary.cc
@@ -181,11 +181,10 @@ template<typename Dimension>
 const vector<int>&
 Boundary<Dimension>::controlNodes(const NodeList<Dimension>& nodeList) const {
   auto itr = mBoundaryNodes.find(const_cast<NodeList<Dimension>*>(&nodeList));
-  if (itr != mBoundaryNodes.end()) {
-    return itr->second.controlNodes;
-  } else {
+  if (itr == mBoundaryNodes.end()) {
     VERIFY2(false, "Boundary::controlNodes: no entry for NodeList: " << nodeList.name());
   }
+  return itr->second.controlNodes;
 }
 
 //------------------------------------------------------------------------------
@@ -195,12 +194,11 @@ template<typename Dimension>
 const vector<int>&
 Boundary<Dimension>::ghostNodes(const NodeList<Dimension>& nodeList) const {
   auto itr = mBoundaryNodes.find(const_cast<NodeList<Dimension>*>(&nodeList));
-  if (itr != mBoundaryNodes.end()) {
-    return itr->second.ghostNodes;
-  } else {
+  if (itr == mBoundaryNodes.end()) {
     std::cerr << "Number of known NodeLists: " << mBoundaryNodes.size() << std::endl;
     VERIFY2(false, "Boundary::ghostNodes: no entry for NodeList: " << nodeList.name());
   }
+  return itr->second.ghostNodes;
 }
 
 //------------------------------------------------------------------------------
@@ -210,11 +208,10 @@ template<typename Dimension>
 const vector<int>&
 Boundary<Dimension>::violationNodes(const NodeList<Dimension>& nodeList) const {
   auto itr = mBoundaryNodes.find(const_cast<NodeList<Dimension>*>(&nodeList));
-  if (itr != mBoundaryNodes.end()) {
-    return itr->second.violationNodes;
-  } else {
+  if (itr == mBoundaryNodes.end()) {
     VERIFY2(false, "Boundary::violationNodes: no entry for NodeList: " << nodeList.name());
   }
+  return itr->second.violationNodes;
 }
 
 //------------------------------------------------------------------------------
@@ -284,22 +281,20 @@ template<typename Dimension>
 typename Boundary<Dimension>::BoundaryNodes&
 Boundary<Dimension>::accessBoundaryNodes(NodeList<Dimension>& nodeList) {
   auto itr = mBoundaryNodes.find(&nodeList);
-  if (itr != mBoundaryNodes.end()) {
-    return itr->second;
-  } else {
+  if (itr == mBoundaryNodes.end()) {
     VERIFY2(false, "Boundary::accessBoundaryNodes: no entry for NodeList: " << nodeList.name());
   }
+  return itr->second;
 }
 
 template<typename Dimension>
 const typename Boundary<Dimension>::BoundaryNodes&
 Boundary<Dimension>::accessBoundaryNodes(NodeList<Dimension>& nodeList) const {
   auto itr = mBoundaryNodes.find(&nodeList);
-  if (itr != mBoundaryNodes.end()) {
-    return itr->second;
-  } else {
+  if (itr == mBoundaryNodes.end()) {
     VERIFY2(false, "Boundary::accessBoundaryNodes: no entry for NodeList: " << nodeList.name());
   }
+  return itr->second;
 }
 
 //------------------------------------------------------------------------------

--- a/src/Boundary/FacetedVolumeBoundary.cc
+++ b/src/Boundary/FacetedVolumeBoundary.cc
@@ -594,7 +594,6 @@ FacetedVolumeBoundary<Dimension>::updateViolationNodes(NodeList<Dimension>& node
   vector<unsigned> potentialFacets;
   vector<Vector> intersections;
   Vector newPos, newVel;
-  SymTensor newH;
   bool inViolation;
   int iter = 0;
   int minFacet;

--- a/src/Boundary/ReflectingBoundary.cc
+++ b/src/Boundary/ReflectingBoundary.cc
@@ -269,7 +269,7 @@ applyGhostBoundary(Field<Dimension, typename Dimension::ThirdRankTensor>& field)
   vector<int>::const_iterator controlItr = this->controlBegin(nodeList);
   vector<int>::const_iterator ghostItr = this->ghostBegin(nodeList);
   const Tensor T = this->reflectOperator();
-  const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
+  //const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
   ThirdRankTensor val;
   for (; controlItr < this->controlEnd(nodeList); ++controlItr, ++ghostItr) {
     CHECK(ghostItr < this->ghostEnd(nodeList));
@@ -308,7 +308,7 @@ applyGhostBoundary(Field<Dimension, typename Dimension::FourthRankTensor>& field
   vector<int>::const_iterator controlItr = this->controlBegin(nodeList);
   vector<int>::const_iterator ghostItr = this->ghostBegin(nodeList);
   const Tensor T = this->reflectOperator();
-  const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
+  //const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
   FourthRankTensor val;
   for (; controlItr < this->controlEnd(nodeList); ++controlItr, ++ghostItr) {
     CHECK(ghostItr < this->ghostEnd(nodeList));
@@ -351,7 +351,7 @@ applyGhostBoundary(Field<Dimension, typename Dimension::FifthRankTensor>& field)
   vector<int>::const_iterator controlItr = this->controlBegin(nodeList);
   vector<int>::const_iterator ghostItr = this->ghostBegin(nodeList);
   const Tensor T = this->reflectOperator();
-  const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
+  //const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
   FifthRankTensor val;
   for (; controlItr < this->controlEnd(nodeList); ++controlItr, ++ghostItr) {
     CHECK(ghostItr < this->ghostEnd(nodeList));
@@ -519,7 +519,7 @@ ReflectingBoundary<Dimension>::
 enforceBoundary(Field<Dimension, typename Dimension::ThirdRankTensor>& field) const {
   REQUIRE(valid());
   const Tensor T = this->reflectOperator();
-  const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
+  //const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
   const NodeList<Dimension>& nodeList = field.nodeList();
   ThirdRankTensor val;
   for (vector<int>::const_iterator itr = this->violationBegin(nodeList);
@@ -552,7 +552,7 @@ ReflectingBoundary<Dimension>::
 enforceBoundary(Field<Dimension, typename Dimension::FourthRankTensor>& field) const {
   REQUIRE(valid());
   const Tensor T = this->reflectOperator();
-  const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
+  //const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
   const NodeList<Dimension>& nodeList = field.nodeList();
   FourthRankTensor val;
   for (vector<int>::const_iterator itr = this->violationBegin(nodeList);
@@ -589,7 +589,7 @@ ReflectingBoundary<Dimension>::
 enforceBoundary(Field<Dimension, typename Dimension::FifthRankTensor>& field) const {
   REQUIRE(valid());
   const Tensor T = this->reflectOperator();
-  const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
+  //const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
   const NodeList<Dimension>& nodeList = field.nodeList();
   FifthRankTensor val;
   for (vector<int>::const_iterator itr = this->violationBegin(nodeList);
@@ -786,7 +786,7 @@ enforceBoundary(vector<typename Dimension::ThirdRankTensor>& faceField,
                 const Mesh<Dimension>& mesh) const {
   REQUIRE(faceField.size() == mesh.numFaces());
   const Tensor T = this->reflectOperator();
-  const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
+  //const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
   const GeomPlane<Dimension>& plane = this->enterPlane();
   const vector<unsigned> faceIDs = this->facesOnPlane(mesh, plane, 1.0e-6);
   ThirdRankTensor val;
@@ -821,7 +821,7 @@ enforceBoundary(vector<typename Dimension::FourthRankTensor>& faceField,
                 const Mesh<Dimension>& mesh) const {
   REQUIRE(faceField.size() == mesh.numFaces());
   const Tensor T = this->reflectOperator();
-  const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
+  //const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
   const GeomPlane<Dimension>& plane = this->enterPlane();
   const vector<unsigned> faceIDs = this->facesOnPlane(mesh, plane, 1.0e-6);
   FourthRankTensor val;
@@ -860,7 +860,7 @@ enforceBoundary(vector<typename Dimension::FifthRankTensor>& faceField,
                 const Mesh<Dimension>& mesh) const {
   REQUIRE(faceField.size() == mesh.numFaces());
   const Tensor T = this->reflectOperator();
-  const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
+  //const Tensor T2 = innerProduct<Dimension>(T.Transpose(), T.Transpose());
   const GeomPlane<Dimension>& plane = this->enterPlane();
   const vector<unsigned> faceIDs = this->facesOnPlane(mesh, plane, 1.0e-6);
   FifthRankTensor val;

--- a/src/CRKSPH/CRKSPH.cc
+++ b/src/CRKSPH/CRKSPH.cc
@@ -268,7 +268,6 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
     Vector gradWi, gradWj;
     Vector deltagrad, forceij, forceji;
     Vector rij, vij, etai, etaj;
-    SymTensor rijdyad;
 
     typename SpheralThreads<Dimension>::FieldListStack threadStack;
     auto DvDt_thread = DvDt.threadCopy(threadStack);

--- a/src/CRKSPH/CRKSPHRZ.cc
+++ b/src/CRKSPH/CRKSPHRZ.cc
@@ -327,7 +327,6 @@ evaluateDerivativesImpl(const Dim<2>::Scalar /*time*/,
     Vector gradWi, gradWj;
     Vector deltagrad, forceij, forceji;
     Vector xij, vij, etai, etaj;
-    SymTensor xijdyad;
 
     typename SpheralThreads<Dimension>::FieldListStack threadStack;
     auto DvDt_thread = DvDt.threadCopy(threadStack);

--- a/src/CRKSPH/SolidCRKSPH.cc
+++ b/src/CRKSPH/SolidCRKSPH.cc
@@ -370,7 +370,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
     Vector gradWi, gradWj;
     Vector deltagrad, forceij, forceji;
     Vector rij, vij, etai, etaj;
-    SymTensor sigmai, sigmaj, rijdyad;
+    SymTensor sigmai, sigmaj;
 
     typename SpheralThreads<Dimension>::FieldListStack threadStack;
     auto DvDt_thread = DvDt.threadCopy(threadStack);

--- a/src/CRKSPH/SolidCRKSPHRZ.cc
+++ b/src/CRKSPH/SolidCRKSPHRZ.cc
@@ -405,7 +405,7 @@ evaluateDerivativesImpl(const Dimension::Scalar /*time*/,
     Vector gradWi, gradWj;
     Vector deltagrad, forceij, forceji;
     Vector xij, vij, etai, etaj;
-    SymTensor sigmai, sigmaj, xijdyad;
+    SymTensor sigmai, sigmaj;
 
     typename SpheralThreads<Dimension>::FieldListStack threadStack;
     auto DvDt_thread = DvDt.threadCopy(threadStack);

--- a/src/CRKSPH/computeSolidCRKSPHSumMassDensity.cc
+++ b/src/CRKSPH/computeSolidCRKSPHSumMassDensity.cc
@@ -41,7 +41,6 @@ computeSolidCRKSPHSumMassDensity(const ConnectivityMap<Dimension>& connectivityM
 
   typedef typename Dimension::Scalar Scalar;
   typedef typename Dimension::Vector Vector;
-  typedef typename Dimension::Tensor Tensor;
 
   const auto W0 = W.kernelValue(0.0, 1.0);
 
@@ -62,8 +61,6 @@ computeSolidCRKSPHSumMassDensity(const ConnectivityMap<Dimension>& connectivityM
     // Some scratch variables.
     int i, j, nodeListi, nodeListj;
     Vector rij, etai, etaj;
-    Vector Bi = Vector::zero, Bj = Vector::zero;
-    Tensor Ci = Tensor::zero, Cj = Tensor::zero;
 
     typename SpheralThreads<Dimension>::FieldListStack threadStack;
     auto massDensity_thread = massDensity.threadCopy(threadStack);

--- a/src/CXXTests/DeviceTestLib/DeviceTest.cc
+++ b/src/CXXTests/DeviceTestLib/DeviceTest.cc
@@ -40,15 +40,15 @@ __host__ int launchCaller(int a, int b)
 {
   int c;
   int *d_c;
-  hipMalloc((void**) &d_c, sizeof(int));
+  (void)hipMalloc((void**) &d_c, sizeof(int));
 
   launch<<<1,1>>>(a,b,d_c);
   hipError_t err = hipGetLastError();
   if (err != hipSuccess) 
       printf("Error: %s\n", hipGetErrorString(err));
 
-  hipMemcpy(&c, d_c, sizeof(int), hipMemcpyDeviceToHost);
-  hipFree(d_c);
+  (void)hipMemcpy(&c, d_c, sizeof(int), hipMemcpyDeviceToHost);
+  (void)hipFree(d_c);
   return c;
 }
 #endif

--- a/src/DataBase/DataBase.cc
+++ b/src/DataBase/DataBase.cc
@@ -1942,7 +1942,6 @@ globalSamplingBoundingVolume(typename Dimension::Vector& centroid,
       }
       radiusNodes = allReduce(radiusNodes, SPHERAL_OP_MAX);
       radiusSample = allReduce(radiusSample, SPHERAL_OP_MAX);
-      const Vector delta = 0.001*(xmaxSample - xminSample);
       radiusNodes *= 1.001;
       radiusSample *= 1.001;
     }

--- a/src/DataBase/IncrementBoundedStateInline.hh
+++ b/src/DataBase/IncrementBoundedStateInline.hh
@@ -63,6 +63,7 @@ update(const KeyType& key,
   const auto allkeys = derivs.keys();
   KeyType dfKey, dfNodeListKey;
   auto numDeltaFields = 0u;
+  CONTRACT_VAR(numDeltaFields);
   for (const auto& dkey: allkeys) {
     StateBase<Dimension>::splitFieldKey(dkey, dfKey, dfNodeListKey);
     if (dfNodeListKey == nodeListKey and

--- a/src/DataBase/IncrementStateInline.hh
+++ b/src/DataBase/IncrementStateInline.hh
@@ -58,6 +58,7 @@ update(const KeyType& key,
   const auto allkeys = derivs.keys();
   KeyType dfKey, dfNodeListKey;
   auto numDeltaFields = 0u;
+  CONTRACT_VAR(numDeltaFields);
   for (const auto& key: allkeys) {
     StateBase<Dimension>::splitFieldKey(key, dfKey, dfNodeListKey);
     if (dfNodeListKey == nodeListKey and

--- a/src/ExternalForce/NFWPotential.cc
+++ b/src/ExternalForce/NFWPotential.cc
@@ -126,7 +126,6 @@ dt(const DataBase<Dimension>& dataBase,
        ++nodeItr) {
     const Vector r = position(nodeItr) - mOrigin;
     const Scalar v = velocity(nodeItr).magnitude() + 1.0e-10;
-    const Vector runit = r.unitVector();
     const Scalar rsoft2 = r.magnitude2() + 1.0e-10;
     const Scalar rsoft = sqrt(rsoft2);
     const Scalar rsoft3 = rsoft*rsoft2;

--- a/src/FSISPH/SolidFSISPHEvaluateDerivatives.cc
+++ b/src/FSISPH/SolidFSISPHEvaluateDerivatives.cc
@@ -479,7 +479,6 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
         //---------------------------------------------------------------
         const auto rhoij = 0.5*(rhoi+rhoj); 
         const auto cij = 0.5*(ci+cj); 
-        const auto vij = vi - vj;
 
         // raw AV
         Q.QPiij(QPiij, QPiji, Qi, Qj,

--- a/src/FieldOperations/gradientMash.cc
+++ b/src/FieldOperations/gradientMash.cc
@@ -337,8 +337,6 @@ gradientMash2(const FieldList<Dimension, DataType>& fieldList,
           const Vector etaj = Hj*rij;
           const Scalar etaiMag = etai.magnitude();
           const Scalar etajMag = etaj.magnitude();
-          const Vector etaiNorm = etai.unitVector();
-          const Vector etajNorm = etaj.unitVector();
 
           // Get the symmetrized kernel gradient for this node pair.
           Scalar Wij;

--- a/src/FileIO/FileIOInline.hh
+++ b/src/FileIO/FileIOInline.hh
@@ -1,5 +1,6 @@
 #include "Geometry/GeomPlane.hh"
 #include "NodeList/NodeListRegistrar.hh"
+#include "Utilities/DBC.hh"
 #include "Utilities/DataTypeTraits.hh"
 #include "Field/FieldList.hh"
 
@@ -69,6 +70,7 @@ FileIO::read(FieldList<Dimension, DataType>& fieldList,
     // We need the NodeListRegistrar.
     const NodeListRegistrar<Dimension>& registrar = NodeListRegistrar<Dimension>::instance();
     const size_t numNodeLists = registrar.numNodeLists();
+    CONTRACT_VAR(numNodeLists);
     const std::vector<std::string> registeredNames = registrar.registeredNames();
 
     // Read the set of NodeLists this FieldList is associated with.

--- a/src/FileIO/PyFileIO.hh
+++ b/src/FileIO/PyFileIO.hh
@@ -33,7 +33,7 @@ public:
   virtual ~PyFileIO();
 
   // Check if the specified path is in the file.
-  virtual bool pathExists(const std::string) const override { VERIFY2(false, "pathExists not overridden"); }
+  virtual bool pathExists(const std::string) const override { VERIFY2(false, "pathExists not overridden"); return false; }
 
   //**************************************************************************
   // Descendent python objects can optionally override these disambiguated methods

--- a/src/FileIO/SiloFileIO.cc
+++ b/src/FileIO/SiloFileIO.cc
@@ -6,6 +6,7 @@
 #include "SiloFileIO.hh"
 #include "Field/Field.hh"
 
+#include "Utilities/DBC.hh"
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/replace.hpp"
 
@@ -90,6 +91,7 @@ string setdir(DBfile* filePtr, const string& ipath) {
 void writeInt(DBfile* filePtr, const int& value, const string path) {
   const string varname = setdir(filePtr, path);
   int dims[1] = {1};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(filePtr, varname.c_str(), &value, dims, 1, DB_INT) == 0,
           "SiloFileIO ERROR: unable to write int variable " << path);
 }
@@ -209,6 +211,7 @@ void
 SiloFileIO::write(const unsigned& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {1};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &value, dims, 1, DB_INT) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -220,6 +223,7 @@ void
 SiloFileIO::write(const size_t& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {1};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &value, dims, 1, DB_INT) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -240,6 +244,8 @@ SiloFileIO::write(const bool& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {1};
   int ivalue = value ? 1 : 0;
+  CONTRACT_VAR(dims);
+  CONTRACT_VAR(ivalue);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &ivalue, dims, 1, DB_INT) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -251,6 +257,7 @@ void
 SiloFileIO::write(const double& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {1};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &value, dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -273,6 +280,7 @@ SiloFileIO::write(const std::vector<int>& value, const string path) {
   if (size > 0) {
     const string varname = setdir(mFilePtr, path + "/value");
     int dims[1] = {size};
+    CONTRACT_VAR(dims);
     VERIFY2(DBWrite(mFilePtr, varname.c_str(), static_cast<void*>(const_cast<int*>(&value[0])), dims, 1, DB_INT) == 0,
             "SiloFileIO ERROR: unable to write std::vector " << path);
   }
@@ -288,6 +296,7 @@ SiloFileIO::write(const std::vector<double>& value, const string path) {
   if (size > 0) {
     const string varname = setdir(mFilePtr, path + "/value");
     int dims[1] = {size};
+    CONTRACT_VAR(dims);
     VERIFY2(DBWrite(mFilePtr, varname.c_str(), static_cast<void*>(const_cast<double*>(&value[0])), dims, 1, DB_DOUBLE) == 0,
             "SiloFileIO ERROR: unable to write std::vector " << path);
   }
@@ -316,6 +325,7 @@ void
 SiloFileIO::write(const Dim<1>::Vector& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<1>::Vector::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -327,6 +337,7 @@ void
 SiloFileIO::write(const Dim<1>::Tensor& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<1>::Tensor::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -338,6 +349,7 @@ void
 SiloFileIO::write(const Dim<1>::SymTensor& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<1>::SymTensor::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -349,6 +361,7 @@ void
 SiloFileIO::write(const Dim<1>::ThirdRankTensor& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<1>::ThirdRankTensor::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -360,6 +373,7 @@ void
 SiloFileIO::write(const Dim<2>::Vector& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<2>::Vector::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -371,6 +385,7 @@ void
 SiloFileIO::write(const Dim<2>::Tensor& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<2>::Tensor::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -382,6 +397,7 @@ void
 SiloFileIO::write(const Dim<2>::SymTensor& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<2>::SymTensor::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -393,6 +409,7 @@ void
 SiloFileIO::write(const Dim<2>::ThirdRankTensor& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<2>::ThirdRankTensor::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -404,6 +421,7 @@ void
 SiloFileIO::write(const Dim<3>::Vector& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<3>::Vector::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -415,6 +433,7 @@ void
 SiloFileIO::write(const Dim<3>::Tensor& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<3>::Tensor::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -426,6 +445,7 @@ void
 SiloFileIO::write(const Dim<3>::SymTensor& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<3>::SymTensor::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }
@@ -437,6 +457,7 @@ void
 SiloFileIO::write(const Dim<3>::ThirdRankTensor& value, const string path) {
   const string varname = setdir(mFilePtr, path);
   int dims[1] = {int(Dim<3>::ThirdRankTensor::numElements)};
+  CONTRACT_VAR(dims);
   VERIFY2(DBWrite(mFilePtr, varname.c_str(), &(*value.begin()), dims, 1, DB_DOUBLE) == 0,
           "SiloFileIO ERROR: unable to write variable " << path);
 }

--- a/src/GSPH/GSPHEvaluateDerivatives.cc
+++ b/src/GSPH/GSPHEvaluateDerivatives.cc
@@ -179,8 +179,6 @@ evaluateDerivatives(const typename Dimension::Scalar time,
       
       // Node displacement.
       const auto rij = ri - rj;
-      const auto rhatij =rij.unitVector();
-      const auto vij = vi - vj;
       const auto etai = Hi*rij;
       const auto etaj = Hj*rij;
       const auto etaMagi = etai.magnitude();

--- a/src/GSPH/MFMEvaluateDerivatives.cc
+++ b/src/GSPH/MFMEvaluateDerivatives.cc
@@ -179,9 +179,6 @@ evaluateDerivatives(const typename Dimension::Scalar time,
 
       // Node displacement.
       const auto rij = ri - rj;
-      const auto rhatij =rij.unitVector();
-      //const auto rMagij = rij.magnitude2();
-      const auto vij = vi - vj;
       const auto etai = Hi*rij;
       const auto etaj = Hj*rij;
       const auto etaMagi = etai.magnitude();

--- a/src/GSPH/MFVEvaluateDerivatives.cc
+++ b/src/GSPH/MFVEvaluateDerivatives.cc
@@ -215,10 +215,7 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
 
       // Node displacement.
       const auto rij = ri - rj;
-      //const auto rMagij = rij.magnitude();
-      //const auto rMagij2 = rij.magnitude2();
       const auto rhatij =rij.unitVector();
-      const auto vij = vi - vj;
       const auto etai = Hi*rij;
       const auto etaj = Hj*rij;
       const auto etaMagi = etai.magnitude();

--- a/src/GSPH/RiemannSolvers/SecondOrderArtificialViscosity.cc
+++ b/src/GSPH/RiemannSolvers/SecondOrderArtificialViscosity.cc
@@ -80,7 +80,6 @@ interfaceState(const typename Dimension::Vector& ri,
   const auto tiny = std::numeric_limits<Scalar>::epsilon();
 
   const Vector rij = ri - rj;
-  const Vector rhatij = rij.unitVector();
   const Vector etaij = 0.5*(Hi+Hj)*rij;
 
   // default to nodal values

--- a/src/Geometry/GeomFacet3d.cc
+++ b/src/Geometry/GeomFacet3d.cc
@@ -212,6 +212,8 @@ decompose(std::vector<std::array<Vector, 3>>& subfacets) const {
       CHECK(0 < subarea and subarea < originalArea);
       const auto subnormalUnit = subnormal.unitVector();
       const auto normalUnit = mNormal.unitVector();
+      CONTRACT_VAR(subnormalUnit);
+      CONTRACT_VAR(normalUnit);
       CHECK2(fuzzyEqual(subnormalUnit(0), normalUnit(0), 1.e-8) &&
              fuzzyEqual(subnormalUnit(1), normalUnit(1), 1.e-8) &&
              fuzzyEqual(subnormalUnit(2), normalUnit(2), 1.e-8), "Normal vector mismatch: " << subnormalUnit << " != " << normalUnit);

--- a/src/Geometry/GeomSymmetricTensor_default.cc
+++ b/src/Geometry/GeomSymmetricTensor_default.cc
@@ -187,6 +187,9 @@ GeomSymmetricTensor<3>::eigenVectors() const {
   const Vector v1 = result.eigenVectors.getColumn(0);
   const Vector v2 = result.eigenVectors.getColumn(1);
   const Vector v3 = result.eigenVectors.getColumn(2);
+  CONTRACT_VAR(v1);
+  CONTRACT_VAR(v2);
+  CONTRACT_VAR(v3);
   ENSURE2(fuzzyEqual(v1.dot(v2), 0.0, tolerance) and 
           fuzzyEqual(v1.dot(v3), 0.0, tolerance) and 
           fuzzyEqual(v2.dot(v3), 0.0, tolerance),

--- a/src/KernelIntegrator/FlatConnectivity.cc
+++ b/src/KernelIntegrator/FlatConnectivity.cc
@@ -207,6 +207,9 @@ computeOverlapIndices(const DataBase<Dimension>& dataBase) {
   const auto numNodeListsDB = dataBase.numFluidNodeLists();
   const auto numNodesDB = dataBase.numFluidNodes();
   const auto numInternalNodesDB = dataBase.numFluidInternalNodes();
+  CONTRACT_VAR(numNodeListsDB);
+  CONTRACT_VAR(numNodesDB);
+  CONTRACT_VAR(numInternalNodesDB);
   const auto& connectivity = dataBase.connectivityMap();
   const auto requireGhostConnectivity = connectivity.buildGhostConnectivity();
   VERIFY(connectivity.buildOverlapConnectivity());
@@ -319,6 +322,10 @@ computeGlobalIndices(const DataBase<Dimension>& dataBase,
   const auto numNodesDB = dataBase.numFluidNodes();
   const auto numInternalNodesDB = dataBase.numFluidInternalNodes();
   const auto numGlobalNodesDB = dataBase.globalNumFluidInternalNodes();
+  CONTRACT_VAR(numNodeListsDB);
+  CONTRACT_VAR(numNodesDB);
+  CONTRACT_VAR(numInternalNodesDB);
+  CONTRACT_VAR(numGlobalNodesDB);
 
   // Make sure number of nodes has not changed since computing indices
   VERIFY(numNodesDB == size_t(mNumLocalNodes));
@@ -401,6 +408,9 @@ computeSurfaceIndices(const DataBase<Dimension>& dataBase,
   const auto numNodeListsDB = dataBase.numFluidNodeLists();
   const auto numNodesDB = dataBase.numFluidNodes();
   const auto numInternalNodesDB = dataBase.numFluidInternalNodes();
+  CONTRACT_VAR(numNodeListsDB);
+  CONTRACT_VAR(numNodesDB);
+  CONTRACT_VAR(numInternalNodesDB);
   const auto& connectivity = dataBase.connectivityMap();
   const auto cells = state.fields(HydroFieldNames::cells, FacetedVolume());
   const auto cellFaceFlags = state.fields(HydroFieldNames::cellFaceFlags, std::vector<CellFaceFlag>());
@@ -549,6 +559,9 @@ computeBoundaryInformation(const DataBase<Dimension>& dataBase,
   const auto numNodeListsDB = dataBase.numFluidNodeLists();
   const auto numNodesDB = dataBase.numFluidNodes();
   const auto numInternalNodesDB = dataBase.numFluidInternalNodes();
+  CONTRACT_VAR(numNodeListsDB);
+  CONTRACT_VAR(numNodesDB);
+  CONTRACT_VAR(numInternalNodesDB);
 
   // Make sure the sizes haven't changed since the indexing was initialized
   VERIFY(numNodesDB == size_t(mNumLocalNodes));

--- a/src/KernelIntegrator/KernelIntegrator.cc
+++ b/src/KernelIntegrator/KernelIntegrator.cc
@@ -153,11 +153,11 @@ performIntegration() {
     const auto pairi = mFlatConnectivity.localToNode(i);
     const auto nodeListi = pairi.first;
     const auto nodei = pairi.second;
-#if REPLACEOVERLAP
-    const auto xi = position(nodeListi, nodei);
-    // const auto volumei = volume(nodeListi, nodei);
-    // const auto deltai = std::pow(volumei, 1. / Dimension::nDim); // An approximation of cell length
-#endif
+// #if REPLACEOVERLAP
+//     const auto xi = position(nodeListi, nodei);
+//     const auto volumei = volume(nodeListi, nodei);
+//     const auto deltai = std::pow(volumei, 1. / Dimension::nDim); // An approximation of cell length
+// #endif
     const auto& cell = cells(nodeListi, nodei);
     
     // Get the number of neighbors for the Voronoi integration region

--- a/src/KernelIntegrator/KernelIntegrator.cc
+++ b/src/KernelIntegrator/KernelIntegrator.cc
@@ -89,6 +89,7 @@ performIntegration() {
   // Get some data out of database and state
   VERIFY(mState);
   const auto numNodeLists = mDataBase.numFluidNodeLists();
+  CONTRACT_VAR(numNodeLists);
   const auto position = mState->fields(HydroFieldNames::position, Vector::zero);
   const auto H = mState->fields(HydroFieldNames::H, SymTensor::zero);
   const auto volume = mState->fields(HydroFieldNames::volume, 0.0);

--- a/src/Material/HelmholtzEquationOfState.hh
+++ b/src/Material/HelmholtzEquationOfState.hh
@@ -77,30 +77,30 @@ public:
           
   // Some of the following methods are disabled
   virtual Scalar pressure(const Scalar /*massDensity*/,
-                          const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); }
+                          const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); return 0; }
           
   virtual Scalar temperature(const Scalar /*massDensity*/,
-                             const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); }
+                             const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); return 0; }
           
   virtual Scalar specificThermalEnergy(const Scalar /*massDensity*/,
-                                       const Scalar /*temperature*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); }
+                                       const Scalar /*temperature*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); return 0; }
           
   virtual Scalar specificHeat(const Scalar /*massDensity*/,
-                              const Scalar /*temperature*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); }
+                              const Scalar /*temperature*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); return 0; }
           
   virtual Scalar soundSpeed(const Scalar /*massDensity*/,
-                            const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); }
+                            const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); return 0; }
           
   // Get the effective gamma (ratio of specific heats) for this eos.
   virtual Scalar gamma(const Scalar /*massDensity*/,
-                       const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); }
+                       const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); return 0; }
           
   // Get the bulk modulus.
   virtual Scalar bulkModulus(const Scalar /*massDensity*/,
-                             const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); }
+                             const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); return 0; }
           
   virtual Scalar entropy(const Scalar /*massDensity*/,
-                         const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); }
+                         const Scalar /*specificThermalEnergy*/) const { VERIFY2(false, "HelmholtzEquationOfState does not support individual state calls."); return 0; }
 
           
   const Field<Dimension, Scalar>& abar() const;

--- a/src/Mesh/generateMesh.cc
+++ b/src/Mesh/generateMesh.cc
@@ -45,6 +45,7 @@ generateMesh(const NodeListIterator nodeListBegin,
 
   // The total number of NodeLists we're working on.
   const size_t numNodeLists = distance(nodeListBegin, nodeListEnd);
+  CONTRACT_VAR(numNodeLists);
   const unsigned voidOffset = distance(nodeListBegin, find(nodeListBegin, nodeListEnd, &voidNodes));
 
   // Pre-conditions.

--- a/src/Neighbor/PairwiseFieldInline.hh
+++ b/src/Neighbor/PairwiseFieldInline.hh
@@ -33,20 +33,22 @@ template<typename Dimension, typename Value, size_t numElements>
 inline
 typename PairwiseField<Dimension, Value, numElements>::const_reference
 PairwiseField<Dimension, Value, numElements>::operator()(const NodePairIdxType& x) const {
-  if (auto p = mPairsPtr.lock()) {
-    return Accessor::at(mValues, p->index(x));
+  auto p = mPairsPtr.lock();
+  if (!p) {
+    VERIFY2(false, "PairwiseField ERROR: attempt to index with invalid pair " << x);
   }
-  VERIFY2(false, "PairwiseField ERROR: attempt to index with invalid pair " << x);
+  return Accessor::at(mValues, p->index(x));
 }
 
 template<typename Dimension, typename Value, size_t numElements>
 inline
 typename PairwiseField<Dimension, Value, numElements>::reference
 PairwiseField<Dimension, Value, numElements>::operator()(const NodePairIdxType& x) {
-  if (auto p = mPairsPtr.lock()) {
-    return Accessor::at(mValues, p->index(x));
+  auto p = mPairsPtr.lock();
+  if (!p) {
+    VERIFY2(false, "PairwiseField ERROR: attempt to index with invalid pair " << x);
   }
-  VERIFY2(false, "PairwiseField ERROR: attempt to index with invalid pair " << x);
+  return Accessor::at(mValues, p->index(x));
 }
 
 //------------------------------------------------------------------------------
@@ -56,10 +58,11 @@ template<typename Dimension, typename Value, size_t numElements>
 inline
 const NodePairList&
 PairwiseField<Dimension, Value, numElements>::pairs() const {
-  if (auto p = mPairsPtr.lock()) {
-    return *p;
+  auto p = mPairsPtr.lock();
+  if (!p) {
+    VERIFY2(false, "Orphaned PairwiseField without NodePairList");
   }
-  VERIFY2(false, "Orphaned PairwiseField without NodePairList");
+  return *p;
 }
 
 }

--- a/src/NodeGenerators/compactFacetedVolumes.cc
+++ b/src/NodeGenerators/compactFacetedVolumes.cc
@@ -213,7 +213,6 @@ unsigned compactFacetedVolumes(std::vector<typename Dimension::FacetedVolume>& s
                   shapej = shapes[j] + centers[j];
                 }
                 if (shapei.intersect(shapej)) {
-                  const Vector centj = shapej.centroid();
                   const double Rj = radius[j];
                   auto overlap = max(0.0, (Ri + Rj - (shapei.centroid() - shapej.centroid()).magnitude())/(Ri + Rj));
 

--- a/src/PYB11/Silo/SiloWrappers.hh
+++ b/src/PYB11/Silo/SiloWrappers.hh
@@ -547,6 +547,7 @@ std::string
 DBGetDir(DBfile& file) {
   char result[256];
   auto valid = DBGetDir(&file, result);
+  CONTRACT_VAR(valid);
   VERIFY2(valid == 0, "Silo ERROR: unable to fetch directory name.");
   return std::string(result);
 }
@@ -893,7 +894,10 @@ DBPutUcdmesh(DBfile& file,
   const unsigned ndims = coords.size();
   VERIFY(ndims == 2 or ndims == 3);
   const unsigned nnodes = coords[0].size();
-  for (unsigned idim = 0; idim != ndims; ++idim) VERIFY(coords[idim].size() == nnodes);
+  for (unsigned idim = 0; idim != ndims; ++idim) {
+    CONTRACT_VAR(idim);
+    VERIFY(coords[idim].size() == nnodes);
+  }
   VERIFY(nzones > 0);
 
   // We need the C-stylish pointers to the coordinates.

--- a/src/RK/computeHullVolume.cc
+++ b/src/RK/computeHullVolume.cc
@@ -296,8 +296,6 @@ computeHullVolume(const FieldList<Dimension, typename Dimension::Vector>& positi
 #pragma omp parallel for
       for (auto i = 0u; i < n; ++i) {
         const auto& ri = position(nodeListi, i);
-        const auto& Hi = H(nodeListi, i);
-        const auto  Hinv = Hi.Inverse();
 
         // Build the set of inverse positions in eta space about this point (including itself as the origin)
         vector<Vector> invPositions = {Vector::zero};

--- a/src/SVPH/computeSVPHCorrections.cc
+++ b/src/SVPH/computeSVPHCorrections.cc
@@ -163,7 +163,7 @@ computeSVPHCorrections(const ConnectivityMap<Dimension>& connectivityMap,
       Scalar Wi, gWi, Wj, gWj;
       W.kernelAndGradValue(etai.magnitude(), Hdeti, Wi, gWi);
       W.kernelAndGradValue(etaj.magnitude(), Hdetj, Wj, gWj);
-      const Vector gradWi = -(Hi*etai.unitVector())*gWi;
+      //const Vector gradWi = -(Hi*etai.unitVector())*gWi;
       const Vector gradWj =  (Hj*etaj.unitVector())*gWj;
 
       // Normalization.

--- a/src/Utilities/AnyVisitor.hh
+++ b/src/Utilities/AnyVisitor.hh
@@ -20,10 +20,10 @@ public:
   template<typename T, typename... EXTRAARGS>
   RETURNT visit(T value, EXTRAARGS&&... extraargs) const  {
     auto it = mVisitors.find(std::type_index(value.type()));
-    if (it != mVisitors.end()) {
-      return it->second(value, extraargs...);
+    if (it == mVisitors.end()) {
+      VERIFY2(false, "AnyVisitor ERROR: unable to process unknown data type " << std::quoted(value.type().name()));
     }
-    VERIFY2(false, "AnyVisitor ERROR: unable to process unknown data type " << std::quoted(value.type().name()));
+    return it->second(value, extraargs...);
   }
 
   template<typename T>

--- a/src/Utilities/bisectRoot.hh
+++ b/src/Utilities/bisectRoot.hh
@@ -70,6 +70,7 @@ bisectRoot(const Function& functor,
 
   VERIFY2(false, "bisectRoot: failed to converge!");
 
+  return 0;
 }
 
 }

--- a/src/Utilities/computeShepardsInterpolation.cc
+++ b/src/Utilities/computeShepardsInterpolation.cc
@@ -35,14 +35,11 @@ computeShepardsInterpolation(const FieldList<Dimension, DataType>& fieldList,
 
   typedef typename Dimension::Scalar Scalar;
   typedef typename Dimension::Vector Vector;
-  typedef typename Dimension::Tensor Tensor;
 
   // Some scratch variables.
   size_t nodeListi, nodeListj;
   Scalar Wi, Wj;
   Vector rij, etai, etaj;
-  Vector Bi = Vector::zero, Bj = Vector::zero;
-  Tensor Ci = Tensor::zero, Cj = Tensor::zero;
 
   // Prepare the return value.
   FieldList<Dimension, DataType> result(FieldStorageType::CopyFields);

--- a/src/Utilities/integrateThroughMeshAlongSegment.cc
+++ b/src/Utilities/integrateThroughMeshAlongSegment.cc
@@ -156,6 +156,7 @@ findIntersections(const Dim<2>::Vector& xmin,
   BEGIN_CONTRACT_SCOPE
   {
     const Vector shat = (s1 - s0).unitVector();
+    CONTRACT_VAR(shat);
     const double segLen = (s1 - s0).magnitude();
     for (vector<Vector>::const_iterator itr = result.begin();
 	 itr != result.end();
@@ -242,6 +243,7 @@ findIntersections(const Dim<3>::Vector& xmin,
   BEGIN_CONTRACT_SCOPE
   {
     const Vector shat = (s1 - s0).unitVector();
+    CONTRACT_VAR(shat);
     const double segLen = (s1 - s0).magnitude();
     for (vector<Vector>::const_iterator itr = result.begin();
 	 itr != result.end();

--- a/src/Utilities/lineSegmentIntersections.hh
+++ b/src/Utilities/lineSegmentIntersections.hh
@@ -236,7 +236,6 @@ double
 segmentSegmentIntersectionTester<Dim<3>::Vector>::
 area2(const Dim<3>::Vector& a, const Dim<3>::Vector& b, const Dim<3>::Vector& c) const {
   typedef Dim<3>::Vector Vector;
-  const Vector ba = b - a;
   const Vector ca = c - a;
   const Vector norm = (b - a).cross(c - a);
   const Vector nhat = norm.unitVector();

--- a/src/Utilities/newtonRaphson.hh
+++ b/src/Utilities/newtonRaphson.hh
@@ -93,6 +93,7 @@ newtonRaphson(const Function& functor,
 
   VERIFY2(false, "newtonRaphson: failed to converge!");
 
+  return 0;
 }
 
 }

--- a/src/Utilities/peanoHilbertOrderIndices.cc
+++ b/src/Utilities/peanoHilbertOrderIndices.cc
@@ -438,7 +438,6 @@ peanoHilbertOrderIndices(const FieldList<Dimension, typename Dimension::Vector>&
   // Get the bounding box and step sizes.
   Vector xmin, xmax;
   globalBoundingBox(positions, xmin, xmax, true);
-  const Vector stepSize = (xmax - xmin)/KeyTraits::maxKey1d;
 
   // Go over all nodes and hash each position.
   for (AllNodeIterator<Dimension> nodeItr = positions.nodeBegin();

--- a/src/VoronoiCells/computeVoronoiVolume.cc
+++ b/src/VoronoiCells/computeVoronoiVolume.cc
@@ -520,15 +520,11 @@ computeVoronoiVolume(const FieldList<Dimension, typename Dimension::Vector>& pos
 
         // State of node i
         const auto& ri = position(nodeListi, i);
-        const auto& Hi = H(nodeListi, i);
-        const auto  Hinv = Hi.Inverse();
         const auto  weighti = haveWeights ? weight(nodeListi, i) : 1.0;
         auto&       pairPlanesi = pairPlanes_thread(nodeListi, i);
 
         // State of node j
         const auto& rj = position(nodeListj, j);
-        const auto& Hj = H(nodeListj, j);
-        const auto  Hjnv = Hj.Inverse();
         const auto  weightj = haveWeights ? weight(nodeListj, j) : 1.0;
         auto&       pairPlanesj = pairPlanes_thread(nodeListj, j);
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix and a requirement to merging #370 .
- It seems the rocmcc gpu compiler pass gets fussy about some unused variable warnings. These warning squash changes help to clean up and make #370 pass.

- Variables were commented out if they were referenced in a later commented block of code.
- Variables were deleted if there was no further mention of the variable name in the scope.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. ([PR#](https://rzlc.llnl.gov/gitlab/owen/LLNLSpheral/-/merge_requests/156))
- [x] LLNLSpheral PR has passed all tests.

