### PR TITLE
[GPU] Geom(Sym)Tensor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ Notable changes include:
     * RankNTensor (Third, Fourth, Fifth) have been refactored to execute on the GPU.
     * Optimizations to RankTensor types:
       * Stack allocation of tensor data; Static casting for CRTP implementation.
+    * GeomTensor & GeomSymmetricTensor have been refactored for use on the GPU.
     * New Logging utility for runtime debug messages.
 
   * Build changes / improvements:

--- a/src/Geometry/EigenStruct.hh
+++ b/src/Geometry/EigenStruct.hh
@@ -8,6 +8,8 @@
 #define __Spheral_EigenStruct_hh__
 
 #include <iostream>
+
+#include "config.hh"
 #include "Geometry/GeomVector_fwd.hh"
 #include "Geometry/GeomTensor_fwd.hh"
 #include "Geometry/GeomSymmetricTensor_fwd.hh"
@@ -20,12 +22,12 @@ struct EigenStruct {
   GeomVector<nDim> eigenValues;
   GeomTensor<nDim> eigenVectors;
 
-  EigenStruct() {}
-  EigenStruct(const EigenStruct& rhs):
+  SPHERAL_HOST_DEVICE EigenStruct() {}
+  SPHERAL_HOST_DEVICE EigenStruct(const EigenStruct& rhs):
     eigenValues(rhs.eigenValues),
     eigenVectors(rhs.eigenVectors) {
   }
-  EigenStruct& operator=(const EigenStruct& rhs) {
+  SPHERAL_HOST_DEVICE EigenStruct& operator=(const EigenStruct& rhs) {
     if (this != &rhs) {
       eigenValues = rhs.eigenValues;
       eigenVectors = rhs.eigenVectors;

--- a/src/Geometry/EigenStruct.hh
+++ b/src/Geometry/EigenStruct.hh
@@ -21,19 +21,6 @@ template<int nDim>
 struct EigenStruct {
   GeomVector<nDim> eigenValues;
   GeomTensor<nDim> eigenVectors;
-
-  SPHERAL_HOST_DEVICE EigenStruct() {}
-  SPHERAL_HOST_DEVICE EigenStruct(const EigenStruct& rhs):
-    eigenValues(rhs.eigenValues),
-    eigenVectors(rhs.eigenVectors) {
-  }
-  SPHERAL_HOST_DEVICE EigenStruct& operator=(const EigenStruct& rhs) {
-    if (this != &rhs) {
-      eigenValues = rhs.eigenValues;
-      eigenVectors = rhs.eigenVectors;
-    }
-    return *this;
-  }
 };
 
 // Forward declarations.

--- a/src/Geometry/GeomSymmetricTensorBase.hh
+++ b/src/Geometry/GeomSymmetricTensorBase.hh
@@ -19,9 +19,8 @@ class GeomSymmetricTensorBase<1> {
   SPHERAL_HOST_DEVICE GeomSymmetricTensorBase(const double xx):
     mxx(xx) {}
  protected:
-  double mxx;
- private:
-  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase();
+  double mxx = 0.0;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase() = default;
 };
 
 template<>
@@ -37,10 +36,10 @@ class GeomSymmetricTensorBase<2> {
     mxy(xy),
     myy(yy) {}
  protected:
-  double mxx, mxy,
-              myy;
- private:
-  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase();
+  double mxx = 0.0;
+  double mxy = 0.0;
+  double myy = 0.0;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase() = default;
 };
 
 template<>
@@ -63,11 +62,13 @@ class GeomSymmetricTensorBase<3> {
     myz(yz),
     mzz(zz) {}
  protected:
-  double mxx, mxy, mxz,
-              myy, myz,
-                   mzz;
- private:
-  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase();
+  double mxx = 0.0;
+  double mxy = 0.0;
+  double mxz = 0.0;
+  double myy = 0.0;
+  double myz = 0.0;
+  double mzz = 0.0;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase() = default;
 };
 
 }

--- a/src/Geometry/GeomSymmetricTensorBase.hh
+++ b/src/Geometry/GeomSymmetricTensorBase.hh
@@ -7,6 +7,8 @@
 #ifndef __Spheral__GeomSymmetricTensorBase__
 #define __Spheral__GeomSymmetricTensorBase__
 
+#include "config.hh"
+
 namespace Spheral {
 
 template<int nDim> class GeomSymmetricTensorBase {};
@@ -14,23 +16,23 @@ template<int nDim> class GeomSymmetricTensorBase {};
 template<>
 class GeomSymmetricTensorBase<1> {
  public:
-  GeomSymmetricTensorBase(const double xx):
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase(const double xx):
     mxx(xx) {}
  protected:
   double mxx;
  private:
-  GeomSymmetricTensorBase();
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase();
 };
 
 template<>
 class GeomSymmetricTensorBase<2> {
  public:
-  GeomSymmetricTensorBase(const double a):
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase(const double a):
     mxx(a),
     mxy(a),
     myy(a) {}
-  GeomSymmetricTensorBase(const double xx, const double xy,
-                                           const double yy):
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase(const double xx, const double xy,
+                                                               const double yy):
     mxx(xx),
     mxy(xy),
     myy(yy) {}
@@ -38,22 +40,22 @@ class GeomSymmetricTensorBase<2> {
   double mxx, mxy,
               myy;
  private:
-  GeomSymmetricTensorBase();
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase();
 };
 
 template<>
 class GeomSymmetricTensorBase<3> {
  public:
-  GeomSymmetricTensorBase(const double a):
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase(const double a):
     mxx(a),
     mxy(a),
     mxz(a),
     myy(a),
     myz(a),
     mzz(a) {}
-  GeomSymmetricTensorBase(const double xx, const double xy, const double xz,
-                                           const double yy, const double yz,
-                                                            const double zz):
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase(const double xx, const double xy, const double xz,
+                                                               const double yy, const double yz,
+                                                                                const double zz):
     mxx(xx),
     mxy(xy),
     mxz(xz),
@@ -65,7 +67,7 @@ class GeomSymmetricTensorBase<3> {
               myy, myz,
                    mzz;
  private:
-  GeomSymmetricTensorBase();
+  SPHERAL_HOST_DEVICE GeomSymmetricTensorBase();
 };
 
 }

--- a/src/Geometry/GeomSymmetricTensorInline_default.hh
+++ b/src/Geometry/GeomSymmetricTensorInline_default.hh
@@ -14,6 +14,7 @@ namespace Spheral {
 // Return the element index corresponding to the given (row,column)
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>::size_type
 GeomSymmetricTensor<1>::elementIndex(const GeomSymmetricTensor<1>::size_type row,
@@ -26,6 +27,7 @@ GeomSymmetricTensor<1>::elementIndex(const GeomSymmetricTensor<1>::size_type row
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>::size_type
 GeomSymmetricTensor<2>::elementIndex(const GeomSymmetricTensor<2>::size_type row,
@@ -40,6 +42,7 @@ GeomSymmetricTensor<2>::elementIndex(const GeomSymmetricTensor<2>::size_type row
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>::size_type
 GeomSymmetricTensor<3>::elementIndex(const GeomSymmetricTensor<3>::size_type row,
@@ -57,6 +60,7 @@ GeomSymmetricTensor<3>::elementIndex(const GeomSymmetricTensor<3>::size_type row
 // Default constructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>::
 GeomSymmetricTensor():
@@ -67,6 +71,7 @@ GeomSymmetricTensor():
 // Construct with the given values for the elements.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>::
 GeomSymmetricTensor(const double a11):
@@ -74,6 +79,7 @@ GeomSymmetricTensor(const double a11):
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>::
 GeomSymmetricTensor(const double a11, const double a12, 
@@ -85,6 +91,7 @@ GeomSymmetricTensor(const double a11, const double a12,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>::
 GeomSymmetricTensor(const double a11, const double a12, const double a13,
@@ -106,6 +113,7 @@ GeomSymmetricTensor(const double a11, const double a12, const double a13,
 // dimensions.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>::
 GeomSymmetricTensor(const double /*a11*/, const double /*a12*/,
@@ -115,6 +123,7 @@ GeomSymmetricTensor(const double /*a11*/, const double /*a12*/,
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>::
 GeomSymmetricTensor(const double /*a11*/, const double /*a12*/, const double /*a13*/,
@@ -128,6 +137,7 @@ GeomSymmetricTensor(const double /*a11*/, const double /*a12*/, const double /*a
 // Copy constructors.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>::
 GeomSymmetricTensor(const GeomSymmetricTensor<nDim>& ten):
@@ -135,6 +145,7 @@ GeomSymmetricTensor(const GeomSymmetricTensor<nDim>& ten):
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>::
 GeomSymmetricTensor(const GeomTensor<1>& ten):
@@ -142,6 +153,7 @@ GeomSymmetricTensor(const GeomTensor<1>& ten):
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>::
 GeomSymmetricTensor(const GeomTensor<2>& ten):
@@ -151,6 +163,7 @@ GeomSymmetricTensor(const GeomTensor<2>& ten):
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>::
 GeomSymmetricTensor(const GeomTensor<3>& ten):
@@ -190,6 +203,7 @@ GeomSymmetricTensor<3>::GeomSymmetricTensor(const Eigen::MatrixBase<Derived>& te
 // Destructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>::~GeomSymmetricTensor() {
 }
@@ -198,6 +212,7 @@ GeomSymmetricTensor<nDim>::~GeomSymmetricTensor() {
 // Assignment operators.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>&
 GeomSymmetricTensor<1>::
@@ -207,6 +222,7 @@ operator=(const GeomTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>&
 GeomSymmetricTensor<2>::
@@ -219,6 +235,7 @@ operator=(const GeomTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>&
 GeomSymmetricTensor<3>::
@@ -233,6 +250,7 @@ operator=(const GeomTensor<3>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>&
 GeomSymmetricTensor<1>::
@@ -242,6 +260,7 @@ operator=(const GeomSymmetricTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>&
 GeomSymmetricTensor<2>::
@@ -253,6 +272,7 @@ operator=(const GeomSymmetricTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>&
 GeomSymmetricTensor<3>::
@@ -307,6 +327,7 @@ GeomSymmetricTensor<3>::operator=(const Eigen::MatrixBase<Derived>& ten) {
 // Access the elements by indicies.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::operator()(const typename GeomSymmetricTensor<nDim>::size_type row,
@@ -317,6 +338,7 @@ GeomSymmetricTensor<nDim>::operator()(const typename GeomSymmetricTensor<nDim>::
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double&
 GeomSymmetricTensor<nDim>::operator()(const typename GeomSymmetricTensor<nDim>::size_type row,
@@ -330,6 +352,7 @@ GeomSymmetricTensor<nDim>::operator()(const typename GeomSymmetricTensor<nDim>::
 // Return the (index) element using the bracket operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::operator[](typename GeomSymmetricTensor<nDim>::size_type index) const {
@@ -338,6 +361,7 @@ GeomSymmetricTensor<nDim>::operator[](typename GeomSymmetricTensor<nDim>::size_t
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double&
 GeomSymmetricTensor<nDim>::operator[](typename GeomSymmetricTensor<nDim>::size_type index) {
@@ -352,6 +376,7 @@ GeomSymmetricTensor<nDim>::operator[](typename GeomSymmetricTensor<nDim>::size_t
 //    zx, zy, zz     31, 32, 33
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::xx() const {
@@ -359,6 +384,7 @@ GeomSymmetricTensor<nDim>::xx() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::xy() const {
@@ -366,6 +392,7 @@ GeomSymmetricTensor<nDim>::xy() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::xz() const {
@@ -373,6 +400,7 @@ GeomSymmetricTensor<nDim>::xz() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::yx() const {
@@ -380,6 +408,7 @@ GeomSymmetricTensor<nDim>::yx() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::yy() const {
@@ -387,6 +416,7 @@ GeomSymmetricTensor<nDim>::yy() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::yz() const {
@@ -394,6 +424,7 @@ GeomSymmetricTensor<nDim>::yz() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::zx() const {
@@ -401,6 +432,7 @@ GeomSymmetricTensor<nDim>::zx() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::zy() const {
@@ -408,6 +440,7 @@ GeomSymmetricTensor<nDim>::zy() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<nDim>::zz() const {
@@ -416,27 +449,28 @@ GeomSymmetricTensor<nDim>::zz() const {
 
 //------------------------------------------------------------------------------
 // 1D dummy elements
-template<> inline double GeomSymmetricTensor<1>::xy() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<1>::xz() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<1>::yx() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<1>::yy() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<1>::yz() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<1>::zx() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<1>::zy() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<1>::zz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<1>::xy() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<1>::xz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<1>::yx() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<1>::yy() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<1>::yz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<1>::zx() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<1>::zy() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<1>::zz() const { return 0.0; }
 
 //------------------------------------------------------------------------------
 // 2D dummy elements
-template<> inline double GeomSymmetricTensor<2>::xz() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<2>::yz() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<2>::zx() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<2>::zy() const { return 0.0; }
-template<> inline double GeomSymmetricTensor<2>::zz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<2>::xz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<2>::yz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<2>::zx() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<2>::zy() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomSymmetricTensor<2>::zz() const { return 0.0; }
 
 //------------------------------------------------------------------------------
 // Set the individual elements, as above.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<nDim>::xx(const double val) {
@@ -444,6 +478,7 @@ GeomSymmetricTensor<nDim>::xx(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<nDim>::xy(const double val) {
@@ -451,6 +486,7 @@ GeomSymmetricTensor<nDim>::xy(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<nDim>::xz(const double val) {
@@ -458,6 +494,7 @@ GeomSymmetricTensor<nDim>::xz(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<nDim>::yx(const double val) {
@@ -465,6 +502,7 @@ GeomSymmetricTensor<nDim>::yx(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<nDim>::yy(const double val) {
@@ -472,6 +510,7 @@ GeomSymmetricTensor<nDim>::yy(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<nDim>::yz(const double val) {
@@ -479,6 +518,7 @@ GeomSymmetricTensor<nDim>::yz(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<nDim>::zx(const double val) {
@@ -486,6 +526,7 @@ GeomSymmetricTensor<nDim>::zx(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<nDim>::zy(const double val) {
@@ -493,6 +534,7 @@ GeomSymmetricTensor<nDim>::zy(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<nDim>::zz(double val) {
@@ -501,27 +543,28 @@ GeomSymmetricTensor<nDim>::zz(double val) {
 
 //------------------------------------------------------------------------------
 // 1D dummy elements
-template<> inline void GeomSymmetricTensor<1>::xy(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<1>::xz(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<1>::yx(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<1>::yy(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<1>::yz(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<1>::zx(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<1>::zy(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<1>::zz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<1>::xy(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<1>::xz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<1>::yx(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<1>::yy(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<1>::yz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<1>::zx(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<1>::zy(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<1>::zz(const double /*val*/) {}
 
 //------------------------------------------------------------------------------
 // 2D dummy elements
-template<> inline void GeomSymmetricTensor<2>::xz(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<2>::yz(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<2>::zx(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<2>::zy(const double /*val*/) {}
-template<> inline void GeomSymmetricTensor<2>::zz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<2>::xz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<2>::yz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<2>::zx(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<2>::zy(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomSymmetricTensor<2>::zz(const double /*val*/) {}
 
 //------------------------------------------------------------------------------
 // Access the individual rows of the GeomSymmetricTensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<1>
 GeomSymmetricTensor<1>::
@@ -531,6 +574,7 @@ getRow(const GeomSymmetricTensor<2>::size_type index) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<2>
 GeomSymmetricTensor<2>::
@@ -540,6 +584,7 @@ getRow(const GeomSymmetricTensor<2>::size_type index) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<3>
 GeomSymmetricTensor<3>::
@@ -552,6 +597,7 @@ getRow(const GeomSymmetricTensor<3>::size_type index) const {
 // Access the individual columns of the GeomSymmetricTensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<1>
 GeomSymmetricTensor<1>::
@@ -561,6 +607,7 @@ getColumn(const GeomSymmetricTensor<2>::size_type index) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<2>
 GeomSymmetricTensor<2>::
@@ -570,6 +617,7 @@ getColumn(const GeomSymmetricTensor<2>::size_type index) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<3>
 GeomSymmetricTensor<3>::
@@ -582,6 +630,7 @@ getColumn(const GeomSymmetricTensor<3>::size_type index) const {
 // Set a row of the GeomSymmetricTensor to a GeomVector.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<1>::
@@ -592,6 +641,7 @@ setRow(const GeomSymmetricTensor<1>::size_type index,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<2>::
@@ -603,6 +653,7 @@ setRow(const GeomSymmetricTensor<2>::size_type index,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<3>::
@@ -618,6 +669,7 @@ setRow(const GeomSymmetricTensor<3>::size_type index,
 // Set a column of the GeomSymmetricTensor to a GeomVector.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<1>::
@@ -628,6 +680,7 @@ setColumn(const GeomSymmetricTensor<1>::size_type index,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<2>::
@@ -639,6 +692,7 @@ setColumn(const GeomSymmetricTensor<2>::size_type index,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<3>::
@@ -654,6 +708,7 @@ setColumn(const GeomSymmetricTensor<3>::size_type index,
 // Iterators to the raw data.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 typename GeomSymmetricTensor<nDim>::iterator
 GeomSymmetricTensor<nDim>::begin() {
@@ -661,6 +716,7 @@ GeomSymmetricTensor<nDim>::begin() {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 typename GeomSymmetricTensor<nDim>::iterator
 GeomSymmetricTensor<nDim>::end() {
@@ -668,6 +724,7 @@ GeomSymmetricTensor<nDim>::end() {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 typename GeomSymmetricTensor<nDim>::const_iterator
 GeomSymmetricTensor<nDim>::begin() const{
@@ -675,6 +732,7 @@ GeomSymmetricTensor<nDim>::begin() const{
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 typename GeomSymmetricTensor<nDim>::const_iterator
 GeomSymmetricTensor<nDim>::end() const {
@@ -685,6 +743,7 @@ GeomSymmetricTensor<nDim>::end() const {
 // Zero out the GeomSymmetricTensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<1>::Zero() {
@@ -692,6 +751,7 @@ GeomSymmetricTensor<1>::Zero() {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<2>::Zero() {
@@ -700,6 +760,7 @@ GeomSymmetricTensor<2>::Zero() {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<3>::Zero() {
@@ -713,6 +774,7 @@ GeomSymmetricTensor<3>::Zero() {
 // Force the tensor to be the identity tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<1>::Identity() {
@@ -720,6 +782,7 @@ GeomSymmetricTensor<1>::Identity() {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<2>::Identity() {
@@ -728,6 +791,7 @@ GeomSymmetricTensor<2>::Identity() {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<3>::Identity() {
@@ -740,6 +804,7 @@ GeomSymmetricTensor<3>::Identity() {
 // Return the negative of a tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>
 GeomSymmetricTensor<1>::operator-() const {
@@ -749,6 +814,7 @@ GeomSymmetricTensor<1>::operator-() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>
 GeomSymmetricTensor<2>::operator-() const {
@@ -760,6 +826,7 @@ GeomSymmetricTensor<2>::operator-() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>
 GeomSymmetricTensor<3>::operator-() const {
@@ -777,6 +844,7 @@ GeomSymmetricTensor<3>::operator-() const {
 // Add two tensors.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomSymmetricTensor<nDim>::
@@ -787,6 +855,7 @@ operator+(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>
 GeomSymmetricTensor<nDim>::
@@ -800,6 +869,7 @@ operator+(const GeomSymmetricTensor<nDim>& rhs) const {
 // Subtract a tensor from another.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomSymmetricTensor<nDim>::
@@ -810,6 +880,7 @@ operator-(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>
 GeomSymmetricTensor<nDim>::
@@ -823,6 +894,7 @@ operator-(const GeomSymmetricTensor<nDim>& rhs) const {
 // Multiply two tensors.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomSymmetricTensor<nDim>::
@@ -831,6 +903,7 @@ operator*(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomSymmetricTensor<nDim>::
@@ -842,6 +915,7 @@ operator*(const GeomSymmetricTensor<nDim>& rhs) const {
 // Multiply a tensor with a vector.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<nDim>
 GeomSymmetricTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
@@ -852,6 +926,7 @@ GeomSymmetricTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // // Add a scalar to a tensor.
 // //------------------------------------------------------------------------------
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<1>
 // GeomSymmetricTensor<1>::operator+(const double rhs) const {
@@ -859,6 +934,7 @@ GeomSymmetricTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<2>
 // GeomSymmetricTensor<2>::operator+(const double rhs) const {
@@ -870,6 +946,7 @@ GeomSymmetricTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<3>
 // GeomSymmetricTensor<3>::operator+(const double rhs) const {
@@ -887,6 +964,7 @@ GeomSymmetricTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // // Subtract a scalar from a tensor.
 // //------------------------------------------------------------------------------
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<1>
 // GeomSymmetricTensor<1>::operator-(const double rhs) const {
@@ -894,6 +972,7 @@ GeomSymmetricTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<2>
 // GeomSymmetricTensor<2>::operator-(const double rhs) const {
@@ -905,6 +984,7 @@ GeomSymmetricTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<3>
 // GeomSymmetricTensor<3>::operator-(const double rhs) const {
@@ -922,6 +1002,7 @@ GeomSymmetricTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // Multiply a tensor by a scalar
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>
 GeomSymmetricTensor<1>::operator*(const double rhs) const {
@@ -929,6 +1010,7 @@ GeomSymmetricTensor<1>::operator*(const double rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>
 GeomSymmetricTensor<2>::operator*(const double rhs) const {
@@ -940,6 +1022,7 @@ GeomSymmetricTensor<2>::operator*(const double rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>
 GeomSymmetricTensor<3>::operator*(const double rhs) const {
@@ -957,6 +1040,7 @@ GeomSymmetricTensor<3>::operator*(const double rhs) const {
 // Divide a tensor by a scalar
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>
 GeomSymmetricTensor<1>::operator/(const double rhs) const {
@@ -965,6 +1049,7 @@ GeomSymmetricTensor<1>::operator/(const double rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>
 GeomSymmetricTensor<2>::operator/(const double rhs) const {
@@ -978,6 +1063,7 @@ GeomSymmetricTensor<2>::operator/(const double rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>
 GeomSymmetricTensor<3>::operator/(const double rhs) const {
@@ -997,6 +1083,7 @@ GeomSymmetricTensor<3>::operator/(const double rhs) const {
 // += symmetric tensor
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>&
 GeomSymmetricTensor<1>::operator+=(const GeomSymmetricTensor<1>& rhs) {
@@ -1005,6 +1092,7 @@ GeomSymmetricTensor<1>::operator+=(const GeomSymmetricTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>&
 GeomSymmetricTensor<2>::operator+=(const GeomSymmetricTensor<2>& rhs) {
@@ -1015,6 +1103,7 @@ GeomSymmetricTensor<2>::operator+=(const GeomSymmetricTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>&
 GeomSymmetricTensor<3>::operator+=(const GeomSymmetricTensor<3>& rhs) {
@@ -1031,6 +1120,7 @@ GeomSymmetricTensor<3>::operator+=(const GeomSymmetricTensor<3>& rhs) {
 // -= symmetric tensor
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>&
 GeomSymmetricTensor<1>::operator-=(const GeomSymmetricTensor<1>& rhs) {
@@ -1039,6 +1129,7 @@ GeomSymmetricTensor<1>::operator-=(const GeomSymmetricTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>&
 GeomSymmetricTensor<2>::operator-=(const GeomSymmetricTensor<2>& rhs) {
@@ -1049,6 +1140,7 @@ GeomSymmetricTensor<2>::operator-=(const GeomSymmetricTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>&
 GeomSymmetricTensor<3>::operator-=(const GeomSymmetricTensor<3>& rhs) {
@@ -1147,6 +1239,7 @@ GeomSymmetricTensor<3>::operator-=(const Eigen::MatrixBase<Derived>& rhs) {
 // // Add a scalar to this tensor in place.
 // //------------------------------------------------------------------------------
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<1>&
 // GeomSymmetricTensor<1>::operator+=(const double rhs) {
@@ -1155,6 +1248,7 @@ GeomSymmetricTensor<3>::operator-=(const Eigen::MatrixBase<Derived>& rhs) {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<2>&
 // GeomSymmetricTensor<2>::operator+=(const double rhs) {
@@ -1165,6 +1259,7 @@ GeomSymmetricTensor<3>::operator-=(const Eigen::MatrixBase<Derived>& rhs) {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<3>&
 // GeomSymmetricTensor<3>::operator+=(const double rhs) {
@@ -1181,6 +1276,7 @@ GeomSymmetricTensor<3>::operator-=(const Eigen::MatrixBase<Derived>& rhs) {
 // // Subtract a scalar from this tensor in place.
 // //------------------------------------------------------------------------------
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<1>&
 // GeomSymmetricTensor<1>::operator-=(const double rhs) {
@@ -1189,6 +1285,7 @@ GeomSymmetricTensor<3>::operator-=(const Eigen::MatrixBase<Derived>& rhs) {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<2>&
 // GeomSymmetricTensor<2>::operator-=(const double rhs) {
@@ -1199,6 +1296,7 @@ GeomSymmetricTensor<3>::operator-=(const Eigen::MatrixBase<Derived>& rhs) {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomSymmetricTensor<3>&
 // GeomSymmetricTensor<3>::operator-=(const double rhs) {
@@ -1215,6 +1313,7 @@ GeomSymmetricTensor<3>::operator-=(const Eigen::MatrixBase<Derived>& rhs) {
 // Multiply this tensor by a scalar in place.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>&
 GeomSymmetricTensor<1>::operator*=(const double rhs) {
@@ -1223,6 +1322,7 @@ GeomSymmetricTensor<1>::operator*=(const double rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>&
 GeomSymmetricTensor<2>::operator*=(const double rhs) {
@@ -1233,6 +1333,7 @@ GeomSymmetricTensor<2>::operator*=(const double rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>&
 GeomSymmetricTensor<3>::operator*=(const double rhs) {
@@ -1249,6 +1350,7 @@ GeomSymmetricTensor<3>::operator*=(const double rhs) {
 // Divide this tensor by a scalar in place
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>&
 GeomSymmetricTensor<1>::operator/=(const double rhs) {
@@ -1258,6 +1360,7 @@ GeomSymmetricTensor<1>::operator/=(const double rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>&
 GeomSymmetricTensor<2>::operator/=(const double rhs) {
@@ -1270,6 +1373,7 @@ GeomSymmetricTensor<2>::operator/=(const double rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>&
 GeomSymmetricTensor<3>::operator/=(const double rhs) {
@@ -1288,6 +1392,7 @@ GeomSymmetricTensor<3>::operator/=(const double rhs) {
 // Define the equivalence operator.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<1>::
@@ -1296,6 +1401,7 @@ operator==(const GeomTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<2>::
@@ -1307,6 +1413,7 @@ operator==(const GeomTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<3>::
@@ -1323,6 +1430,7 @@ operator==(const GeomTensor<3>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<1>::
@@ -1331,6 +1439,7 @@ operator==(const GeomSymmetricTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<2>::
@@ -1341,6 +1450,7 @@ operator==(const GeomSymmetricTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<3>::
@@ -1355,6 +1465,7 @@ operator==(const GeomSymmetricTensor<3>& rhs) const {
 }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<1>::
@@ -1363,6 +1474,7 @@ operator==(const GeomSymmetricTensor<3>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<2>::
@@ -1373,6 +1485,7 @@ operator==(const GeomSymmetricTensor<3>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<3>::
@@ -1390,6 +1503,7 @@ operator==(const GeomSymmetricTensor<3>& rhs) const {
 // Define the not equivalence than comparitor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1398,6 +1512,7 @@ operator!=(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1406,6 +1521,7 @@ operator!=(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<int nDim>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<nDim>::
@@ -1417,6 +1533,7 @@ operator!=(const GeomSymmetricTensor<nDim>& rhs) const {
 // Define the less than operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1425,6 +1542,7 @@ operator<(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1433,6 +1551,7 @@ operator<(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<1>::
@@ -1441,6 +1560,7 @@ operator<(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<2>::
@@ -1451,6 +1571,7 @@ operator<(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<3>::
@@ -1468,6 +1589,7 @@ operator<(const GeomSymmetricTensor<nDim>& rhs) const {
 // Define the greater than operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1476,6 +1598,7 @@ operator>(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1484,6 +1607,7 @@ operator>(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<1>::
@@ -1492,6 +1616,7 @@ operator>(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<2>::
@@ -1502,6 +1627,7 @@ operator>(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<3>::
@@ -1519,6 +1645,7 @@ operator>(const GeomSymmetricTensor<nDim>& rhs) const {
 // Define the less than or equal operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1527,6 +1654,7 @@ operator<=(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1535,6 +1663,7 @@ operator<=(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<1>::
@@ -1543,6 +1672,7 @@ operator<=(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<2>::
@@ -1553,6 +1683,7 @@ operator<=(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<3>::
@@ -1570,6 +1701,7 @@ operator<=(const GeomSymmetricTensor<nDim>& rhs) const {
 // Define the greater than or equal operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1578,6 +1710,7 @@ operator>=(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomSymmetricTensor<nDim>::
@@ -1586,6 +1719,7 @@ operator>=(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<1>::
@@ -1594,6 +1728,7 @@ operator>=(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<2>::
@@ -1604,6 +1739,7 @@ operator>=(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomSymmetricTensor<3>::
@@ -1621,6 +1757,7 @@ operator>=(const GeomSymmetricTensor<nDim>& rhs) const {
 // Return the symmetric part.  A no-op for this class.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>
 GeomSymmetricTensor<nDim>::Symmetric() const {
@@ -1632,6 +1769,7 @@ GeomSymmetricTensor<nDim>::Symmetric() const {
 //   Bij = 0.5*(Aij - Aji)
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomSymmetricTensor<nDim>::SkewSymmetric() const {
@@ -1642,6 +1780,7 @@ GeomSymmetricTensor<nDim>::SkewSymmetric() const {
 // Return the transpose of the GeomSymmetricTensor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<nDim>
 GeomSymmetricTensor<nDim>::
@@ -1653,6 +1792,7 @@ Transpose() const {
 // Return the inverse of the tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>
 GeomSymmetricTensor<1>::Inverse() const {
@@ -1661,6 +1801,7 @@ GeomSymmetricTensor<1>::Inverse() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>
 GeomSymmetricTensor<2>::Inverse() const {
@@ -1670,6 +1811,7 @@ GeomSymmetricTensor<2>::Inverse() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>
 GeomSymmetricTensor<3>::Inverse() const {
@@ -1689,6 +1831,7 @@ GeomSymmetricTensor<3>::Inverse() const {
 // Return the diagonal elements of the GeomSymmetricTensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<1>
 GeomSymmetricTensor<1>::diagonalElements() const {
@@ -1696,6 +1839,7 @@ GeomSymmetricTensor<1>::diagonalElements() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<2>
 GeomSymmetricTensor<2>::diagonalElements() const {
@@ -1703,6 +1847,7 @@ GeomSymmetricTensor<2>::diagonalElements() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<3>
 GeomSymmetricTensor<3>::diagonalElements() const {
@@ -1713,6 +1858,7 @@ GeomSymmetricTensor<3>::diagonalElements() const {
 // Return the trace of the tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<1>::Trace() const {
@@ -1720,6 +1866,7 @@ GeomSymmetricTensor<1>::Trace() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<2>::Trace() const {
@@ -1727,6 +1874,7 @@ GeomSymmetricTensor<2>::Trace() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<3>::Trace() const {
@@ -1737,6 +1885,7 @@ GeomSymmetricTensor<3>::Trace() const {
 // Return the determinant of the tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<1>::Determinant() const {
@@ -1744,6 +1893,7 @@ GeomSymmetricTensor<1>::Determinant() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<2>::Determinant() const {
@@ -1751,14 +1901,15 @@ GeomSymmetricTensor<2>::Determinant() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<3>::Determinant() const {
-  return ((this->mxx)*(this->myy)*(this->mzz) +
-	  (this->mxy)*(this->myz)*(this->mxz) +
-	  (this->mxz)*(this->mxy)*(this->myz) -
-	  (this->mxx)*(this->myz)*(this->myz) -
-	  (this->mxy)*(this->mxy)*(this->mzz) -
+  return ((this->mxx)*(this->myy)*(this->mzz) + 
+	  (this->mxy)*(this->myz)*(this->mxz) + 
+	  (this->mxz)*(this->mxy)*(this->myz) - 
+	  (this->mxx)*(this->myz)*(this->myz) - 
+	  (this->mxy)*(this->mxy)*(this->mzz) - 
 	  (this->mxz)*(this->myy)*(this->mxz));
 }
 
@@ -1766,6 +1917,7 @@ GeomSymmetricTensor<3>::Determinant() const {
 // Multiply a tensor with a vector.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<1>
 GeomSymmetricTensor<1>::dot(const GeomVector<1>& rhs) const {
@@ -1773,6 +1925,7 @@ GeomSymmetricTensor<1>::dot(const GeomVector<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<2>
 GeomSymmetricTensor<2>::dot(const GeomVector<2>& rhs) const {
@@ -1781,6 +1934,7 @@ GeomSymmetricTensor<2>::dot(const GeomVector<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<3>
 GeomSymmetricTensor<3>::dot(const GeomVector<3>& rhs) const {
@@ -1794,6 +1948,7 @@ GeomSymmetricTensor<3>::dot(const GeomVector<3>& rhs) const {
 // multiplication.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomSymmetricTensor<1>::dot(const GeomTensor<1>& rhs) const {
@@ -1801,6 +1956,7 @@ GeomSymmetricTensor<1>::dot(const GeomTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomSymmetricTensor<2>::dot(const GeomTensor<2>& rhs) const {
@@ -1811,6 +1967,7 @@ GeomSymmetricTensor<2>::dot(const GeomTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomSymmetricTensor<3>::dot(const GeomTensor<3>& rhs) const {
@@ -1826,6 +1983,7 @@ GeomSymmetricTensor<3>::dot(const GeomTensor<3>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomSymmetricTensor<1>::dot(const GeomSymmetricTensor<1>& rhs) const {
@@ -1833,6 +1991,7 @@ GeomSymmetricTensor<1>::dot(const GeomSymmetricTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomSymmetricTensor<2>::dot(const GeomSymmetricTensor<2>& rhs) const {
@@ -1843,6 +2002,7 @@ GeomSymmetricTensor<2>::dot(const GeomSymmetricTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomSymmetricTensor<3>::dot(const GeomSymmetricTensor<3>& rhs) const {
@@ -1862,6 +2022,7 @@ GeomSymmetricTensor<3>::dot(const GeomSymmetricTensor<3>& rhs) const {
 // Return the doubledot product.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<1>::
@@ -1870,6 +2031,7 @@ doubledot(const GeomTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<2>::
@@ -1879,6 +2041,7 @@ doubledot(const GeomTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<3>::
@@ -1892,6 +2055,7 @@ doubledot(const GeomTensor<3>& rhs) const {
 // Return the doubledot product with a symmetric tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<1>::
@@ -1900,6 +2064,7 @@ doubledot(const GeomSymmetricTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<2>::
@@ -1909,6 +2074,7 @@ doubledot(const GeomSymmetricTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<3>::
@@ -1922,6 +2088,7 @@ doubledot(const GeomSymmetricTensor<3>& rhs) const {
 // Return the doubledot product with ourself.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<1>::
@@ -1930,6 +2097,7 @@ selfDoubledot() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<2>::
@@ -1939,6 +2107,7 @@ selfDoubledot() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<3>::
@@ -1952,6 +2121,7 @@ selfDoubledot() const {
 // Return the square of this tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>
 GeomSymmetricTensor<1>::
@@ -1960,6 +2130,7 @@ square() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>
 GeomSymmetricTensor<2>::
@@ -1972,6 +2143,7 @@ square() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>
 GeomSymmetricTensor<3>::
@@ -1990,6 +2162,7 @@ square() const {
 // Return the cube of this tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>
 GeomSymmetricTensor<1>::
@@ -1998,6 +2171,7 @@ cube() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>
 GeomSymmetricTensor<2>::
@@ -2010,6 +2184,7 @@ cube() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>
 GeomSymmetricTensor<3>::
@@ -2030,10 +2205,8 @@ cube() const {
   return result;
 }
 
-//------------------------------------------------------------------------------
-// Return a new tensor with the elements of this tensor squared.
-//------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>
 GeomSymmetricTensor<1>::
@@ -2042,6 +2215,7 @@ squareElements() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>
 GeomSymmetricTensor<2>::
@@ -2054,6 +2228,7 @@ squareElements() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>
 GeomSymmetricTensor<3>::
@@ -2072,6 +2247,7 @@ squareElements() const {
 // Apply a rotational transform to this tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<1>::
@@ -2081,6 +2257,7 @@ rotationalTransform(const GeomTensor<1>& R) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<2>::
@@ -2105,6 +2282,7 @@ rotationalTransform(const GeomTensor<2>& R) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomSymmetricTensor<3>::
@@ -2147,6 +2325,7 @@ rotationalTransform(const GeomTensor<3>& R) {
 // Return the maximum absolute value of the elements.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<1>::
@@ -2155,6 +2334,7 @@ maxAbsElement() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<2>::
@@ -2165,6 +2345,7 @@ maxAbsElement() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomSymmetricTensor<3>::
@@ -2181,6 +2362,7 @@ maxAbsElement() const {
 // Find the eigenvalues of a tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<1>
 GeomSymmetricTensor<1>::eigenValues() const {
@@ -2189,6 +2371,7 @@ GeomSymmetricTensor<1>::eigenValues() const {
 
 //----------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<2>
 GeomSymmetricTensor<2>::eigenValues() const {
@@ -2208,6 +2391,7 @@ GeomSymmetricTensor<2>::eigenValues() const {
 // www.geometrictools.com
 //----------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<3>
 GeomSymmetricTensor<3>::eigenValues() const {

--- a/src/Geometry/GeomSymmetricTensorInline_default.hh
+++ b/src/Geometry/GeomSymmetricTensorInline_default.hh
@@ -57,17 +57,6 @@ GeomSymmetricTensor<3>::elementIndex(const GeomSymmetricTensor<3>::size_type row
 }
 
 //------------------------------------------------------------------------------
-// Default constructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomSymmetricTensor<nDim>::
-GeomSymmetricTensor():
-  GeomSymmetricTensorBase<nDim>(0.0) {
-}
-
-//------------------------------------------------------------------------------
 // Construct with the given values for the elements.
 //------------------------------------------------------------------------------
 template<int nDim>
@@ -136,14 +125,6 @@ GeomSymmetricTensor(const double /*a11*/, const double /*a12*/, const double /*a
 //------------------------------------------------------------------------------
 // Copy constructors.
 //------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomSymmetricTensor<nDim>::
-GeomSymmetricTensor(const GeomSymmetricTensor<nDim>& ten):
-  GeomSymmetricTensorBase<nDim>(ten) {
-}
-
 template<>
 SPHERAL_HOST_DEVICE
 inline
@@ -200,15 +181,6 @@ GeomSymmetricTensor<3>::GeomSymmetricTensor(const Eigen::MatrixBase<Derived>& te
 }
 
 //------------------------------------------------------------------------------
-// Destructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomSymmetricTensor<nDim>::~GeomSymmetricTensor() {
-}
-
-//------------------------------------------------------------------------------
 // Assignment operators.
 //------------------------------------------------------------------------------
 template<>
@@ -246,43 +218,6 @@ operator=(const GeomTensor<3>& rhs) {
   this->myy = rhs.yy();
   this->myz = rhs.yz();
   this->mzz = rhs.zz();
-  return *this;
-}
-
-template<>
-SPHERAL_HOST_DEVICE
-inline
-GeomSymmetricTensor<1>&
-GeomSymmetricTensor<1>::
-operator=(const GeomSymmetricTensor<1>& rhs) {
-  this->mxx = rhs.mxx;
-  return *this;
-}
-
-template<>
-SPHERAL_HOST_DEVICE
-inline
-GeomSymmetricTensor<2>&
-GeomSymmetricTensor<2>::
-operator=(const GeomSymmetricTensor<2>& rhs) {
-  this->mxx = rhs.mxx;
-  this->mxy = rhs.mxy;
-  this->myy = rhs.myy;
-  return *this;
-}
-
-template<>
-SPHERAL_HOST_DEVICE
-inline
-GeomSymmetricTensor<3>&
-GeomSymmetricTensor<3>::
-operator=(const GeomSymmetricTensor<3>& rhs) {
-  this->mxx = rhs.mxx;
-  this->mxy = rhs.mxy;
-  this->mxz = rhs.mxz;
-  this->myy = rhs.myy;
-  this->myz = rhs.myz;
-  this->mzz = rhs.mzz;
   return *this;
 }
 

--- a/src/Geometry/GeomSymmetricTensorInline_default.hh
+++ b/src/Geometry/GeomSymmetricTensorInline_default.hh
@@ -684,21 +684,56 @@ GeomSymmetricTensor<nDim>::end() const {
 //------------------------------------------------------------------------------
 // Zero out the GeomSymmetricTensor.
 //------------------------------------------------------------------------------
-template<int nDim>
+template<>
 inline
 void
-GeomSymmetricTensor<nDim>::Zero() {
-  *this = zero;
+GeomSymmetricTensor<1>::Zero() {
+  *this = GeomSymmetricTensor<1>(0.0);
 }
+
+template<>
+inline
+void
+GeomSymmetricTensor<2>::Zero() {
+  *this = GeomSymmetricTensor<2>(0.0, 0.0,
+                                 0.0, 0.0);
+}
+
+template<>
+inline
+void
+GeomSymmetricTensor<3>::Zero() {
+  *this = GeomSymmetricTensor<3>(0.0, 0.0, 0.0,
+                                 0.0, 0.0, 0.0,
+                                 0.0, 0.0, 0.0);
+}
+
 
 //------------------------------------------------------------------------------
 // Force the tensor to be the identity tensor.
 //------------------------------------------------------------------------------
-template<int nDim>
+template<>
 inline
 void
-GeomSymmetricTensor<nDim>::Identity() {
-  *this = one;
+GeomSymmetricTensor<1>::Identity() {
+  *this = GeomSymmetricTensor<1>(1.0);
+}
+
+template<>
+inline
+void
+GeomSymmetricTensor<2>::Identity() {
+  *this = GeomSymmetricTensor<2>(1.0, 0.0,
+                                 0.0, 1.0);
+}
+
+template<>
+inline
+void
+GeomSymmetricTensor<3>::Identity() {
+  *this = GeomSymmetricTensor<3>(1.0, 0.0, 0.0,
+                                 0.0, 1.0, 0.0,
+                                 0.0, 0.0, 1.0);
 }
 
 //------------------------------------------------------------------------------
@@ -1600,7 +1635,7 @@ template<int nDim>
 inline
 GeomTensor<nDim>
 GeomSymmetricTensor<nDim>::SkewSymmetric() const {
-  return GeomTensor<nDim>::zero;
+  return GeomTensor<nDim>();
 }
 
 //------------------------------------------------------------------------------

--- a/src/Geometry/GeomSymmetricTensor_default.cc
+++ b/src/Geometry/GeomSymmetricTensor_default.cc
@@ -230,19 +230,16 @@ template class GeomSymmetricTensor<3>;
 // Set the static variables.
 //------------------------------------------------------------------------------
 template<> const unsigned GeomSymmetricTensor<1>::nDimensions = 1;
-template<> const unsigned GeomSymmetricTensor<1>::numElements = 1;
 template<> const GeomSymmetricTensor<1> GeomSymmetricTensor<1>::zero = GeomSymmetricTensor<1>(0.0);
 template<> const GeomSymmetricTensor<1> GeomSymmetricTensor<1>::one = GeomSymmetricTensor<1>(1.0);
 
 template<> const unsigned GeomSymmetricTensor<2>::nDimensions = 2;
-template<> const unsigned GeomSymmetricTensor<2>::numElements = 3;
 template<> const GeomSymmetricTensor<2> GeomSymmetricTensor<2>::zero = GeomSymmetricTensor<2>(0.0, 0.0,
                                                                                               0.0, 0.0);
 template<> const GeomSymmetricTensor<2> GeomSymmetricTensor<2>::one = GeomSymmetricTensor<2>(1.0, 0.0,
                                                                                              0.0, 1.0);
 
 template<> const unsigned GeomSymmetricTensor<3>::nDimensions = 3;
-template<> const unsigned GeomSymmetricTensor<3>::numElements = 6;
 template<> const GeomSymmetricTensor<3> GeomSymmetricTensor<3>::zero = GeomSymmetricTensor<3>(0.0, 0.0, 0.0,
                                                                                               0.0, 0.0, 0.0,
                                                                                               0.0, 0.0, 0.0);

--- a/src/Geometry/GeomSymmetricTensor_default.hh
+++ b/src/Geometry/GeomSymmetricTensor_default.hh
@@ -15,6 +15,8 @@
 #ifndef __Spheral_GeomSymmetricTensor_hh_
 #define __Spheral_GeomSymmetricTensor_hh_
 
+#include "config.hh"
+
 #include "Geometry/GeomVector_fwd.hh"
 #include "Geometry/GeomTensor_fwd.hh"
 #include "Geometry/GeomSymmetricTensor_fwd.hh"
@@ -46,110 +48,110 @@ public:
   static const double sqrt3;
 
   // Constructors.
-  GeomSymmetricTensor();
-  explicit GeomSymmetricTensor(const double a11);
-  GeomSymmetricTensor(const double /*a11*/, const double /*a12*/,
-                      const double /*a21*/, const double /*a22*/);
-  GeomSymmetricTensor(const double /*a11*/, const double /*a12*/, const double /*a13*/,
-                      const double /*a21*/, const double /*a22*/, const double /*a23*/,
-                      const double /*a31*/, const double /*a32*/, const double /*a33*/);
-  GeomSymmetricTensor(const GeomSymmetricTensor& ten);
-  explicit GeomSymmetricTensor(const GeomTensor<nDim>& ten);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor();
+  SPHERAL_HOST_DEVICE explicit GeomSymmetricTensor(const double a11);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor(const double /*a11*/, const double /*a12*/,
+                                          const double /*a21*/, const double /*a22*/);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor(const double /*a11*/, const double /*a12*/, const double /*a13*/,
+                                          const double /*a21*/, const double /*a22*/, const double /*a23*/,
+                                          const double /*a31*/, const double /*a32*/, const double /*a33*/);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor(const GeomSymmetricTensor& ten);
+  SPHERAL_HOST_DEVICE explicit GeomSymmetricTensor(const GeomTensor<nDim>& ten);
   template<typename Derived> GeomSymmetricTensor(const Eigen::MatrixBase<Derived>& ten);
 
   // Destructor.
-  ~GeomSymmetricTensor();
+  SPHERAL_HOST_DEVICE ~GeomSymmetricTensor();
 
   // Assignment.
-  GeomSymmetricTensor& operator=(const GeomTensor<nDim>& rhs);
-  GeomSymmetricTensor& operator=(const GeomSymmetricTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor& operator=(const GeomTensor<nDim>& rhs);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor& operator=(const GeomSymmetricTensor& rhs);
   template<typename Derived> GeomSymmetricTensor& operator=(const Eigen::MatrixBase<Derived>& rhs);
 
   // Access the elements by indicies.
-  double operator()(const size_type row, const size_type column) const;
-  double& operator()(const size_type row, const size_type column);
+  SPHERAL_HOST_DEVICE double operator()(const size_type row, const size_type column) const;
+  SPHERAL_HOST_DEVICE double& operator()(const size_type row, const size_type column);
 
   // More C++ style indexing.
-  double operator[](size_type index) const;
-  double& operator[](size_type index);
+  SPHERAL_HOST_DEVICE double operator[](size_type index) const;
+  SPHERAL_HOST_DEVICE double& operator[](size_type index);
 
   // Access the individual elements by (x,y,z) notation.
-  double xx() const;
-  double xy() const;
-  double xz() const;
-  double yx() const;
-  double yy() const;
-  double yz() const;
-  double zx() const;
-  double zy() const;
-  double zz() const;
-  void xx(double val);
-  void xy(double val);
-  void xz(double val);
-  void yx(double val);
-  void yy(double val);
-  void yz(double val);
-  void zx(double val);
-  void zy(double val);
-  void zz(double val);
+  SPHERAL_HOST_DEVICE double xx() const;
+  SPHERAL_HOST_DEVICE double xy() const;
+  SPHERAL_HOST_DEVICE double xz() const;
+  SPHERAL_HOST_DEVICE double yx() const;
+  SPHERAL_HOST_DEVICE double yy() const;
+  SPHERAL_HOST_DEVICE double yz() const;
+  SPHERAL_HOST_DEVICE double zx() const;
+  SPHERAL_HOST_DEVICE double zy() const;
+  SPHERAL_HOST_DEVICE double zz() const;
+  SPHERAL_HOST_DEVICE void xx(double val);
+  SPHERAL_HOST_DEVICE void xy(double val);
+  SPHERAL_HOST_DEVICE void xz(double val);
+  SPHERAL_HOST_DEVICE void yx(double val);
+  SPHERAL_HOST_DEVICE void yy(double val);
+  SPHERAL_HOST_DEVICE void yz(double val);
+  SPHERAL_HOST_DEVICE void zx(double val);
+  SPHERAL_HOST_DEVICE void zy(double val);
+  SPHERAL_HOST_DEVICE void zz(double val);
 
   // Get/set rows and columns.
-  GeomVector<nDim> getRow(size_type index) const;
-  GeomVector<nDim> getColumn(size_type index) const;
-  void setRow(size_type index, const GeomVector<nDim>& vec);
-  void setColumn(size_type index, const GeomVector<nDim>& vec);
+  SPHERAL_HOST_DEVICE GeomVector<nDim> getRow(size_type index) const;
+  SPHERAL_HOST_DEVICE GeomVector<nDim> getColumn(size_type index) const;
+  SPHERAL_HOST_DEVICE void setRow(size_type index, const GeomVector<nDim>& vec);
+  SPHERAL_HOST_DEVICE void setColumn(size_type index, const GeomVector<nDim>& vec);
 
   // Iterator access to the raw data.
-  iterator begin();
-  iterator end();
+  SPHERAL_HOST_DEVICE iterator begin();
+  SPHERAL_HOST_DEVICE iterator end();
 
-  const_iterator begin() const;
-  const_iterator end() const;
+  SPHERAL_HOST_DEVICE const_iterator begin() const;
+  SPHERAL_HOST_DEVICE const_iterator end() const;
 
   // The zero and identity matrices.
-  void Zero();
-  void Identity();
+  SPHERAL_HOST_DEVICE void Zero();
+  SPHERAL_HOST_DEVICE void Identity();
 
-  GeomSymmetricTensor operator-() const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor operator-() const;
 
-  GeomTensor<nDim> operator+(const GeomTensor<nDim>& rhs) const;
-  GeomTensor<nDim> operator-(const GeomTensor<nDim>& rhs) const;
-  GeomTensor<nDim> operator*(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor<nDim> operator+(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor<nDim> operator-(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor<nDim> operator*(const GeomTensor<nDim>& rhs) const;
 
-  GeomSymmetricTensor operator+(const GeomSymmetricTensor& rhs) const;
-  GeomSymmetricTensor operator-(const GeomSymmetricTensor& rhs) const;
-  GeomTensor<nDim>    operator*(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor operator+(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor operator-(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor<nDim>    operator*(const GeomSymmetricTensor& rhs) const;
 
-  GeomVector<nDim> operator*(const GeomVector<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomVector<nDim> operator*(const GeomVector<nDim>& rhs) const;
   // GeomSymmetricTensor operator+(const double rhs) const;
   // GeomSymmetricTensor operator-(const double rhs) const;
-  GeomSymmetricTensor operator*(const double rhs) const;
-  GeomSymmetricTensor operator/(const double rhs) const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor operator*(const double rhs) const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor operator/(const double rhs) const;
 
-  GeomSymmetricTensor& operator+=(const GeomSymmetricTensor& rhs);
-  GeomSymmetricTensor& operator-=(const GeomSymmetricTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor& operator+=(const GeomSymmetricTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor& operator-=(const GeomSymmetricTensor& rhs);
 
   template<typename Derived> GeomSymmetricTensor& operator+=(const Eigen::MatrixBase<Derived>& rhs);
   template<typename Derived> GeomSymmetricTensor& operator-=(const Eigen::MatrixBase<Derived>& rhs);
 
   // GeomSymmetricTensor& operator+=(const double rhs);
   // GeomSymmetricTensor& operator-=(const double rhs);
-  GeomSymmetricTensor& operator*=(const double rhs);
-  GeomSymmetricTensor& operator/=(const double rhs);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor& operator*=(const double rhs);
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor& operator/=(const double rhs);
 
-  bool operator==(const GeomTensor<nDim>& rhs) const;
-  bool operator!=(const GeomTensor<nDim>& rhs) const;
-  bool operator<(const GeomTensor<nDim>& rhs) const;
-  bool operator>(const GeomTensor<nDim>& rhs) const;
-  bool operator<=(const GeomTensor<nDim>& rhs) const;
-  bool operator>=(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator==(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator!=(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<=(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>=(const GeomTensor<nDim>& rhs) const;
 
-  bool operator==(const GeomSymmetricTensor& rhs) const;
-  bool operator!=(const GeomSymmetricTensor& rhs) const;
-  bool operator<(const GeomSymmetricTensor& rhs) const;
-  bool operator>(const GeomSymmetricTensor& rhs) const;
-  bool operator<=(const GeomSymmetricTensor& rhs) const;
-  bool operator>=(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator==(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator!=(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<=(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>=(const GeomSymmetricTensor& rhs) const;
 
   // bool operator==(const double rhs) const;
   // bool operator!=(const double rhs) const;
@@ -158,26 +160,26 @@ public:
   // bool operator<=(const double rhs) const;
   // bool operator>=(const double rhs) const;
 
-  GeomSymmetricTensor Symmetric() const;
-  GeomTensor<nDim> SkewSymmetric() const;
-  GeomSymmetricTensor Transpose() const;
-  GeomSymmetricTensor Inverse() const;
-  GeomVector<nDim> diagonalElements() const;
-  double Trace() const;
-  double Determinant() const;
-  GeomVector<nDim> dot(const GeomVector<nDim>& rhs) const;
-  GeomTensor<nDim> dot(const GeomTensor<nDim>& rhs) const;
-  GeomTensor<nDim> dot(const GeomSymmetricTensor& rhs) const;
-  double doubledot(const GeomTensor<nDim>& rhs) const;
-  double doubledot(const GeomSymmetricTensor& rhs) const;
-  double selfDoubledot() const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor Symmetric() const;
+  SPHERAL_HOST_DEVICE GeomTensor<nDim> SkewSymmetric() const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor Transpose() const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor Inverse() const;
+  SPHERAL_HOST_DEVICE GeomVector<nDim> diagonalElements() const;
+  SPHERAL_HOST_DEVICE double Trace() const;
+  SPHERAL_HOST_DEVICE double Determinant() const;
+  SPHERAL_HOST_DEVICE GeomVector<nDim> dot(const GeomVector<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor<nDim> dot(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor<nDim> dot(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE double doubledot(const GeomTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE double doubledot(const GeomSymmetricTensor& rhs) const;
+  SPHERAL_HOST_DEVICE double selfDoubledot() const;
 
   // Return the square of this tensor (using matrix multiplication).  Note that
   // for a symmetric tensor this is guaranteed to return a symmetric product.
-  GeomSymmetricTensor square() const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor square() const;
 
   // Same idea for the cube.
-  GeomSymmetricTensor cube() const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor cube() const;
 
   // Compute the "square root" of the tensor: the tensor that, 
   // when squared, equals this tensor.
@@ -191,13 +193,13 @@ public:
 
   // Return a tensor where each element is the square of the corresponding 
   // element of this tensor.
-  GeomSymmetricTensor squareElements() const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor squareElements() const;
 
   // A simple method for returning the eigenvalues of a tensor.
-  GeomVector<nDim> eigenValues() const;
+  SPHERAL_HOST_DEVICE GeomVector<nDim> eigenValues() const;
   
   // Apply a rotational transform to this tensor ( R^-1 * (*this) * R ).
-  void rotationalTransform(const GeomTensor<nDim>& R);
+  SPHERAL_HOST_DEVICE void rotationalTransform(const GeomTensor<nDim>& R);
 
   // We also provide a method to retrieve the eigenvectors as an EigenStruct.
   // Note that the eigen vectors are the columns of the full tensor in the resulting
@@ -205,14 +207,14 @@ public:
   EigenStructType eigenVectors() const;
 
   // Return the max absolute element.
-  double maxAbsElement() const;
+  SPHERAL_HOST_DEVICE double maxAbsElement() const;
 
   //  Convert to an Eigen Vector
   EigenType eigen() const;
 
 private:
   //--------------------------- Private Interface ---------------------------//
-  size_type elementIndex(const size_type row, const size_type column) const;
+  SPHERAL_HOST_DEVICE size_type elementIndex(const size_type row, const size_type column) const;
 };
 
 // Declare specializations.
@@ -222,164 +224,164 @@ template<> const unsigned GeomSymmetricTensor<2>::nDimensions;
 template<> const unsigned GeomSymmetricTensor<3>::nDimensions;
 #endif
 
-template<> GeomVector<1> GeomSymmetricTensor<1>::eigenValues() const;
-template<> GeomVector<2> GeomSymmetricTensor<2>::eigenValues() const;
-template<> GeomVector<3> GeomSymmetricTensor<3>::eigenValues() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<1> GeomSymmetricTensor<1>::eigenValues() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<2> GeomSymmetricTensor<2>::eigenValues() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<3> GeomSymmetricTensor<3>::eigenValues() const;
 
 template<> EigenStruct<1> GeomSymmetricTensor<1>::eigenVectors() const;
 template<> EigenStruct<2> GeomSymmetricTensor<2>::eigenVectors() const;
 template<> EigenStruct<3> GeomSymmetricTensor<3>::eigenVectors() const;
 
-template<> GeomSymmetricTensor<2>::GeomSymmetricTensor(const double, const double,
-                                                       const double, const double);
-template<> GeomSymmetricTensor<3>::GeomSymmetricTensor(const double, const double, const double,
-                                                       const double, const double, const double,
-                                                       const double, const double, const double);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>::GeomSymmetricTensor(const double, const double,
+                                                                           const double, const double);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>::GeomSymmetricTensor(const double, const double, const double,
+                                                                           const double, const double, const double,
+                                                                           const double, const double, const double);
 
-template<> GeomSymmetricTensor<1>::GeomSymmetricTensor(const GeomTensor<1>&);
-template<> GeomSymmetricTensor<2>::GeomSymmetricTensor(const GeomTensor<2>&);
-template<> GeomSymmetricTensor<3>::GeomSymmetricTensor(const GeomTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1>::GeomSymmetricTensor(const GeomTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>::GeomSymmetricTensor(const GeomTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>::GeomSymmetricTensor(const GeomTensor<3>&);
 
-template<> GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator=(const GeomTensor<1>&);
-template<> GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator=(const GeomTensor<2>&);
-template<> GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator=(const GeomTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator=(const GeomTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator=(const GeomTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator=(const GeomTensor<3>&);
 
-template<> GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator=(const GeomSymmetricTensor<1>&);
-template<> GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator=(const GeomSymmetricTensor<2>&);
-template<> GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator=(const GeomSymmetricTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator=(const GeomSymmetricTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator=(const GeomSymmetricTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator=(const GeomSymmetricTensor<3>&);
 
-template<> double GeomSymmetricTensor<1>::xy() const;
-template<> double GeomSymmetricTensor<1>::xz() const;
-template<> double GeomSymmetricTensor<1>::yx() const;
-template<> double GeomSymmetricTensor<1>::yy() const;
-template<> double GeomSymmetricTensor<1>::yz() const;
-template<> double GeomSymmetricTensor<1>::zx() const;
-template<> double GeomSymmetricTensor<1>::zy() const;
-template<> double GeomSymmetricTensor<1>::zz() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::xy() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::xz() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::yx() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::yy() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::yz() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::zx() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::zy() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::zz() const;
 
-template<> double GeomSymmetricTensor<2>::xz() const;
-template<> double GeomSymmetricTensor<2>::yz() const;
-template<> double GeomSymmetricTensor<2>::zx() const;
-template<> double GeomSymmetricTensor<2>::zy() const;
-template<> double GeomSymmetricTensor<2>::zz() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::xz() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::yz() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::zx() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::zy() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::zz() const;
 
-template<> void GeomSymmetricTensor<1>::xy(const double);
-template<> void GeomSymmetricTensor<1>::xz(const double);
-template<> void GeomSymmetricTensor<1>::yx(const double);
-template<> void GeomSymmetricTensor<1>::yy(const double);
-template<> void GeomSymmetricTensor<1>::yz(const double);
-template<> void GeomSymmetricTensor<1>::zx(const double);
-template<> void GeomSymmetricTensor<1>::zy(const double);
-template<> void GeomSymmetricTensor<1>::zz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::xy(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::xz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::yx(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::yy(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::yz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::zx(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::zy(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::zz(const double);
 
-template<> void GeomSymmetricTensor<2>::xz(const double);
-template<> void GeomSymmetricTensor<2>::yz(const double);
-template<> void GeomSymmetricTensor<2>::zx(const double);
-template<> void GeomSymmetricTensor<2>::zy(const double);
-template<> void GeomSymmetricTensor<2>::zz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<2>::xz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<2>::yz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<2>::zx(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<2>::zy(const double);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<2>::zz(const double);
 
-template<> GeomVector<1> GeomSymmetricTensor<1>::getRow(const GeomSymmetricTensor<1>::size_type) const;
-template<> GeomVector<2> GeomSymmetricTensor<2>::getRow(const GeomSymmetricTensor<2>::size_type) const;
-template<> GeomVector<3> GeomSymmetricTensor<3>::getRow(const GeomSymmetricTensor<3>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<1> GeomSymmetricTensor<1>::getRow(const GeomSymmetricTensor<1>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<2> GeomSymmetricTensor<2>::getRow(const GeomSymmetricTensor<2>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<3> GeomSymmetricTensor<3>::getRow(const GeomSymmetricTensor<3>::size_type) const;
 
-template<> GeomVector<1> GeomSymmetricTensor<1>::getColumn(const GeomSymmetricTensor<1>::size_type) const;
-template<> GeomVector<2> GeomSymmetricTensor<2>::getColumn(const GeomSymmetricTensor<2>::size_type) const;
-template<> GeomVector<3> GeomSymmetricTensor<3>::getColumn(const GeomSymmetricTensor<3>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<1> GeomSymmetricTensor<1>::getColumn(const GeomSymmetricTensor<1>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<2> GeomSymmetricTensor<2>::getColumn(const GeomSymmetricTensor<2>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<3> GeomSymmetricTensor<3>::getColumn(const GeomSymmetricTensor<3>::size_type) const;
 
-template<> void GeomSymmetricTensor<1>::setRow(const GeomSymmetricTensor<1>::size_type, const GeomVector<1>&);
-template<> void GeomSymmetricTensor<2>::setRow(const GeomSymmetricTensor<2>::size_type, const GeomVector<2>&);
-template<> void GeomSymmetricTensor<3>::setRow(const GeomSymmetricTensor<3>::size_type, const GeomVector<3>&);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::setRow(const GeomSymmetricTensor<1>::size_type, const GeomVector<1>&);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<2>::setRow(const GeomSymmetricTensor<2>::size_type, const GeomVector<2>&);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<3>::setRow(const GeomSymmetricTensor<3>::size_type, const GeomVector<3>&);
 
-template<> void GeomSymmetricTensor<1>::setColumn(const GeomSymmetricTensor<1>::size_type, const GeomVector<1>&);
-template<> void GeomSymmetricTensor<2>::setColumn(const GeomSymmetricTensor<2>::size_type, const GeomVector<2>&);
-template<> void GeomSymmetricTensor<3>::setColumn(const GeomSymmetricTensor<3>::size_type, const GeomVector<3>&);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::setColumn(const GeomSymmetricTensor<1>::size_type, const GeomVector<1>&);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<2>::setColumn(const GeomSymmetricTensor<2>::size_type, const GeomVector<2>&);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<3>::setColumn(const GeomSymmetricTensor<3>::size_type, const GeomVector<3>&);
 
-template<> GeomSymmetricTensor<1> GeomSymmetricTensor<1>::operator-() const;
-template<> GeomSymmetricTensor<2> GeomSymmetricTensor<2>::operator-() const;
-template<> GeomSymmetricTensor<3> GeomSymmetricTensor<3>::operator-() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1> GeomSymmetricTensor<1>::operator-() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2> GeomSymmetricTensor<2>::operator-() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3> GeomSymmetricTensor<3>::operator-() const;
 
-template<> GeomSymmetricTensor<1> GeomSymmetricTensor<1>::operator*(const double) const;
-template<> GeomSymmetricTensor<2> GeomSymmetricTensor<2>::operator*(const double) const;
-template<> GeomSymmetricTensor<3> GeomSymmetricTensor<3>::operator*(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1> GeomSymmetricTensor<1>::operator*(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2> GeomSymmetricTensor<2>::operator*(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3> GeomSymmetricTensor<3>::operator*(const double) const;
 
-template<> GeomSymmetricTensor<1> GeomSymmetricTensor<1>::operator/(const double) const;
-template<> GeomSymmetricTensor<2> GeomSymmetricTensor<2>::operator/(const double) const;
-template<> GeomSymmetricTensor<3> GeomSymmetricTensor<3>::operator/(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1> GeomSymmetricTensor<1>::operator/(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2> GeomSymmetricTensor<2>::operator/(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3> GeomSymmetricTensor<3>::operator/(const double) const;
 
-template<> GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator+=(const GeomSymmetricTensor<1>&);
-template<> GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator+=(const GeomSymmetricTensor<2>&);
-template<> GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator+=(const GeomSymmetricTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator+=(const GeomSymmetricTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator+=(const GeomSymmetricTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator+=(const GeomSymmetricTensor<3>&);
 
-template<> GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator-=(const GeomSymmetricTensor<1>&);
-template<> GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator-=(const GeomSymmetricTensor<2>&);
-template<> GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator-=(const GeomSymmetricTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator-=(const GeomSymmetricTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator-=(const GeomSymmetricTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator-=(const GeomSymmetricTensor<3>&);
 
-template<> GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator*=(const double);
-template<> GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator*=(const double);
-template<> GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator*=(const double);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator*=(const double);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator*=(const double);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator*=(const double);
 
-template<> GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator/=(const double);
-template<> GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator/=(const double);
-template<> GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator/=(const double);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator/=(const double);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator/=(const double);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator/=(const double);
 
-template<> bool GeomSymmetricTensor<1>::operator==(const GeomTensor<1>&) const;
-template<> bool GeomSymmetricTensor<2>::operator==(const GeomTensor<2>&) const;
-template<> bool GeomSymmetricTensor<3>::operator==(const GeomTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomSymmetricTensor<1>::operator==(const GeomTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomSymmetricTensor<2>::operator==(const GeomTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomSymmetricTensor<3>::operator==(const GeomTensor<3>&) const;
 
-template<> bool GeomSymmetricTensor<1>::operator==(const GeomSymmetricTensor<1>&) const;
-template<> bool GeomSymmetricTensor<2>::operator==(const GeomSymmetricTensor<2>&) const;
-template<> bool GeomSymmetricTensor<3>::operator==(const GeomSymmetricTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomSymmetricTensor<1>::operator==(const GeomSymmetricTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomSymmetricTensor<2>::operator==(const GeomSymmetricTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomSymmetricTensor<3>::operator==(const GeomSymmetricTensor<3>&) const;
 
-template<> GeomVector<1> GeomSymmetricTensor<1>::diagonalElements() const;
-template<> GeomVector<2> GeomSymmetricTensor<2>::diagonalElements() const;
-template<> GeomVector<3> GeomSymmetricTensor<3>::diagonalElements() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<1> GeomSymmetricTensor<1>::diagonalElements() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<2> GeomSymmetricTensor<2>::diagonalElements() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<3> GeomSymmetricTensor<3>::diagonalElements() const;
 
-template<> double GeomSymmetricTensor<1>::Trace() const;
-template<> double GeomSymmetricTensor<2>::Trace() const;
-template<> double GeomSymmetricTensor<3>::Trace() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::Trace() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::Trace() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<3>::Trace() const;
 
-template<> double GeomSymmetricTensor<1>::Determinant() const;
-template<> double GeomSymmetricTensor<2>::Determinant() const;
-template<> double GeomSymmetricTensor<3>::Determinant() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::Determinant() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::Determinant() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<3>::Determinant() const;
 
-template<> GeomVector<1> GeomSymmetricTensor<1>::dot(const GeomVector<1>&) const;
-template<> GeomVector<2> GeomSymmetricTensor<2>::dot(const GeomVector<2>&) const;
-template<> GeomVector<3> GeomSymmetricTensor<3>::dot(const GeomVector<3>&) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<1> GeomSymmetricTensor<1>::dot(const GeomVector<1>&) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<2> GeomSymmetricTensor<2>::dot(const GeomVector<2>&) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<3> GeomSymmetricTensor<3>::dot(const GeomVector<3>&) const;
 
-template<> GeomTensor<1> GeomSymmetricTensor<1>::dot(const GeomTensor<1>&) const;
-template<> GeomTensor<2> GeomSymmetricTensor<2>::dot(const GeomTensor<2>&) const;
-template<> GeomTensor<3> GeomSymmetricTensor<3>::dot(const GeomTensor<3>&) const;
-template<> GeomTensor<1> GeomSymmetricTensor<1>::dot(const GeomSymmetricTensor<1>&) const;
-template<> GeomTensor<2> GeomSymmetricTensor<2>::dot(const GeomSymmetricTensor<2>&) const;
-template<> GeomTensor<3> GeomSymmetricTensor<3>::dot(const GeomSymmetricTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomSymmetricTensor<1>::dot(const GeomTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomSymmetricTensor<2>::dot(const GeomTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomSymmetricTensor<3>::dot(const GeomTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomSymmetricTensor<1>::dot(const GeomSymmetricTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomSymmetricTensor<2>::dot(const GeomSymmetricTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomSymmetricTensor<3>::dot(const GeomSymmetricTensor<3>&) const;
 
-template<> double GeomSymmetricTensor<1>::doubledot(const GeomTensor<1>&) const;
-template<> double GeomSymmetricTensor<2>::doubledot(const GeomTensor<2>&) const;
-template<> double GeomSymmetricTensor<3>::doubledot(const GeomTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::doubledot(const GeomTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::doubledot(const GeomTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<3>::doubledot(const GeomTensor<3>&) const;
 
-template<> double GeomSymmetricTensor<1>::doubledot(const GeomSymmetricTensor<1>&) const;
-template<> double GeomSymmetricTensor<2>::doubledot(const GeomSymmetricTensor<2>&) const;
-template<> double GeomSymmetricTensor<3>::doubledot(const GeomSymmetricTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::doubledot(const GeomSymmetricTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::doubledot(const GeomSymmetricTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<3>::doubledot(const GeomSymmetricTensor<3>&) const;
 
-template<> GeomSymmetricTensor<1> GeomSymmetricTensor<1>::square() const;
-template<> GeomSymmetricTensor<2> GeomSymmetricTensor<2>::square() const;
-template<> GeomSymmetricTensor<3> GeomSymmetricTensor<3>::square() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1> GeomSymmetricTensor<1>::square() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2> GeomSymmetricTensor<2>::square() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3> GeomSymmetricTensor<3>::square() const;
 
-template<> GeomSymmetricTensor<1> GeomSymmetricTensor<1>::cube() const;
-template<> GeomSymmetricTensor<2> GeomSymmetricTensor<2>::cube() const;
-template<> GeomSymmetricTensor<3> GeomSymmetricTensor<3>::cube() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1> GeomSymmetricTensor<1>::cube() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2> GeomSymmetricTensor<2>::cube() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3> GeomSymmetricTensor<3>::cube() const;
 
-template<> GeomSymmetricTensor<1> GeomSymmetricTensor<1>::squareElements() const;
-template<> GeomSymmetricTensor<2> GeomSymmetricTensor<2>::squareElements() const;
-template<> GeomSymmetricTensor<3> GeomSymmetricTensor<3>::squareElements() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1> GeomSymmetricTensor<1>::squareElements() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2> GeomSymmetricTensor<2>::squareElements() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3> GeomSymmetricTensor<3>::squareElements() const;
 
-template<> void GeomSymmetricTensor<1>::rotationalTransform(const GeomTensor<1>&);
-template<> void GeomSymmetricTensor<2>::rotationalTransform(const GeomTensor<2>&);
-template<> void GeomSymmetricTensor<3>::rotationalTransform(const GeomTensor<3>&);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<1>::rotationalTransform(const GeomTensor<1>&);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<2>::rotationalTransform(const GeomTensor<2>&);
+template<> SPHERAL_HOST_DEVICE void GeomSymmetricTensor<3>::rotationalTransform(const GeomTensor<3>&);
 
-template<> double GeomSymmetricTensor<1>::maxAbsElement() const;
-template<> double GeomSymmetricTensor<2>::maxAbsElement() const;
-template<> double GeomSymmetricTensor<3>::maxAbsElement() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::maxAbsElement() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<2>::maxAbsElement() const;
+template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<3>::maxAbsElement() const;
 
 template<> const GeomSymmetricTensor<1> GeomSymmetricTensor<1>::zero;
 template<> const GeomSymmetricTensor<2> GeomSymmetricTensor<2>::zero;

--- a/src/Geometry/GeomSymmetricTensor_default.hh
+++ b/src/Geometry/GeomSymmetricTensor_default.hh
@@ -39,7 +39,7 @@ public:
 
   // Useful static memeber data.
   static const size_type nDimensions;
-  static const size_type numElements;
+  static constexpr size_type numElements = (nDim * (nDim+1)) / 2;
   static const GeomSymmetricTensor zero;
   static const GeomSymmetricTensor one;
   static const double onethird;
@@ -220,10 +220,6 @@ private:
 template<> const unsigned GeomSymmetricTensor<1>::nDimensions;
 template<> const unsigned GeomSymmetricTensor<2>::nDimensions;
 template<> const unsigned GeomSymmetricTensor<3>::nDimensions;
-
-template<> const unsigned GeomSymmetricTensor<1>::numElements;
-template<> const unsigned GeomSymmetricTensor<2>::numElements;
-template<> const unsigned GeomSymmetricTensor<3>::numElements;
 #endif
 
 template<> GeomVector<1> GeomSymmetricTensor<1>::eigenValues() const;

--- a/src/Geometry/GeomSymmetricTensor_default.hh
+++ b/src/Geometry/GeomSymmetricTensor_default.hh
@@ -48,23 +48,18 @@ public:
   static const double sqrt3;
 
   // Constructors.
-  SPHERAL_HOST_DEVICE GeomSymmetricTensor();
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor() = default;
   SPHERAL_HOST_DEVICE explicit GeomSymmetricTensor(const double a11);
   SPHERAL_HOST_DEVICE GeomSymmetricTensor(const double /*a11*/, const double /*a12*/,
                                           const double /*a21*/, const double /*a22*/);
   SPHERAL_HOST_DEVICE GeomSymmetricTensor(const double /*a11*/, const double /*a12*/, const double /*a13*/,
                                           const double /*a21*/, const double /*a22*/, const double /*a23*/,
                                           const double /*a31*/, const double /*a32*/, const double /*a33*/);
-  SPHERAL_HOST_DEVICE GeomSymmetricTensor(const GeomSymmetricTensor& ten);
   SPHERAL_HOST_DEVICE explicit GeomSymmetricTensor(const GeomTensor<nDim>& ten);
   template<typename Derived> GeomSymmetricTensor(const Eigen::MatrixBase<Derived>& ten);
 
-  // Destructor.
-  SPHERAL_HOST_DEVICE ~GeomSymmetricTensor();
-
   // Assignment.
   SPHERAL_HOST_DEVICE GeomSymmetricTensor& operator=(const GeomTensor<nDim>& rhs);
-  SPHERAL_HOST_DEVICE GeomSymmetricTensor& operator=(const GeomSymmetricTensor& rhs);
   template<typename Derived> GeomSymmetricTensor& operator=(const Eigen::MatrixBase<Derived>& rhs);
 
   // Access the elements by indicies.
@@ -245,10 +240,6 @@ template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>::GeomSymmetricTensor(const
 template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator=(const GeomTensor<1>&);
 template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator=(const GeomTensor<2>&);
 template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator=(const GeomTensor<3>&);
-
-template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1>& GeomSymmetricTensor<1>::operator=(const GeomSymmetricTensor<1>&);
-template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2>& GeomSymmetricTensor<2>::operator=(const GeomSymmetricTensor<2>&);
-template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3>& GeomSymmetricTensor<3>::operator=(const GeomSymmetricTensor<3>&);
 
 template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::xy() const;
 template<> SPHERAL_HOST_DEVICE double GeomSymmetricTensor<1>::xz() const;

--- a/src/Geometry/GeomTensorBase.hh
+++ b/src/Geometry/GeomTensorBase.hh
@@ -18,9 +18,8 @@ class GeomTensorBase<1> {
   SPHERAL_HOST_DEVICE GeomTensorBase(const double xx):
     mxx(xx) {}
  protected:
-  double mxx;
- private:
-  SPHERAL_HOST_DEVICE GeomTensorBase();
+  double mxx = 0.0;
+  SPHERAL_HOST_DEVICE GeomTensorBase() = default;
 };
 
 template<>
@@ -39,10 +38,11 @@ class GeomTensorBase<2> {
     myx(yx),
     myy(yy) {}
  protected:
-  double mxx, mxy,
-         myx, myy;
- private:
-  SPHERAL_HOST_DEVICE GeomTensorBase();
+  double mxx = 0.0;
+  double mxy = 0.0;
+  double myx = 0.0;
+  double myy = 0.0;
+  SPHERAL_HOST_DEVICE GeomTensorBase() = default;
 };
 
 template<>
@@ -72,11 +72,16 @@ class GeomTensorBase<3> {
     mzy(zy), 
     mzz(zz) {}
  protected:
-  double mxx, mxy, mxz,
-         myx, myy, myz,
-         mzx, mzy, mzz;
- private:
-  SPHERAL_HOST_DEVICE GeomTensorBase();
+  double mxx = 0.0;
+  double mxy = 0.0;
+  double mxz = 0.0;
+  double myx = 0.0;
+  double myy = 0.0;
+  double myz = 0.0;
+  double mzx = 0.0;
+  double mzy = 0.0;
+  double mzz = 0.0;
+  SPHERAL_HOST_DEVICE GeomTensorBase() = default;
 };
 
 }

--- a/src/Geometry/GeomTensorBase.hh
+++ b/src/Geometry/GeomTensorBase.hh
@@ -6,6 +6,8 @@
 #ifndef __Spheral__GeomTensorBase__
 #define __Spheral__GeomTensorBase__
 
+#include "config.hh"
+
 namespace Spheral {
 
 template<int nDim> class GeomTensorBase {};
@@ -13,23 +15,24 @@ template<int nDim> class GeomTensorBase {};
 template<>
 class GeomTensorBase<1> {
  public:
-  GeomTensorBase(const double xx):
+  SPHERAL_HOST_DEVICE GeomTensorBase(const double xx):
     mxx(xx) {}
  protected:
   double mxx;
  private:
-  GeomTensorBase();
+  SPHERAL_HOST_DEVICE GeomTensorBase();
 };
 
 template<>
 class GeomTensorBase<2> {
  public:
-  GeomTensorBase(const double a):
+  SPHERAL_HOST_DEVICE GeomTensorBase(const double a):
     mxx(a),
     mxy(a),
     myx(a),
     myy(a) {}
-  GeomTensorBase(const double xx, const double xy,
+  SPHERAL_HOST_DEVICE GeomTensorBase(
+                 const double xx, const double xy,
                  const double yx, const double yy):
     mxx(xx),
     mxy(xy),
@@ -39,13 +42,13 @@ class GeomTensorBase<2> {
   double mxx, mxy,
          myx, myy;
  private:
-  GeomTensorBase();
+  SPHERAL_HOST_DEVICE GeomTensorBase();
 };
 
 template<>
 class GeomTensorBase<3> {
  public:
-  GeomTensorBase(const double a):
+  SPHERAL_HOST_DEVICE GeomTensorBase(const double a):
     mxx(a),
     mxy(a),
     mxz(a),
@@ -55,7 +58,8 @@ class GeomTensorBase<3> {
     mzx(a),
     mzy(a), 
     mzz(a) {}
-  GeomTensorBase(const double xx, const double xy, const double xz,
+  SPHERAL_HOST_DEVICE GeomTensorBase(
+                 const double xx, const double xy, const double xz,
                  const double yx, const double yy, const double yz,
                  const double zx, const double zy, const double zz):
     mxx(xx),
@@ -72,7 +76,7 @@ class GeomTensorBase<3> {
          myx, myy, myz,
          mzx, mzy, mzz;
  private:
-  GeomTensorBase();
+  SPHERAL_HOST_DEVICE GeomTensorBase();
 };
 
 }

--- a/src/Geometry/GeomTensorInline_default.hh
+++ b/src/Geometry/GeomTensorInline_default.hh
@@ -14,6 +14,7 @@ namespace Spheral {
 // Return the element index corresponding to the given (row,column)
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 typename GeomTensor<nDim>::size_type
 GeomTensor<nDim>::elementIndex(const typename GeomTensor<nDim>::size_type row,
@@ -27,6 +28,7 @@ GeomTensor<nDim>::elementIndex(const typename GeomTensor<nDim>::size_type row,
 // Default constructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>::
 GeomTensor():
@@ -37,6 +39,7 @@ GeomTensor():
 // Construct with the given values for the elements.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>::
 GeomTensor(const double a11):
@@ -44,6 +47,7 @@ GeomTensor(const double a11):
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>::
 GeomTensor(const double a11, const double a12, 
@@ -53,6 +57,7 @@ GeomTensor(const double a11, const double a12,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>::
 GeomTensor(const double a11, const double a12, const double a13,
@@ -68,6 +73,7 @@ GeomTensor(const double a11, const double a12, const double a13,
 // dimensions.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>::
 GeomTensor(const double /*a11*/, const double /*a12*/,
@@ -77,6 +83,7 @@ GeomTensor(const double /*a11*/, const double /*a12*/,
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>::
 GeomTensor(const double /*a11*/, const double /*a12*/, const double /*a13*/,
@@ -90,6 +97,7 @@ GeomTensor(const double /*a11*/, const double /*a12*/, const double /*a13*/,
 // Copy constructors.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>::
 GeomTensor(const GeomTensor<nDim>& ten):
@@ -97,6 +105,7 @@ GeomTensor(const GeomTensor<nDim>& ten):
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>::
 GeomTensor(const GeomSymmetricTensor<1>& ten):
@@ -104,6 +113,7 @@ GeomTensor(const GeomSymmetricTensor<1>& ten):
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>::
 GeomTensor(const GeomSymmetricTensor<2>& ten):
@@ -112,6 +122,7 @@ GeomTensor(const GeomSymmetricTensor<2>& ten):
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>::
 GeomTensor(const GeomSymmetricTensor<3>& ten):
@@ -151,6 +162,7 @@ GeomTensor<3>::GeomTensor(const Eigen::MatrixBase<Derived>& ten):
 // Destructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>::~GeomTensor() {
 }
@@ -159,6 +171,7 @@ GeomTensor<nDim>::~GeomTensor() {
 // Assignment operators.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::
@@ -168,6 +181,7 @@ operator=(const GeomTensor<1>& ten) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::
@@ -180,6 +194,7 @@ operator=(const GeomTensor<2>& ten) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::
@@ -197,6 +212,7 @@ operator=(const GeomTensor<3>& ten) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::
@@ -206,6 +222,7 @@ operator=(const GeomSymmetricTensor<1>& ten) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::
@@ -218,6 +235,7 @@ operator=(const GeomSymmetricTensor<2>& ten) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::
@@ -279,6 +297,7 @@ GeomTensor<3>::operator=(const Eigen::MatrixBase<Derived>& ten) {
 // Access the elements by indicies.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::operator()(const typename GeomTensor<nDim>::size_type row,
@@ -289,6 +308,7 @@ GeomTensor<nDim>::operator()(const typename GeomTensor<nDim>::size_type row,
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double&
 GeomTensor<nDim>::operator()(const typename GeomTensor<nDim>::size_type row,
@@ -302,6 +322,7 @@ GeomTensor<nDim>::operator()(const typename GeomTensor<nDim>::size_type row,
 // Return the (index) element using the bracket operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::operator[](typename GeomTensor<nDim>::size_type index) const {
@@ -310,6 +331,7 @@ GeomTensor<nDim>::operator[](typename GeomTensor<nDim>::size_type index) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double&
 GeomTensor<nDim>::operator[](typename GeomTensor<nDim>::size_type index) {
@@ -324,6 +346,7 @@ GeomTensor<nDim>::operator[](typename GeomTensor<nDim>::size_type index) {
 //    zx, zy, zz     31, 32, 33
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::xx() const {
@@ -331,6 +354,7 @@ GeomTensor<nDim>::xx() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::xy() const {
@@ -338,6 +362,7 @@ GeomTensor<nDim>::xy() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::xz() const {
@@ -345,6 +370,7 @@ GeomTensor<nDim>::xz() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::yx() const {
@@ -352,6 +378,7 @@ GeomTensor<nDim>::yx() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::yy() const {
@@ -359,6 +386,7 @@ GeomTensor<nDim>::yy() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::yz() const {
@@ -366,6 +394,7 @@ GeomTensor<nDim>::yz() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::zx() const {
@@ -373,6 +402,7 @@ GeomTensor<nDim>::zx() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::zy() const {
@@ -380,6 +410,7 @@ GeomTensor<nDim>::zy() const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<nDim>::zz() const {
@@ -388,27 +419,28 @@ GeomTensor<nDim>::zz() const {
 
 //------------------------------------------------------------------------------
 // 1D dummy elements
-template<> inline double GeomTensor<1>::xy() const { return 0.0; }
-template<> inline double GeomTensor<1>::xz() const { return 0.0; }
-template<> inline double GeomTensor<1>::yx() const { return 0.0; }
-template<> inline double GeomTensor<1>::yy() const { return 0.0; }
-template<> inline double GeomTensor<1>::yz() const { return 0.0; }
-template<> inline double GeomTensor<1>::zx() const { return 0.0; }
-template<> inline double GeomTensor<1>::zy() const { return 0.0; }
-template<> inline double GeomTensor<1>::zz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<1>::xy() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<1>::xz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<1>::yx() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<1>::yy() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<1>::yz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<1>::zx() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<1>::zy() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<1>::zz() const { return 0.0; }
 
 //------------------------------------------------------------------------------
 // 2D dummy elements
-template<> inline double GeomTensor<2>::xz() const { return 0.0; }
-template<> inline double GeomTensor<2>::yz() const { return 0.0; }
-template<> inline double GeomTensor<2>::zx() const { return 0.0; }
-template<> inline double GeomTensor<2>::zy() const { return 0.0; }
-template<> inline double GeomTensor<2>::zz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<2>::xz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<2>::yz() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<2>::zx() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<2>::zy() const { return 0.0; }
+template<> SPHERAL_HOST_DEVICE inline double GeomTensor<2>::zz() const { return 0.0; }
 
 //------------------------------------------------------------------------------
 // Set the individual elements, as above.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<nDim>::xx(const double val) {
@@ -416,6 +448,7 @@ GeomTensor<nDim>::xx(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<nDim>::xy(const double val) {
@@ -423,6 +456,7 @@ GeomTensor<nDim>::xy(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<nDim>::xz(const double val) {
@@ -430,6 +464,7 @@ GeomTensor<nDim>::xz(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<nDim>::yx(const double val) {
@@ -437,6 +472,7 @@ GeomTensor<nDim>::yx(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<nDim>::yy(const double val) {
@@ -444,6 +480,7 @@ GeomTensor<nDim>::yy(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<nDim>::yz(const double val) {
@@ -451,6 +488,7 @@ GeomTensor<nDim>::yz(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<nDim>::zx(const double val) {
@@ -458,6 +496,7 @@ GeomTensor<nDim>::zx(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<nDim>::zy(const double val) {
@@ -465,6 +504,7 @@ GeomTensor<nDim>::zy(const double val) {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<nDim>::zz(double val) {
@@ -473,27 +513,28 @@ GeomTensor<nDim>::zz(double val) {
 
 //------------------------------------------------------------------------------
 // 1D dummy elements
-template<> inline void GeomTensor<1>::xy(const double /*val*/) {}
-template<> inline void GeomTensor<1>::xz(const double /*val*/) {}
-template<> inline void GeomTensor<1>::yx(const double /*val*/) {}
-template<> inline void GeomTensor<1>::yy(const double /*val*/) {}
-template<> inline void GeomTensor<1>::yz(const double /*val*/) {}
-template<> inline void GeomTensor<1>::zx(const double /*val*/) {}
-template<> inline void GeomTensor<1>::zy(const double /*val*/) {}
-template<> inline void GeomTensor<1>::zz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<1>::xy(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<1>::xz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<1>::yx(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<1>::yy(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<1>::yz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<1>::zx(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<1>::zy(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<1>::zz(const double /*val*/) {}
 
 //------------------------------------------------------------------------------
 // 2D dummy elements
-template<> inline void GeomTensor<2>::xz(const double /*val*/) {}
-template<> inline void GeomTensor<2>::yz(const double /*val*/) {}
-template<> inline void GeomTensor<2>::zx(const double /*val*/) {}
-template<> inline void GeomTensor<2>::zy(const double /*val*/) {}
-template<> inline void GeomTensor<2>::zz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<2>::xz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<2>::yz(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<2>::zx(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<2>::zy(const double /*val*/) {}
+template<> SPHERAL_HOST_DEVICE inline void GeomTensor<2>::zz(const double /*val*/) {}
 
 //------------------------------------------------------------------------------
 // Access the individual rows of the GeomTensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<1>
 GeomTensor<1>::getRow(const GeomTensor<1>::size_type index) const {
@@ -502,6 +543,7 @@ GeomTensor<1>::getRow(const GeomTensor<1>::size_type index) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<2>
 GeomTensor<2>::getRow(const GeomTensor<2>::size_type index) const {
@@ -510,6 +552,7 @@ GeomTensor<2>::getRow(const GeomTensor<2>::size_type index) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<3>
 GeomTensor<3>::getRow(const GeomTensor<3>::size_type index) const {
@@ -521,6 +564,7 @@ GeomTensor<3>::getRow(const GeomTensor<3>::size_type index) const {
 // Access the individual columns of the GeomTensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<1>
 GeomTensor<1>::getColumn(const GeomTensor<2>::size_type index) const {
@@ -529,6 +573,7 @@ GeomTensor<1>::getColumn(const GeomTensor<2>::size_type index) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<2>
 GeomTensor<2>::getColumn(const GeomTensor<2>::size_type index) const {
@@ -537,6 +582,7 @@ GeomTensor<2>::getColumn(const GeomTensor<2>::size_type index) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<3>
 GeomTensor<3>::getColumn(const GeomTensor<3>::size_type index) const {
@@ -548,6 +594,7 @@ GeomTensor<3>::getColumn(const GeomTensor<3>::size_type index) const {
 // Set a row of the GeomTensor to a GeomVector.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<1>::setRow(const GeomTensor<1>::size_type index,
@@ -557,6 +604,7 @@ GeomTensor<1>::setRow(const GeomTensor<1>::size_type index,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<2>::setRow(const GeomTensor<2>::size_type index,
@@ -567,6 +615,7 @@ GeomTensor<2>::setRow(const GeomTensor<2>::size_type index,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<3>::setRow(const GeomTensor<3>::size_type index,
@@ -581,6 +630,7 @@ GeomTensor<3>::setRow(const GeomTensor<3>::size_type index,
 // Set a column of the GeomTensor to a GeomVector.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<1>::setColumn(const GeomTensor<1>::size_type index,
@@ -590,6 +640,7 @@ GeomTensor<1>::setColumn(const GeomTensor<1>::size_type index,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<2>::setColumn(const GeomTensor<2>::size_type index,
@@ -600,6 +651,7 @@ GeomTensor<2>::setColumn(const GeomTensor<2>::size_type index,
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<3>::setColumn(const GeomTensor<3>::size_type index,
@@ -614,6 +666,7 @@ GeomTensor<3>::setColumn(const GeomTensor<3>::size_type index,
 // Iterators to the raw data.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 typename GeomTensor<nDim>::iterator
 GeomTensor<nDim>::begin() {
@@ -621,6 +674,7 @@ GeomTensor<nDim>::begin() {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 typename GeomTensor<nDim>::iterator
 GeomTensor<nDim>::end() {
@@ -628,6 +682,7 @@ GeomTensor<nDim>::end() {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 typename GeomTensor<nDim>::const_iterator
 GeomTensor<nDim>::begin() const{
@@ -635,6 +690,7 @@ GeomTensor<nDim>::begin() const{
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 typename GeomTensor<nDim>::const_iterator
 GeomTensor<nDim>::end() const {
@@ -645,6 +701,7 @@ GeomTensor<nDim>::end() const {
 // Zero out the GeomTensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<1>::Zero() {
@@ -652,6 +709,7 @@ GeomTensor<1>::Zero() {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<2>::Zero() {
@@ -662,6 +720,7 @@ GeomTensor<2>::Zero() {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<3>::Zero() {
@@ -680,6 +739,7 @@ GeomTensor<3>::Zero() {
 // Force the tensor to be the identity tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<1>::Identity() {
@@ -687,6 +747,7 @@ GeomTensor<1>::Identity() {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<2>::Identity() {
@@ -697,6 +758,7 @@ GeomTensor<2>::Identity() {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<3>::Identity() {
@@ -715,6 +777,7 @@ GeomTensor<3>::Identity() {
 // Return the negative of a tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::operator-() const {
@@ -724,6 +787,7 @@ GeomTensor<1>::operator-() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::operator-() const {
@@ -736,6 +800,7 @@ GeomTensor<2>::operator-() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::operator-() const {
@@ -756,6 +821,7 @@ GeomTensor<3>::operator-() const {
 // Add two tensors.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomTensor<nDim>::
@@ -766,6 +832,7 @@ operator+(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomTensor<nDim>::
@@ -779,6 +846,7 @@ operator+(const GeomSymmetricTensor<nDim>& rhs) const {
 // Subtract a tensor from another.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomTensor<nDim>::
@@ -789,6 +857,7 @@ operator-(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomTensor<nDim>::
@@ -802,6 +871,7 @@ operator-(const GeomSymmetricTensor<nDim>& rhs) const {
 // Multiply two tensors.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomTensor<nDim>::
@@ -810,6 +880,7 @@ operator*(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<nDim>
 GeomTensor<nDim>::
@@ -821,6 +892,7 @@ operator*(const GeomSymmetricTensor<nDim>& rhs) const {
 // Multiply a tensor with a vector.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<nDim>
 GeomTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
@@ -831,6 +903,7 @@ GeomTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // // Add a scalar to a tensor.
 // //------------------------------------------------------------------------------
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<1>
 // GeomTensor<1>::operator+(const double rhs) const {
@@ -838,6 +911,7 @@ GeomTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<2>
 // GeomTensor<2>::operator+(const double rhs) const {
@@ -846,6 +920,7 @@ GeomTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<3>
 // GeomTensor<3>::operator+(const double rhs) const {
@@ -858,6 +933,7 @@ GeomTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // // Subtract a scalar from a tensor.
 // //------------------------------------------------------------------------------
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<1>
 // GeomTensor<1>::operator-(const double rhs) const {
@@ -865,6 +941,7 @@ GeomTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<2>
 // GeomTensor<2>::operator-(const double rhs) const {
@@ -873,6 +950,7 @@ GeomTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<3>
 // GeomTensor<3>::operator-(const double rhs) const {
@@ -886,6 +964,7 @@ GeomTensor<nDim>::operator*(const GeomVector<nDim>& rhs) const {
 // Multiply a tensor by a scalar
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::operator*(const double rhs) const {
@@ -893,6 +972,7 @@ GeomTensor<1>::operator*(const double rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::operator*(const double rhs) const {
@@ -901,6 +981,7 @@ GeomTensor<2>::operator*(const double rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::operator*(const double rhs) const {
@@ -914,6 +995,7 @@ GeomTensor<3>::operator*(const double rhs) const {
 // Divide a tensor by a scalar
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::operator/(const double rhs) const {
@@ -922,6 +1004,7 @@ GeomTensor<1>::operator/(const double rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::operator/(const double rhs) const {
@@ -932,6 +1015,7 @@ GeomTensor<2>::operator/(const double rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::operator/(const double rhs) const {
@@ -947,6 +1031,7 @@ GeomTensor<3>::operator/(const double rhs) const {
 // += tensor
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::operator+=(const GeomTensor<1>& rhs) {
@@ -955,6 +1040,7 @@ GeomTensor<1>::operator+=(const GeomTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::operator+=(const GeomTensor<2>& rhs) {
@@ -966,6 +1052,7 @@ GeomTensor<2>::operator+=(const GeomTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::operator+=(const GeomTensor<3>& rhs) {
@@ -985,6 +1072,7 @@ GeomTensor<3>::operator+=(const GeomTensor<3>& rhs) {
 // += symmetric tensor
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::operator+=(const GeomSymmetricTensor<1>& rhs) {
@@ -993,6 +1081,7 @@ GeomTensor<1>::operator+=(const GeomSymmetricTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::operator+=(const GeomSymmetricTensor<2>& rhs) {
@@ -1004,6 +1093,7 @@ GeomTensor<2>::operator+=(const GeomSymmetricTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::operator+=(const GeomSymmetricTensor<3>& rhs) {
@@ -1064,6 +1154,7 @@ GeomTensor<3>::operator+=(const Eigen::MatrixBase<Derived>& rhs) {
 // -= tensor
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::operator-=(const GeomTensor<1>& rhs) {
@@ -1072,6 +1163,7 @@ GeomTensor<1>::operator-=(const GeomTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::operator-=(const GeomTensor<2>& rhs) {
@@ -1083,6 +1175,7 @@ GeomTensor<2>::operator-=(const GeomTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::operator-=(const GeomTensor<3>& rhs) {
@@ -1102,6 +1195,7 @@ GeomTensor<3>::operator-=(const GeomTensor<3>& rhs) {
 // -= symmetric tensor
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::operator-=(const GeomSymmetricTensor<1>& rhs) {
@@ -1110,6 +1204,7 @@ GeomTensor<1>::operator-=(const GeomSymmetricTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::operator-=(const GeomSymmetricTensor<2>& rhs) {
@@ -1121,6 +1216,7 @@ GeomTensor<2>::operator-=(const GeomSymmetricTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::operator-=(const GeomSymmetricTensor<3>& rhs) {
@@ -1181,6 +1277,7 @@ GeomTensor<3>::operator-=(const Eigen::MatrixBase<Derived>& rhs) {
 // Multiply by a tensor in place.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::operator*=(const GeomTensor<1>& rhs) {
@@ -1189,6 +1286,7 @@ GeomTensor<1>::operator*=(const GeomTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::operator*=(const GeomTensor<2>& rhs) {
@@ -1204,6 +1302,7 @@ GeomTensor<2>::operator*=(const GeomTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::operator*=(const GeomTensor<3>& rhs) {
@@ -1229,6 +1328,7 @@ GeomTensor<3>::operator*=(const GeomTensor<3>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::operator*=(const GeomSymmetricTensor<1>& rhs) {
@@ -1237,6 +1337,7 @@ GeomTensor<1>::operator*=(const GeomSymmetricTensor<1>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::operator*=(const GeomSymmetricTensor<2>& rhs) {
@@ -1252,6 +1353,7 @@ GeomTensor<2>::operator*=(const GeomSymmetricTensor<2>& rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>& rhs) {
@@ -1280,6 +1382,7 @@ GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>& rhs) {
 // // Add a scalar to this tensor in place.
 // //------------------------------------------------------------------------------
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<1>&
 // GeomTensor<1>::operator+=(const double rhs) {
@@ -1288,6 +1391,7 @@ GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>& rhs) {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<2>&
 // GeomTensor<2>::operator+=(const double rhs) {
@@ -1299,6 +1403,7 @@ GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>& rhs) {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<3>&
 // GeomTensor<3>::operator+=(const double rhs) {
@@ -1318,6 +1423,7 @@ GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>& rhs) {
 // // Subtract a scalar from this tensor in place.
 // //------------------------------------------------------------------------------
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<1>&
 // GeomTensor<1>::operator-=(const double rhs) {
@@ -1326,6 +1432,7 @@ GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>& rhs) {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<2>&
 // GeomTensor<2>::operator-=(const double rhs) {
@@ -1337,6 +1444,7 @@ GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>& rhs) {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // GeomTensor<3>&
 // GeomTensor<3>::operator-=(const double rhs) {
@@ -1356,6 +1464,7 @@ GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>& rhs) {
 // Multiply this tensor by a scalar in place.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::operator*=(const double rhs) {
@@ -1364,6 +1473,7 @@ GeomTensor<1>::operator*=(const double rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::operator*=(const double rhs) {
@@ -1375,6 +1485,7 @@ GeomTensor<2>::operator*=(const double rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::operator*=(const double rhs) {
@@ -1394,6 +1505,7 @@ GeomTensor<3>::operator*=(const double rhs) {
 // Divide this tensor by a scalar in place
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>&
 GeomTensor<1>::operator/=(const double rhs) {
@@ -1403,6 +1515,7 @@ GeomTensor<1>::operator/=(const double rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>&
 GeomTensor<2>::operator/=(const double rhs) {
@@ -1416,6 +1529,7 @@ GeomTensor<2>::operator/=(const double rhs) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>&
 GeomTensor<3>::operator/=(const double rhs) {
@@ -1437,6 +1551,7 @@ GeomTensor<3>::operator/=(const double rhs) {
 // Define the equivalence operator.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<1>::
@@ -1445,6 +1560,7 @@ operator==(const GeomTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<2>::
@@ -1456,6 +1572,7 @@ operator==(const GeomTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<3>::
@@ -1472,6 +1589,7 @@ operator==(const GeomTensor<3>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<1>::
@@ -1480,6 +1598,7 @@ operator==(const GeomSymmetricTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<2>::
@@ -1491,6 +1610,7 @@ operator==(const GeomSymmetricTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<3>::
@@ -1507,6 +1627,7 @@ operator==(const GeomSymmetricTensor<3>& rhs) const {
 }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<1>::
@@ -1515,6 +1636,7 @@ operator==(const GeomSymmetricTensor<3>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<2>::
@@ -1526,6 +1648,7 @@ operator==(const GeomSymmetricTensor<3>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<3>::
@@ -1545,6 +1668,7 @@ operator==(const GeomSymmetricTensor<3>& rhs) const {
 // Define the not equivalence than comparitor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1553,6 +1677,7 @@ operator!=(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1561,6 +1686,7 @@ operator!=(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<int nDim>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<nDim>::
@@ -1572,6 +1698,7 @@ operator!=(const GeomSymmetricTensor<nDim>& rhs) const {
 // Define the less than operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1580,6 +1707,7 @@ operator<(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1588,6 +1716,7 @@ operator<(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<1>::
@@ -1596,6 +1725,7 @@ operator<(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<2>::
@@ -1607,6 +1737,7 @@ operator<(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<3>::
@@ -1626,6 +1757,7 @@ operator<(const GeomSymmetricTensor<nDim>& rhs) const {
 // Define the greater than operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1634,6 +1766,7 @@ operator>(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1642,6 +1775,7 @@ operator>(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<int nDim>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<nDim>::
@@ -1650,6 +1784,7 @@ operator>(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<2>::
@@ -1661,6 +1796,7 @@ operator>(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<3>::
@@ -1680,6 +1816,7 @@ operator>(const GeomSymmetricTensor<nDim>& rhs) const {
 // Define the less than or equal operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1688,6 +1825,7 @@ operator<=(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1696,6 +1834,7 @@ operator<=(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<1>::
@@ -1704,6 +1843,7 @@ operator<=(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<2>::
@@ -1715,6 +1855,7 @@ operator<=(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<3>::
@@ -1734,6 +1875,7 @@ operator<=(const GeomSymmetricTensor<nDim>& rhs) const {
 // Define the greater than or equal operator.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1742,6 +1884,7 @@ operator>=(const GeomTensor<nDim>& rhs) const {
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 bool
 GeomTensor<nDim>::
@@ -1750,6 +1893,7 @@ operator>=(const GeomSymmetricTensor<nDim>& rhs) const {
 }
 
 // template<int nDim>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<nDim>::
@@ -1758,6 +1902,7 @@ operator>=(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<2>::
@@ -1769,6 +1914,7 @@ operator>=(const GeomSymmetricTensor<nDim>& rhs) const {
 // }
 
 // template<>
+// SPHERAL_HOST_DEVICE
 // inline
 // bool
 // GeomTensor<3>::
@@ -1789,6 +1935,7 @@ operator>=(const GeomSymmetricTensor<nDim>& rhs) const {
 //   Bij = 0.5*(Aij + Aji)
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<1>
 GeomTensor<1>::Symmetric() const {
@@ -1796,6 +1943,7 @@ GeomTensor<1>::Symmetric() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<2>
 GeomTensor<2>::Symmetric() const {
@@ -1807,6 +1955,7 @@ GeomTensor<2>::Symmetric() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomSymmetricTensor<3>
 GeomTensor<3>::Symmetric() const {
@@ -1825,6 +1974,7 @@ GeomTensor<3>::Symmetric() const {
 //   Bij = 0.5*(Aij - Aji)
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::SkewSymmetric() const {
@@ -1832,6 +1982,7 @@ GeomTensor<1>::SkewSymmetric() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::SkewSymmetric() const {
@@ -1842,6 +1993,7 @@ GeomTensor<2>::SkewSymmetric() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::SkewSymmetric() const {
@@ -1859,6 +2011,7 @@ GeomTensor<3>::SkewSymmetric() const {
 // Return the transpose of the GeomTensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::
@@ -1867,6 +2020,7 @@ Transpose() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::
@@ -1876,6 +2030,7 @@ Transpose() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::
@@ -1889,6 +2044,7 @@ Transpose() const {
 // Return the inverse of the tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::Inverse() const {
@@ -1897,6 +2053,7 @@ GeomTensor<1>::Inverse() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::Inverse() const {
@@ -1906,6 +2063,7 @@ GeomTensor<2>::Inverse() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::Inverse() const {
@@ -1919,6 +2077,7 @@ GeomTensor<3>::Inverse() const {
 // Return the diagonal elements of the GeomTensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<1>
 GeomTensor<1>::diagonalElements() const {
@@ -1926,6 +2085,7 @@ GeomTensor<1>::diagonalElements() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<2>
 GeomTensor<2>::diagonalElements() const {
@@ -1933,6 +2093,7 @@ GeomTensor<2>::diagonalElements() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<3>
 GeomTensor<3>::diagonalElements() const {
@@ -1943,6 +2104,7 @@ GeomTensor<3>::diagonalElements() const {
 // Return the trace of the tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<1>::Trace() const {
@@ -1950,6 +2112,7 @@ GeomTensor<1>::Trace() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<2>::Trace() const {
@@ -1957,6 +2120,7 @@ GeomTensor<2>::Trace() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<3>::Trace() const {
@@ -1967,6 +2131,7 @@ GeomTensor<3>::Trace() const {
 // Return the determinant of the tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<1>::Determinant() const {
@@ -1974,6 +2139,7 @@ GeomTensor<1>::Determinant() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<2>::Determinant() const {
@@ -1981,6 +2147,7 @@ GeomTensor<2>::Determinant() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<3>::Determinant() const {
@@ -1992,6 +2159,7 @@ GeomTensor<3>::Determinant() const {
 // Multiply a tensor with a vector.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<1>
 GeomTensor<1>::dot(const GeomVector<1>& rhs) const {
@@ -1999,6 +2167,7 @@ GeomTensor<1>::dot(const GeomVector<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<2>
 GeomTensor<2>::dot(const GeomVector<2>& rhs) const {
@@ -2007,6 +2176,7 @@ GeomTensor<2>::dot(const GeomVector<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomVector<3>
 GeomTensor<3>::dot(const GeomVector<3>& rhs) const {
@@ -2020,6 +2190,7 @@ GeomTensor<3>::dot(const GeomVector<3>& rhs) const {
 // multiplication.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::dot(const GeomTensor<1>& rhs) const {
@@ -2027,6 +2198,7 @@ GeomTensor<1>::dot(const GeomTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::dot(const GeomTensor<2>& rhs) const {
@@ -2037,6 +2209,7 @@ GeomTensor<2>::dot(const GeomTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::dot(const GeomTensor<3>& rhs) const {
@@ -2052,6 +2225,7 @@ GeomTensor<3>::dot(const GeomTensor<3>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::dot(const GeomSymmetricTensor<1>& rhs) const {
@@ -2060,6 +2234,7 @@ GeomTensor<1>::dot(const GeomSymmetricTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::dot(const GeomSymmetricTensor<2>& rhs) const {
@@ -2070,6 +2245,7 @@ GeomTensor<2>::dot(const GeomSymmetricTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::dot(const GeomSymmetricTensor<3>& rhs) const {
@@ -2088,6 +2264,7 @@ GeomTensor<3>::dot(const GeomSymmetricTensor<3>& rhs) const {
 // Return the doubledot product.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<1>::
@@ -2096,6 +2273,7 @@ doubledot(const GeomTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<2>::
@@ -2105,6 +2283,7 @@ doubledot(const GeomTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<3>::
@@ -2118,6 +2297,7 @@ doubledot(const GeomTensor<3>& rhs) const {
 // Return the doubledot product with a symmetric tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<1>::
@@ -2126,6 +2306,7 @@ doubledot(const GeomSymmetricTensor<1>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<2>::
@@ -2135,6 +2316,7 @@ doubledot(const GeomSymmetricTensor<2>& rhs) const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<3>::
@@ -2148,6 +2330,7 @@ doubledot(const GeomSymmetricTensor<3>& rhs) const {
 // Return the doubledot product with ourself.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<1>::
@@ -2156,6 +2339,7 @@ selfDoubledot() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<2>::
@@ -2165,6 +2349,7 @@ selfDoubledot() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<3>::
@@ -2178,6 +2363,7 @@ selfDoubledot() const {
 // Return the square of this tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::
@@ -2186,6 +2372,7 @@ square() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::
@@ -2197,6 +2384,7 @@ square() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::
@@ -2216,6 +2404,7 @@ square() const {
 // Return a new tensor with the elements of this tensor squared.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<1>
 GeomTensor<1>::
@@ -2224,6 +2413,7 @@ squareElements() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<2>
 GeomTensor<2>::
@@ -2235,6 +2425,7 @@ squareElements() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 GeomTensor<3>
 GeomTensor<3>::
@@ -2254,6 +2445,7 @@ squareElements() const {
 // Apply a rotational transform to this tensor.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<1>::
@@ -2263,6 +2455,7 @@ rotationalTransform(const GeomTensor<1>& R) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<2>::
@@ -2291,6 +2484,7 @@ rotationalTransform(const GeomTensor<2>& R) {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 void
 GeomTensor<3>::
@@ -2342,6 +2536,7 @@ rotationalTransform(const GeomTensor<3>& R) {
 // Return the maximum absolute value of the elements.
 //------------------------------------------------------------------------------
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<1>::
@@ -2350,6 +2545,7 @@ maxAbsElement() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<2>::
@@ -2361,6 +2557,7 @@ maxAbsElement() const {
 }
 
 template<>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomTensor<3>::

--- a/src/Geometry/GeomTensorInline_default.hh
+++ b/src/Geometry/GeomTensorInline_default.hh
@@ -25,17 +25,6 @@ GeomTensor<nDim>::elementIndex(const typename GeomTensor<nDim>::size_type row,
 }
 
 //------------------------------------------------------------------------------
-// Default constructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomTensor<nDim>::
-GeomTensor():
-  GeomTensorBase<nDim>(0.0) {
-}
-
-//------------------------------------------------------------------------------
 // Construct with the given values for the elements.
 //------------------------------------------------------------------------------
 template<int nDim>
@@ -96,14 +85,6 @@ GeomTensor(const double /*a11*/, const double /*a12*/, const double /*a13*/,
 //------------------------------------------------------------------------------
 // Copy constructors.
 //------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomTensor<nDim>::
-GeomTensor(const GeomTensor<nDim>& ten):
-  GeomTensorBase<nDim>(ten) {
-}
-
 template<>
 SPHERAL_HOST_DEVICE
 inline
@@ -159,58 +140,8 @@ GeomTensor<3>::GeomTensor(const Eigen::MatrixBase<Derived>& ten):
 }
 
 //------------------------------------------------------------------------------
-// Destructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomTensor<nDim>::~GeomTensor() {
-}
-
-//------------------------------------------------------------------------------
 // Assignment operators.
 //------------------------------------------------------------------------------
-template<>
-SPHERAL_HOST_DEVICE
-inline
-GeomTensor<1>&
-GeomTensor<1>::
-operator=(const GeomTensor<1>& ten) {
-  this->mxx = ten.mxx;
-  return *this;
-}
-
-template<>
-SPHERAL_HOST_DEVICE
-inline
-GeomTensor<2>&
-GeomTensor<2>::
-operator=(const GeomTensor<2>& ten) {
-  this->mxx = ten.mxx;
-  this->mxy = ten.mxy;
-  this->myx = ten.myx;
-  this->myy = ten.myy;
-  return *this;
-}
-
-template<>
-SPHERAL_HOST_DEVICE
-inline
-GeomTensor<3>&
-GeomTensor<3>::
-operator=(const GeomTensor<3>& ten) {
-  this->mxx = ten.mxx;
-  this->mxy = ten.mxy;
-  this->mxz = ten.mxz;
-  this->myx = ten.myx;
-  this->myy = ten.myy;
-  this->myz = ten.myz;
-  this->mzx = ten.mzx;
-  this->mzy = ten.mzy;
-  this->mzz = ten.mzz;
-  return *this;
-}
-
 template<>
 SPHERAL_HOST_DEVICE
 inline

--- a/src/Geometry/GeomTensor_default.cc
+++ b/src/Geometry/GeomTensor_default.cc
@@ -51,19 +51,16 @@ GeomTensor<3>::eigenValues() const {
 // Set the static variables.
 //------------------------------------------------------------------------------
 template<> const unsigned GeomTensor<1>::nDimensions = 1;
-template<> const unsigned GeomTensor<1>::numElements = 1;
 template<> const GeomTensor<1> GeomTensor<1>::zero = GeomTensor<1>(0.0);
 template<> const GeomTensor<1> GeomTensor<1>::one = GeomTensor<1>(1.0);
 
 template<> const unsigned GeomTensor<2>::nDimensions = 2;
-template<> const unsigned GeomTensor<2>::numElements = 4;
 template<> const GeomTensor<2> GeomTensor<2>::zero = GeomTensor<2>(0.0, 0.0,
                                                                    0.0, 0.0);
 template<> const GeomTensor<2> GeomTensor<2>::one = GeomTensor<2>(1.0, 0.0,
                                                                   0.0, 1.0);
 
 template<> const unsigned GeomTensor<3>::nDimensions = 3;
-template<> const unsigned GeomTensor<3>::numElements = 9;
 template<> const GeomTensor<3> GeomTensor<3>::zero = GeomTensor<3>(0.0, 0.0, 0.0,
                                                                    0.0, 0.0, 0.0,
                                                                    0.0, 0.0, 0.0);

--- a/src/Geometry/GeomTensor_default.hh
+++ b/src/Geometry/GeomTensor_default.hh
@@ -46,114 +46,114 @@ public:
   static const GeomTensor one;
 
   // Constructors.
-  GeomTensor();
-  explicit GeomTensor(const double a11);
-  GeomTensor(const double a11, const double a12,
+  SPHERAL_HOST_DEVICE GeomTensor();
+  SPHERAL_HOST_DEVICE explicit GeomTensor(const double a11);
+  SPHERAL_HOST_DEVICE GeomTensor(const double a11, const double a12,
              const double a21, const double a22);
-  GeomTensor(const double a11, const double a12, const double a13,
+  SPHERAL_HOST_DEVICE GeomTensor(const double a11, const double a12, const double a13,
              const double a21, const double a22, const double a23,
              const double a31, const double a32, const double a33);
-  GeomTensor(const GeomTensor& ten);
-  explicit GeomTensor(const GeomSymmetricTensor<nDim>& ten);
+  SPHERAL_HOST_DEVICE GeomTensor(const GeomTensor& ten);
+  SPHERAL_HOST_DEVICE explicit GeomTensor(const GeomSymmetricTensor<nDim>& ten);
   GeomTensor(const EigenType& ten);
   template<typename Derived> GeomTensor(const Eigen::MatrixBase<Derived>& ten);
 
   // Destructor.
-  ~GeomTensor();
+  SPHERAL_HOST_DEVICE ~GeomTensor();
 
   // Assignment.
-  GeomTensor& operator=(const GeomTensor& rhs);
-  GeomTensor& operator=(const GeomSymmetricTensor<nDim>& rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator=(const GeomTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator=(const GeomSymmetricTensor<nDim>& rhs);
   template<typename Derived> GeomTensor& operator=(const Eigen::MatrixBase<Derived>& rhs);
 
   // Access the elements by indicies.
-  double operator()(const size_type row, const size_type column) const;
-  double& operator()(const size_type row, const size_type column);
+  SPHERAL_HOST_DEVICE double operator()(const size_type row, const size_type column) const;
+  SPHERAL_HOST_DEVICE double& operator()(const size_type row, const size_type column);
 
   // More C++ style indexing.
-  double operator[](size_type index) const;
-  double& operator[](size_type index);
+  SPHERAL_HOST_DEVICE double operator[](size_type index) const;
+  SPHERAL_HOST_DEVICE double& operator[](size_type index);
 
   // Access the individual elements by (x,y,z) notation.
-  double xx() const;
-  double xy() const;
-  double xz() const;
-  double yx() const;
-  double yy() const;
-  double yz() const;
-  double zx() const;
-  double zy() const;
-  double zz() const;
-  void xx(double val);
-  void xy(double val);
-  void xz(double val);
-  void yx(double val);
-  void yy(double val);
-  void yz(double val);
-  void zx(double val);
-  void zy(double val);
-  void zz(double val);
+  SPHERAL_HOST_DEVICE double xx() const;
+  SPHERAL_HOST_DEVICE double xy() const;
+  SPHERAL_HOST_DEVICE double xz() const;
+  SPHERAL_HOST_DEVICE double yx() const;
+  SPHERAL_HOST_DEVICE double yy() const;
+  SPHERAL_HOST_DEVICE double yz() const;
+  SPHERAL_HOST_DEVICE double zx() const;
+  SPHERAL_HOST_DEVICE double zy() const;
+  SPHERAL_HOST_DEVICE double zz() const;
+  SPHERAL_HOST_DEVICE void xx(double val);
+  SPHERAL_HOST_DEVICE void xy(double val);
+  SPHERAL_HOST_DEVICE void xz(double val);
+  SPHERAL_HOST_DEVICE void yx(double val);
+  SPHERAL_HOST_DEVICE void yy(double val);
+  SPHERAL_HOST_DEVICE void yz(double val);
+  SPHERAL_HOST_DEVICE void zx(double val);
+  SPHERAL_HOST_DEVICE void zy(double val);
+  SPHERAL_HOST_DEVICE void zz(double val);
 
   // Get/set rows and columns.
-  GeomVector<nDim> getRow(size_type index) const;
-  GeomVector<nDim> getColumn(size_type index) const;
-  void setRow(size_type index, const GeomVector<nDim>& vec);
-  void setColumn(size_type index, const GeomVector<nDim>& vec);
+  SPHERAL_HOST_DEVICE GeomVector<nDim> getRow(size_type index) const;
+  SPHERAL_HOST_DEVICE GeomVector<nDim> getColumn(size_type index) const;
+  SPHERAL_HOST_DEVICE void setRow(size_type index, const GeomVector<nDim>& vec);
+  SPHERAL_HOST_DEVICE void setColumn(size_type index, const GeomVector<nDim>& vec);
 
   // Iterator access to the raw data.
-  iterator begin();
-  iterator end();
+  SPHERAL_HOST_DEVICE iterator begin();
+  SPHERAL_HOST_DEVICE iterator end();
 
-  const_iterator begin() const;
-  const_iterator end() const;
+  SPHERAL_HOST_DEVICE const_iterator begin() const;
+  SPHERAL_HOST_DEVICE const_iterator end() const;
 
   // The zero and identity matrices.
-  void Zero();
-  void Identity();
+  SPHERAL_HOST_DEVICE void Zero();
+  SPHERAL_HOST_DEVICE void Identity();
 
-  GeomTensor operator-() const;
+  SPHERAL_HOST_DEVICE GeomTensor operator-() const;
 
-  GeomTensor operator+(const GeomTensor& rhs) const;
-  GeomTensor operator-(const GeomTensor& rhs) const;
-  GeomTensor operator*(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor operator+(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor operator-(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor operator*(const GeomTensor& rhs) const;
 
-  GeomTensor operator+(const GeomSymmetricTensor<nDim>& rhs) const;
-  GeomTensor operator-(const GeomSymmetricTensor<nDim>& rhs) const;
-  GeomTensor operator*(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor operator+(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor operator-(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor operator*(const GeomSymmetricTensor<nDim>& rhs) const;
 
-  GeomVector<nDim> operator*(const GeomVector<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE GeomVector<nDim> operator*(const GeomVector<nDim>& rhs) const;
   // GeomTensor operator+(const double val) const;
   // GeomTensor operator-(const double val) const;
-  GeomTensor operator*(const double val) const;
-  GeomTensor operator/(const double val) const;
+  SPHERAL_HOST_DEVICE GeomTensor operator*(const double val) const;
+  SPHERAL_HOST_DEVICE GeomTensor operator/(const double val) const;
 
-  GeomTensor& operator+=(const GeomTensor& rhs);
-  GeomTensor& operator-=(const GeomTensor& rhs);
-  GeomTensor& operator*=(const GeomTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator+=(const GeomTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator-=(const GeomTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator*=(const GeomTensor& rhs);
 
-  GeomTensor& operator+=(const GeomSymmetricTensor<nDim>& rhs);
-  GeomTensor& operator-=(const GeomSymmetricTensor<nDim>& rhs);
-  GeomTensor& operator*=(const GeomSymmetricTensor<nDim>& rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator+=(const GeomSymmetricTensor<nDim>& rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator-=(const GeomSymmetricTensor<nDim>& rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator*=(const GeomSymmetricTensor<nDim>& rhs);
 
   template<typename Derived> GeomTensor& operator+=(const Eigen::MatrixBase<Derived>& rhs);
   template<typename Derived> GeomTensor& operator-=(const Eigen::MatrixBase<Derived>& rhs);
 
-  GeomTensor& operator*=(const double rhs);
-  GeomTensor& operator/=(const double rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator*=(const double rhs);
+  SPHERAL_HOST_DEVICE GeomTensor& operator/=(const double rhs);
 
-  bool operator==(const GeomTensor& rhs) const;
-  bool operator!=(const GeomTensor& rhs) const;
-  bool operator<(const GeomTensor& rhs) const;
-  bool operator>(const GeomTensor& rhs) const;
-  bool operator<=(const GeomTensor& rhs) const;
-  bool operator>=(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator==(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator!=(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<=(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>=(const GeomTensor& rhs) const;
 
-  bool operator==(const GeomSymmetricTensor<nDim>& rhs) const;
-  bool operator!=(const GeomSymmetricTensor<nDim>& rhs) const;
-  bool operator<(const GeomSymmetricTensor<nDim>& rhs) const;
-  bool operator>(const GeomSymmetricTensor<nDim>& rhs) const;
-  bool operator<=(const GeomSymmetricTensor<nDim>& rhs) const;
-  bool operator>=(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator==(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator!=(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<=(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>=(const GeomSymmetricTensor<nDim>& rhs) const;
 
   // bool operator==(const double rhs) const;
   // bool operator!=(const double rhs) const;
@@ -162,42 +162,42 @@ public:
   // bool operator<=(const double rhs) const;
   // bool operator>=(const double rhs) const;
 
-  GeomSymmetricTensor<nDim> Symmetric() const;
-  GeomTensor SkewSymmetric() const;
-  GeomTensor Transpose() const;
-  GeomTensor Inverse() const;
-  GeomVector<nDim> diagonalElements() const;
-  double Trace() const;
-  double Determinant() const;
-  GeomVector<nDim> dot(const GeomVector<nDim>& vec) const;
-  GeomTensor dot(const GeomTensor& rhs) const;
-  GeomTensor dot(const GeomSymmetricTensor<nDim>& rhs) const;
-  double doubledot(const GeomTensor& rhs) const;
-  double doubledot(const GeomSymmetricTensor<nDim>& rhs) const;
-  double selfDoubledot() const;
+  SPHERAL_HOST_DEVICE GeomSymmetricTensor<nDim> Symmetric() const;
+  SPHERAL_HOST_DEVICE GeomTensor SkewSymmetric() const;
+  SPHERAL_HOST_DEVICE GeomTensor Transpose() const;
+  SPHERAL_HOST_DEVICE GeomTensor Inverse() const;
+  SPHERAL_HOST_DEVICE GeomVector<nDim> diagonalElements() const;
+  SPHERAL_HOST_DEVICE double Trace() const;
+  SPHERAL_HOST_DEVICE double Determinant() const;
+  SPHERAL_HOST_DEVICE GeomVector<nDim> dot(const GeomVector<nDim>& vec) const;
+  SPHERAL_HOST_DEVICE GeomTensor dot(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE GeomTensor dot(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE double doubledot(const GeomTensor& rhs) const;
+  SPHERAL_HOST_DEVICE double doubledot(const GeomSymmetricTensor<nDim>& rhs) const;
+  SPHERAL_HOST_DEVICE double selfDoubledot() const;
 
   // Return the square of this tensor (using matrix multiplication).
-  GeomTensor square() const;
+  SPHERAL_HOST_DEVICE GeomTensor square() const;
 
   // Return a tensor where each element is the square of the corresponding 
   // element of this tensor.
-  GeomTensor squareElements() const;
+  SPHERAL_HOST_DEVICE GeomTensor squareElements() const;
 
   // A simple method for returning the eigenvalues of a tensor.
   GeomVector<nDim> eigenValues() const;
   
   // Apply a rotational transform to this tensor ( R^-1 * (*this) * R ).
-  void rotationalTransform(const GeomTensor& R);
+  SPHERAL_HOST_DEVICE void rotationalTransform(const GeomTensor& R);
 
   // Return the max absolute element.
-  double maxAbsElement() const;
+  SPHERAL_HOST_DEVICE double maxAbsElement() const;
 
   //  Convert to an Eigen Vector
   EigenType eigen() const;
 
 private:
   //--------------------------- Private Interface ---------------------------//
-  size_type elementIndex(const size_type row, const size_type column) const;
+  SPHERAL_HOST_DEVICE size_type elementIndex(const size_type row, const size_type column) const;
 };
 
 // Declare specializations.
@@ -215,195 +215,179 @@ template<> const GeomTensor<3> GeomTensor<3>::zero;
 template<> const GeomTensor<3> GeomTensor<3>::one;
 #endif
 
-template<> GeomTensor<2>::GeomTensor(const double, const double,
-                                     const double, const double);
-template<> GeomTensor<3>::GeomTensor(const double, const double, const double,
-                                     const double, const double, const double,
-                                     const double, const double, const double);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>::GeomTensor(const double, const double,
+                                                         const double, const double);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>::GeomTensor(const double, const double, const double,
+                                                         const double, const double, const double,
+                                                         const double, const double, const double);
 
-template<> GeomTensor<1>& GeomTensor<1>::operator=(const GeomTensor<1>& rhs);
-template<> GeomTensor<2>& GeomTensor<2>::operator=(const GeomTensor<2>& rhs);
-template<> GeomTensor<3>& GeomTensor<3>::operator=(const GeomTensor<3>& rhs);
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator=(const GeomTensor<1>& rhs);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator=(const GeomTensor<2>& rhs);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator=(const GeomTensor<3>& rhs);
 
-template<> GeomTensor<1>& GeomTensor<1>::operator=(const GeomSymmetricTensor<1>& rhs);
-template<> GeomTensor<2>& GeomTensor<2>::operator=(const GeomSymmetricTensor<2>& rhs);
-template<> GeomTensor<3>& GeomTensor<3>::operator=(const GeomSymmetricTensor<3>& rhs);
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator=(const GeomSymmetricTensor<1>& rhs);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator=(const GeomSymmetricTensor<2>& rhs);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator=(const GeomSymmetricTensor<3>& rhs);
 
-template<> double GeomTensor<1>::xy() const;
-template<> double GeomTensor<1>::xz() const;
-template<> double GeomTensor<1>::yx() const;
-template<> double GeomTensor<1>::yy() const;
-template<> double GeomTensor<1>::yz() const;
-template<> double GeomTensor<1>::zx() const;
-template<> double GeomTensor<1>::zy() const;
-template<> double GeomTensor<1>::zz() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::xy() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::xz() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::yx() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::yy() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::yz() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::zx() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::zy() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::zz() const;
 
-template<> double GeomTensor<2>::xz() const;
-template<> double GeomTensor<2>::yz() const;
-template<> double GeomTensor<2>::zx() const;
-template<> double GeomTensor<2>::zy() const;
-template<> double GeomTensor<2>::zz() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::xz() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::yz() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::zx() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::zy() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::zz() const;
 
-template<> void GeomTensor<1>::xy(const double);
-template<> void GeomTensor<1>::xz(const double);
-template<> void GeomTensor<1>::yx(const double);
-template<> void GeomTensor<1>::yy(const double);
-template<> void GeomTensor<1>::yz(const double);
-template<> void GeomTensor<1>::zx(const double);
-template<> void GeomTensor<1>::zy(const double);
-template<> void GeomTensor<1>::zz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::xy(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::xz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::yx(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::yy(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::yz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::zx(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::zy(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::zz(const double);
 
-template<> void GeomTensor<2>::xz(const double);
-template<> void GeomTensor<2>::yz(const double);
-template<> void GeomTensor<2>::zx(const double);
-template<> void GeomTensor<2>::zy(const double);
-template<> void GeomTensor<2>::zz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<2>::xz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<2>::yz(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<2>::zx(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<2>::zy(const double);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<2>::zz(const double);
 
-template<> GeomVector<1> GeomTensor<1>::getRow(const GeomTensor<1>::size_type) const;
-template<> GeomVector<2> GeomTensor<2>::getRow(const GeomTensor<2>::size_type) const;
-template<> GeomVector<3> GeomTensor<3>::getRow(const GeomTensor<3>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<1> GeomTensor<1>::getRow(const GeomTensor<1>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<2> GeomTensor<2>::getRow(const GeomTensor<2>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<3> GeomTensor<3>::getRow(const GeomTensor<3>::size_type) const;
 
-template<> GeomVector<1> GeomTensor<1>::getColumn(const GeomTensor<1>::size_type) const;
-template<> GeomVector<2> GeomTensor<2>::getColumn(const GeomTensor<2>::size_type) const;
-template<> GeomVector<3> GeomTensor<3>::getColumn(const GeomTensor<3>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<1> GeomTensor<1>::getColumn(const GeomTensor<1>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<2> GeomTensor<2>::getColumn(const GeomTensor<2>::size_type) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<3> GeomTensor<3>::getColumn(const GeomTensor<3>::size_type) const;
 
-template<> void GeomTensor<1>::setRow(const GeomTensor<1>::size_type, const GeomVector<1>&);
-template<> void GeomTensor<2>::setRow(const GeomTensor<2>::size_type, const GeomVector<2>&);
-template<> void GeomTensor<3>::setRow(const GeomTensor<3>::size_type, const GeomVector<3>&);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::setRow(const GeomTensor<1>::size_type, const GeomVector<1>&);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<2>::setRow(const GeomTensor<2>::size_type, const GeomVector<2>&);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<3>::setRow(const GeomTensor<3>::size_type, const GeomVector<3>&);
 
-template<> void GeomTensor<1>::setColumn(const GeomTensor<1>::size_type, const GeomVector<1>&);
-template<> void GeomTensor<2>::setColumn(const GeomTensor<2>::size_type, const GeomVector<2>&);
-template<> void GeomTensor<3>::setColumn(const GeomTensor<3>::size_type, const GeomVector<3>&);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::setColumn(const GeomTensor<1>::size_type, const GeomVector<1>&);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<2>::setColumn(const GeomTensor<2>::size_type, const GeomVector<2>&);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<3>::setColumn(const GeomTensor<3>::size_type, const GeomVector<3>&);
 
-template<> GeomTensor<1> GeomTensor<1>::operator-() const;
-template<> GeomTensor<2> GeomTensor<2>::operator-() const;
-template<> GeomTensor<3> GeomTensor<3>::operator-() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::operator-() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::operator-() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::operator-() const;
 
-// template<> GeomTensor<1> GeomTensor<1>::operator+(const double) const;
-// template<> GeomTensor<2> GeomTensor<2>::operator+(const double) const;
-// template<> GeomTensor<3> GeomTensor<3>::operator+(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::operator*(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::operator*(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::operator*(const double) const;
 
-// template<> GeomTensor<1> GeomTensor<1>::operator-(const double) const;
-// template<> GeomTensor<2> GeomTensor<2>::operator-(const double) const;
-// template<> GeomTensor<3> GeomTensor<3>::operator-(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::operator/(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::operator/(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::operator/(const double) const;
 
-template<> GeomTensor<1> GeomTensor<1>::operator*(const double) const;
-template<> GeomTensor<2> GeomTensor<2>::operator*(const double) const;
-template<> GeomTensor<3> GeomTensor<3>::operator*(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator+=(const GeomTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator+=(const GeomTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator+=(const GeomTensor<3>&);
 
-template<> GeomTensor<1> GeomTensor<1>::operator/(const double) const;
-template<> GeomTensor<2> GeomTensor<2>::operator/(const double) const;
-template<> GeomTensor<3> GeomTensor<3>::operator/(const double) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator+=(const GeomSymmetricTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator+=(const GeomSymmetricTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator+=(const GeomSymmetricTensor<3>&);
 
-template<> GeomTensor<1>& GeomTensor<1>::operator+=(const GeomTensor<1>&);
-template<> GeomTensor<2>& GeomTensor<2>::operator+=(const GeomTensor<2>&);
-template<> GeomTensor<3>& GeomTensor<3>::operator+=(const GeomTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator-=(const GeomTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator-=(const GeomTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator-=(const GeomTensor<3>&);
 
-template<> GeomTensor<1>& GeomTensor<1>::operator+=(const GeomSymmetricTensor<1>&);
-template<> GeomTensor<2>& GeomTensor<2>::operator+=(const GeomSymmetricTensor<2>&);
-template<> GeomTensor<3>& GeomTensor<3>::operator+=(const GeomSymmetricTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator-=(const GeomSymmetricTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator-=(const GeomSymmetricTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator-=(const GeomSymmetricTensor<3>&);
 
-template<> GeomTensor<1>& GeomTensor<1>::operator-=(const GeomTensor<1>&);
-template<> GeomTensor<2>& GeomTensor<2>::operator-=(const GeomTensor<2>&);
-template<> GeomTensor<3>& GeomTensor<3>::operator-=(const GeomTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator*=(const GeomTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator*=(const GeomTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator*=(const GeomTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator*=(const GeomSymmetricTensor<1>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator*=(const GeomSymmetricTensor<2>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>&);
 
-template<> GeomTensor<1>& GeomTensor<1>::operator-=(const GeomSymmetricTensor<1>&);
-template<> GeomTensor<2>& GeomTensor<2>::operator-=(const GeomSymmetricTensor<2>&);
-template<> GeomTensor<3>& GeomTensor<3>::operator-=(const GeomSymmetricTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator*=(const double);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator*=(const double);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator*=(const double);
 
-template<> GeomTensor<1>& GeomTensor<1>::operator*=(const GeomTensor<1>&);
-template<> GeomTensor<2>& GeomTensor<2>::operator*=(const GeomTensor<2>&);
-template<> GeomTensor<3>& GeomTensor<3>::operator*=(const GeomTensor<3>&);
-template<> GeomTensor<1>& GeomTensor<1>::operator*=(const GeomSymmetricTensor<1>&);
-template<> GeomTensor<2>& GeomTensor<2>::operator*=(const GeomSymmetricTensor<2>&);
-template<> GeomTensor<3>& GeomTensor<3>::operator*=(const GeomSymmetricTensor<3>&);
+template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator/=(const double);
+template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator/=(const double);
+template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator/=(const double);
 
-// template<> GeomTensor<1>& GeomTensor<1>::operator+=(const double);
-// template<> GeomTensor<2>& GeomTensor<2>::operator+=(const double);
-// template<> GeomTensor<3>& GeomTensor<3>::operator+=(const double);
+template<> SPHERAL_HOST_DEVICE bool GeomTensor<1>::operator==(const GeomTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomTensor<2>::operator==(const GeomTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomTensor<3>::operator==(const GeomTensor<3>&) const;
 
-// template<> GeomTensor<1>& GeomTensor<1>::operator-=(const double);
-// template<> GeomTensor<2>& GeomTensor<2>::operator-=(const double);
-// template<> GeomTensor<3>& GeomTensor<3>::operator-=(const double);
+template<> SPHERAL_HOST_DEVICE bool GeomTensor<1>::operator==(const GeomSymmetricTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomTensor<2>::operator==(const GeomSymmetricTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE bool GeomTensor<3>::operator==(const GeomSymmetricTensor<3>&) const;
 
-template<> GeomTensor<1>& GeomTensor<1>::operator*=(const double);
-template<> GeomTensor<2>& GeomTensor<2>::operator*=(const double);
-template<> GeomTensor<3>& GeomTensor<3>::operator*=(const double);
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<1> GeomTensor<1>::Symmetric() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<2> GeomTensor<2>::Symmetric() const;
+template<> SPHERAL_HOST_DEVICE GeomSymmetricTensor<3> GeomTensor<3>::Symmetric() const;
 
-template<> GeomTensor<1>& GeomTensor<1>::operator/=(const double);
-template<> GeomTensor<2>& GeomTensor<2>::operator/=(const double);
-template<> GeomTensor<3>& GeomTensor<3>::operator/=(const double);
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::SkewSymmetric() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::SkewSymmetric() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::SkewSymmetric() const;
 
-template<> bool GeomTensor<1>::operator==(const GeomTensor<1>&) const;
-template<> bool GeomTensor<2>::operator==(const GeomTensor<2>&) const;
-template<> bool GeomTensor<3>::operator==(const GeomTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::Transpose() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::Transpose() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::Transpose() const;
 
-template<> bool GeomTensor<1>::operator==(const GeomSymmetricTensor<1>&) const;
-template<> bool GeomTensor<2>::operator==(const GeomSymmetricTensor<2>&) const;
-template<> bool GeomTensor<3>::operator==(const GeomSymmetricTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::Inverse() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::Inverse() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::Inverse() const;
 
-template<> GeomSymmetricTensor<1> GeomTensor<1>::Symmetric() const;
-template<> GeomSymmetricTensor<2> GeomTensor<2>::Symmetric() const;
-template<> GeomSymmetricTensor<3> GeomTensor<3>::Symmetric() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<1> GeomTensor<1>::diagonalElements() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<2> GeomTensor<2>::diagonalElements() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<3> GeomTensor<3>::diagonalElements() const;
 
-template<> GeomTensor<1> GeomTensor<1>::SkewSymmetric() const;
-template<> GeomTensor<2> GeomTensor<2>::SkewSymmetric() const;
-template<> GeomTensor<3> GeomTensor<3>::SkewSymmetric() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::Trace() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::Trace() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<3>::Trace() const;
 
-template<> GeomTensor<1> GeomTensor<1>::Transpose() const;
-template<> GeomTensor<2> GeomTensor<2>::Transpose() const;
-template<> GeomTensor<3> GeomTensor<3>::Transpose() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::Determinant() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::Determinant() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<3>::Determinant() const;
 
-template<> GeomTensor<1> GeomTensor<1>::Inverse() const;
-template<> GeomTensor<2> GeomTensor<2>::Inverse() const;
-template<> GeomTensor<3> GeomTensor<3>::Inverse() const;
+template<> SPHERAL_HOST_DEVICE GeomVector<1> GeomTensor<1>::dot(const GeomVector<1>&) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<2> GeomTensor<2>::dot(const GeomVector<2>&) const;
+template<> SPHERAL_HOST_DEVICE GeomVector<3> GeomTensor<3>::dot(const GeomVector<3>&) const;
 
-template<> GeomVector<1> GeomTensor<1>::diagonalElements() const;
-template<> GeomVector<2> GeomTensor<2>::diagonalElements() const;
-template<> GeomVector<3> GeomTensor<3>::diagonalElements() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::dot(const GeomTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::dot(const GeomTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::dot(const GeomTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::dot(const GeomSymmetricTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::dot(const GeomSymmetricTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::dot(const GeomSymmetricTensor<3>&) const;
 
-template<> double GeomTensor<1>::Trace() const;
-template<> double GeomTensor<2>::Trace() const;
-template<> double GeomTensor<3>::Trace() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::doubledot(const GeomTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::doubledot(const GeomTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<3>::doubledot(const GeomTensor<3>&) const;
 
-template<> double GeomTensor<1>::Determinant() const;
-template<> double GeomTensor<2>::Determinant() const;
-template<> double GeomTensor<3>::Determinant() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::doubledot(const GeomSymmetricTensor<1>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::doubledot(const GeomSymmetricTensor<2>&) const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<3>::doubledot(const GeomSymmetricTensor<3>&) const;
 
-template<> GeomVector<1> GeomTensor<1>::dot(const GeomVector<1>&) const;
-template<> GeomVector<2> GeomTensor<2>::dot(const GeomVector<2>&) const;
-template<> GeomVector<3> GeomTensor<3>::dot(const GeomVector<3>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::square() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::square() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::square() const;
 
-template<> GeomTensor<1> GeomTensor<1>::dot(const GeomTensor<1>&) const;
-template<> GeomTensor<2> GeomTensor<2>::dot(const GeomTensor<2>&) const;
-template<> GeomTensor<3> GeomTensor<3>::dot(const GeomTensor<3>&) const;
-template<> GeomTensor<1> GeomTensor<1>::dot(const GeomSymmetricTensor<1>&) const;
-template<> GeomTensor<2> GeomTensor<2>::dot(const GeomSymmetricTensor<2>&) const;
-template<> GeomTensor<3> GeomTensor<3>::dot(const GeomSymmetricTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<1> GeomTensor<1>::squareElements() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<2> GeomTensor<2>::squareElements() const;
+template<> SPHERAL_HOST_DEVICE GeomTensor<3> GeomTensor<3>::squareElements() const;
 
-template<> double GeomTensor<1>::doubledot(const GeomTensor<1>&) const;
-template<> double GeomTensor<2>::doubledot(const GeomTensor<2>&) const;
-template<> double GeomTensor<3>::doubledot(const GeomTensor<3>&) const;
+template<> SPHERAL_HOST_DEVICE void GeomTensor<1>::rotationalTransform(const GeomTensor<1>&);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<2>::rotationalTransform(const GeomTensor<2>&);
+template<> SPHERAL_HOST_DEVICE void GeomTensor<3>::rotationalTransform(const GeomTensor<3>&);
 
-template<> double GeomTensor<1>::doubledot(const GeomSymmetricTensor<1>&) const;
-template<> double GeomTensor<2>::doubledot(const GeomSymmetricTensor<2>&) const;
-template<> double GeomTensor<3>::doubledot(const GeomSymmetricTensor<3>&) const;
-
-template<> GeomTensor<1> GeomTensor<1>::square() const;
-template<> GeomTensor<2> GeomTensor<2>::square() const;
-template<> GeomTensor<3> GeomTensor<3>::square() const;
-
-template<> GeomTensor<1> GeomTensor<1>::squareElements() const;
-template<> GeomTensor<2> GeomTensor<2>::squareElements() const;
-template<> GeomTensor<3> GeomTensor<3>::squareElements() const;
-
-template<> void GeomTensor<1>::rotationalTransform(const GeomTensor<1>&);
-template<> void GeomTensor<2>::rotationalTransform(const GeomTensor<2>&);
-template<> void GeomTensor<3>::rotationalTransform(const GeomTensor<3>&);
-
-template<> double GeomTensor<1>::maxAbsElement() const;
-template<> double GeomTensor<2>::maxAbsElement() const;
-template<> double GeomTensor<3>::maxAbsElement() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<1>::maxAbsElement() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<2>::maxAbsElement() const;
+template<> SPHERAL_HOST_DEVICE double GeomTensor<3>::maxAbsElement() const;
 
 template<> const GeomTensor<1> GeomTensor<1>::zero;
 template<> const GeomTensor<2> GeomTensor<2>::zero;

--- a/src/Geometry/GeomTensor_default.hh
+++ b/src/Geometry/GeomTensor_default.hh
@@ -46,23 +46,18 @@ public:
   static const GeomTensor one;
 
   // Constructors.
-  SPHERAL_HOST_DEVICE GeomTensor();
+  SPHERAL_HOST_DEVICE GeomTensor() = default;
   SPHERAL_HOST_DEVICE explicit GeomTensor(const double a11);
   SPHERAL_HOST_DEVICE GeomTensor(const double a11, const double a12,
              const double a21, const double a22);
   SPHERAL_HOST_DEVICE GeomTensor(const double a11, const double a12, const double a13,
              const double a21, const double a22, const double a23,
              const double a31, const double a32, const double a33);
-  SPHERAL_HOST_DEVICE GeomTensor(const GeomTensor& ten);
   SPHERAL_HOST_DEVICE explicit GeomTensor(const GeomSymmetricTensor<nDim>& ten);
   GeomTensor(const EigenType& ten);
   template<typename Derived> GeomTensor(const Eigen::MatrixBase<Derived>& ten);
 
-  // Destructor.
-  SPHERAL_HOST_DEVICE ~GeomTensor();
-
   // Assignment.
-  SPHERAL_HOST_DEVICE GeomTensor& operator=(const GeomTensor& rhs);
   SPHERAL_HOST_DEVICE GeomTensor& operator=(const GeomSymmetricTensor<nDim>& rhs);
   template<typename Derived> GeomTensor& operator=(const Eigen::MatrixBase<Derived>& rhs);
 
@@ -220,10 +215,6 @@ template<> SPHERAL_HOST_DEVICE GeomTensor<2>::GeomTensor(const double, const dou
 template<> SPHERAL_HOST_DEVICE GeomTensor<3>::GeomTensor(const double, const double, const double,
                                                          const double, const double, const double,
                                                          const double, const double, const double);
-
-template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator=(const GeomTensor<1>& rhs);
-template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator=(const GeomTensor<2>& rhs);
-template<> SPHERAL_HOST_DEVICE GeomTensor<3>& GeomTensor<3>::operator=(const GeomTensor<3>& rhs);
 
 template<> SPHERAL_HOST_DEVICE GeomTensor<1>& GeomTensor<1>::operator=(const GeomSymmetricTensor<1>& rhs);
 template<> SPHERAL_HOST_DEVICE GeomTensor<2>& GeomTensor<2>::operator=(const GeomSymmetricTensor<2>& rhs);

--- a/src/Geometry/GeomTensor_default.hh
+++ b/src/Geometry/GeomTensor_default.hh
@@ -41,7 +41,7 @@ public:
 
   // Useful static memeber data.
   static const size_type nDimensions;
-  static const size_type numElements;
+  static constexpr size_type numElements = nDim * nDim;
   static const GeomTensor zero;
   static const GeomTensor one;
 
@@ -203,17 +203,14 @@ private:
 // Declare specializations.
 #ifndef WIN32
 template<> const unsigned      GeomTensor<1>::nDimensions;
-template<> const unsigned      GeomTensor<1>::numElements;
 template<> const GeomTensor<1> GeomTensor<1>::zero;
 template<> const GeomTensor<1> GeomTensor<1>::one;
 
 template<> const unsigned      GeomTensor<2>::nDimensions;
-template<> const unsigned      GeomTensor<2>::numElements;
 template<> const GeomTensor<2> GeomTensor<2>::zero;
 template<> const GeomTensor<2> GeomTensor<2>::one;
 
 template<> const unsigned      GeomTensor<3>::nDimensions;
-template<> const unsigned      GeomTensor<3>::numElements;
 template<> const GeomTensor<3> GeomTensor<3>::zero;
 template<> const GeomTensor<3> GeomTensor<3>::one;
 #endif

--- a/src/Utilities/DBC.hh
+++ b/src/Utilities/DBC.hh
@@ -171,6 +171,7 @@ inline bool nearlyEqual(const T& x,
 #define CHECK(x) ASSERT(x)
 #define CHECK2(x, msg) ASSERT2(x, msg)
 
+#ifndef SPHERAL_GPU_ACTIVE
 #define VERIFY2(x, msg) \
    if (!(x)) { \
       std::stringstream s; \
@@ -180,6 +181,13 @@ inline bool nearlyEqual(const T& x,
       ::Spheral::dbc::VERIFYError reason(s.str());\
       throw reason;\
    }
+#else // SPHERAL_GPU_ACTIVE
+#define VERIFY2(x, null_msg) \
+  if (!(x)) { \
+    printf("Verification failed:\n...at line %d of file %s.\n", __LINE__, __FILE__); \
+    abort(); \
+  }
+#endif // SPHERAL_GPU_ACTIVE
 #define VERIFY(x) VERIFY2(x, #x)
 
 // //----------------------------------------------------------------------------

--- a/tests/cpp/Geometry/CMakeLists.txt
+++ b/tests/cpp/Geometry/CMakeLists.txt
@@ -6,6 +6,20 @@ spheral_add_test(
 )
 
 spheral_add_test(
+  NAME geomsymmetrictensor_test
+  SOURCES geomsymmetrictensor_tests.cc
+  DEPENDS_ON Spheral_Utilities
+  #DEBUG_LINKER
+)
+
+spheral_add_test(
+  NAME geomtensor_test
+  SOURCES geomtensor_tests.cc
+  DEPENDS_ON Spheral_Utilities
+  #DEBUG_LINKER
+)
+
+spheral_add_test(
   NAME rankntensor_test
   SOURCES rankntensor_tests.cc
   DEPENDS_ON Spheral_Utilities

--- a/tests/cpp/Geometry/geomsymmetrictensor_tests.cc
+++ b/tests/cpp/Geometry/geomsymmetrictensor_tests.cc
@@ -1,0 +1,415 @@
+#include "test-basic-exec-policies.hh"
+#include "test-utilities.hh"
+
+#include "Geometry/GeomSymmetricTensor.hh"
+#include "Geometry/GeomTensor.hh"
+#include "Geometry/GeomVector.hh"
+
+using SymTensor = Spheral::GeomSymmetricTensor<3>;
+using Tensor = Spheral::GeomTensor<3>;
+using Vector = Spheral::GeomVector<3>;
+
+class GeomSymmetricTensorTest : public ::testing::Test {};
+
+// Setting up Typed Test Suite for GeomSymmetricTensor
+TYPED_TEST_SUITE_P(GeomSymmetricTensorTypedTest);
+template <typename T> class GeomSymmetricTensorTypedTest : public GeomSymmetricTensorTest {};
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, Ctor) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1;
+    SPHERAL_ASSERT_EQ(T1.xx(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 0.0);
+
+    SymTensor T2(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SPHERAL_ASSERT_EQ(T2.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T2.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T2.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T2.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T2.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T2.zz(), 9.0);
+
+    SymTensor T3(T2);
+    SPHERAL_ASSERT_EQ(T3.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T3.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T3.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T3.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T3.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T3.zz(), 9.0);
+
+    Tensor GT(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T4(GT);
+    SPHERAL_ASSERT_EQ(T4.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T4.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T4.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T4.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T4.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T4.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, Assignment) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T2;
+    T2 = T1;
+    SPHERAL_ASSERT_EQ(T2.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T2.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T2.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T2.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T2.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T2.zz(), 9.0);
+
+    Tensor GT(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    T2 = GT;
+    SPHERAL_ASSERT_EQ(T2.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T2.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T2.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T2.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T2.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T2.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, Accessors) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SPHERAL_ASSERT_EQ(T1(0, 0), 1.0);
+    SPHERAL_ASSERT_EQ(T1(0, 1), 2.0);
+    SPHERAL_ASSERT_EQ(T1(0, 2), 3.0);
+    SPHERAL_ASSERT_EQ(T1(1, 0), 2.0);
+    SPHERAL_ASSERT_EQ(T1(1, 1), 5.0);
+    SPHERAL_ASSERT_EQ(T1(1, 2), 6.0);
+    SPHERAL_ASSERT_EQ(T1(2, 0), 3.0);
+    SPHERAL_ASSERT_EQ(T1(2, 1), 6.0);
+    SPHERAL_ASSERT_EQ(T1(2, 2), 9.0);
+
+    SPHERAL_ASSERT_EQ(T1[0], 1.0);
+    SPHERAL_ASSERT_EQ(T1[1], 2.0);
+    SPHERAL_ASSERT_EQ(T1[5], 9.0);
+
+    T1(0,0) = 10.0;
+    SPHERAL_ASSERT_EQ(T1.xx(), 10.0);
+    T1[1] = 20.0;
+    SPHERAL_ASSERT_EQ(T1.xy(), 20.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, Setters) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1;
+    T1.xx(1.0);
+    T1.xy(2.0);
+    T1.xz(3.0);
+    T1.yy(5.0);
+    T1.yz(6.0);
+    T1.zz(9.0);
+    SPHERAL_ASSERT_EQ(T1.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, GetSetRowsColumns) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    Vector row0 = T1.getRow(0);
+    SPHERAL_ASSERT_EQ(row0.x(), 1.0);
+    SPHERAL_ASSERT_EQ(row0.y(), 2.0);
+    SPHERAL_ASSERT_EQ(row0.z(), 3.0);
+
+    Vector col1 = T1.getColumn(1);
+    SPHERAL_ASSERT_EQ(col1.x(), 2.0);
+    SPHERAL_ASSERT_EQ(col1.y(), 5.0);
+    SPHERAL_ASSERT_EQ(col1.z(), 6.0);
+
+    Vector newRow(10.0, 11.0, 12.0);
+    T1.setRow(0, newRow);
+    SPHERAL_ASSERT_EQ(T1.xx(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 11.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 12.0);
+
+    Vector newCol(13.0, 14.0, 15.0);
+    T1.setColumn(1, newCol);
+    SPHERAL_ASSERT_EQ(T1.xy(), 13.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 14.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 15.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, ZeroIdentity) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    T1.Zero();
+    SPHERAL_ASSERT_EQ(T1.xx(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 0.0);
+
+    T1.Identity();
+    SPHERAL_ASSERT_EQ(T1.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 1.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, UnaryMinus) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T2 = -T1;
+    SPHERAL_ASSERT_EQ(T2.xx(), -1.0);
+    SPHERAL_ASSERT_EQ(T2.xy(), -2.0);
+    SPHERAL_ASSERT_EQ(T2.xz(), -3.0);
+    SPHERAL_ASSERT_EQ(T2.yy(), -5.0);
+    SPHERAL_ASSERT_EQ(T2.yz(), -6.0);
+    SPHERAL_ASSERT_EQ(T2.zz(), -9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, AddSub) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T2(9.0, 8.0, 7.0, 8.0, 5.0, 4.0, 7.0, 4.0, 1.0);
+
+    SymTensor T_add = T1 + T2;
+    SPHERAL_ASSERT_EQ(T_add.xx(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.xy(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.xz(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.yz(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.zz(), 10.0);
+
+    SymTensor T_sub = T1 - T2;
+    SPHERAL_ASSERT_EQ(T_sub.xx(), -8.0);
+    SPHERAL_ASSERT_EQ(T_sub.xy(), -6.0);
+    SPHERAL_ASSERT_EQ(T_sub.xz(), -4.0);
+    SPHERAL_ASSERT_EQ(T_sub.yy(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub.yz(), 2.0);
+    SPHERAL_ASSERT_EQ(T_sub.zz(), 8.0);
+
+    Tensor GT(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T_add_gen = T1 + GT;
+    SPHERAL_ASSERT_EQ(T_add_gen.xx(), 2.0);
+    SPHERAL_ASSERT_EQ(T_add_gen.xy(), 4.0);
+    SPHERAL_ASSERT_EQ(T_add_gen.xz(), 6.0);
+    SPHERAL_ASSERT_EQ(T_add_gen.yx(), 6.0);
+    SPHERAL_ASSERT_EQ(T_add_gen.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add_gen.yz(), 12.0);
+    SPHERAL_ASSERT_EQ(T_add_gen.zx(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add_gen.zy(), 14.0);
+    SPHERAL_ASSERT_EQ(T_add_gen.zz(), 18.0);
+
+    Tensor T_sub_gen = T1 - GT;
+    SPHERAL_ASSERT_EQ(T_sub_gen.xx(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub_gen.xy(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub_gen.xz(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub_gen.yx(), -2.0);
+    SPHERAL_ASSERT_EQ(T_sub_gen.yy(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub_gen.yz(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub_gen.zx(), -4.0);
+    SPHERAL_ASSERT_EQ(T_sub_gen.zy(), -2.0);
+    SPHERAL_ASSERT_EQ(T_sub_gen.zz(), 0.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, ScalarMulDiv) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    double s = 2.0;
+
+    SymTensor T_mul = T1 * s;
+    SPHERAL_ASSERT_EQ(T_mul.xx(), 2.0);
+    SPHERAL_ASSERT_EQ(T_mul.xy(), 4.0);
+    SPHERAL_ASSERT_EQ(T_mul.xz(), 6.0);
+    SPHERAL_ASSERT_EQ(T_mul.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T_mul.yz(), 12.0);
+    SPHERAL_ASSERT_EQ(T_mul.zz(), 18.0);
+
+    SymTensor T_div = T1 / s;
+    SPHERAL_ASSERT_EQ(T_div.xx(), 0.5);
+    SPHERAL_ASSERT_EQ(T_div.xy(), 1.0);
+    SPHERAL_ASSERT_EQ(T_div.xz(), 1.5);
+    SPHERAL_ASSERT_EQ(T_div.yy(), 2.5);
+    SPHERAL_ASSERT_EQ(T_div.yz(), 3.0);
+    SPHERAL_ASSERT_EQ(T_div.zz(), 4.5);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, InPlaceAddSub) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T2(9.0, 8.0, 7.0, 8.0, 5.0, 4.0, 7.0, 4.0, 1.0);
+    
+    T1 += T2;
+    SPHERAL_ASSERT_EQ(T1.xx(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 10.0);
+
+    T1 -= T2;
+    SPHERAL_ASSERT_EQ(T1.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, InPlaceScalarMulDiv) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    double s = 2.0;
+
+    T1 *= s;
+    SPHERAL_ASSERT_EQ(T1.xx(), 2.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 4.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 6.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 12.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 18.0);
+
+    T1 /= s;
+    SPHERAL_ASSERT_EQ(T1.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, Comparison) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T2(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T3(9.0, 8.0, 7.0, 8.0, 5.0, 4.0, 7.0, 4.0, 1.0);
+
+    SPHERAL_ASSERT_TRUE(T1 == T2);
+    SPHERAL_ASSERT_TRUE(T1 != T3);
+    SPHERAL_ASSERT_TRUE(T1 < T3);
+    SPHERAL_ASSERT_TRUE(T3 > T1);
+    SPHERAL_ASSERT_TRUE(T1 <= T2);
+    SPHERAL_ASSERT_TRUE(T1 >= T2);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, Transpose) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T_trans = T1.Transpose();
+    SPHERAL_ASSERT_EQ(T_trans.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T_trans.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T_trans.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T_trans.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T_trans.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T_trans.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, TraceDeterminant) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SPHERAL_ASSERT_EQ(T1.Trace(), 15.0);
+    SPHERAL_ASSERT_EQ(T1.Determinant(), 0.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, DotProduct) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T2(9.0, 8.0, 7.0, 8.0, 5.0, 4.0, 7.0, 4.0, 1.0);
+    Tensor T_dot = T1.dot(T2);
+    // Expected values calculated manually
+    SPHERAL_ASSERT_EQ(T_dot.xx(), 46.0);
+    SPHERAL_ASSERT_EQ(T_dot.xy(), 30.0);
+    SPHERAL_ASSERT_EQ(T_dot.xz(), 18.0);
+    SPHERAL_ASSERT_EQ(T_dot.yx(), 100.0);
+    SPHERAL_ASSERT_EQ(T_dot.yy(), 65.0);
+    SPHERAL_ASSERT_EQ(T_dot.yz(), 40.0);
+    SPHERAL_ASSERT_EQ(T_dot.zx(), 138.0);
+    SPHERAL_ASSERT_EQ(T_dot.zy(), 90.0);
+    SPHERAL_ASSERT_EQ(T_dot.zz(), 54.0);
+
+    Vector V1(1.0, 2.0, 3.0);
+    Vector V_dot = T1.dot(V1);
+    SPHERAL_ASSERT_EQ(V_dot.x(), 14.0);
+    SPHERAL_ASSERT_EQ(V_dot.y(), 30.0);
+    SPHERAL_ASSERT_EQ(V_dot.z(), 42.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, DoubleDotProduct) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T2(9.0, 8.0, 7.0, 8.0, 5.0, 4.0, 7.0, 4.0, 1.0);
+    double ddot = T1.doubledot(T2);
+    // Expected value calculated manually
+    SPHERAL_ASSERT_EQ(ddot, 1.0*9.0 + 2.0*8.0 + 3.0*7.0 +
+                            2.0*8.0 + 5.0*5.0 + 6.0*4.0 +
+                            3.0*7.0 + 6.0*4.0 + 9.0*1.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, Square) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T_sq = T1.square();
+    // Expected values calculated manually
+    SPHERAL_ASSERT_EQ(T_sq.xx(), 14.0);
+    SPHERAL_ASSERT_EQ(T_sq.xy(), 30.0);
+    SPHERAL_ASSERT_EQ(T_sq.xz(), 42.0);
+    SPHERAL_ASSERT_EQ(T_sq.yy(), 65.0);
+    SPHERAL_ASSERT_EQ(T_sq.yz(), 90.0);
+    SPHERAL_ASSERT_EQ(T_sq.zz(), 126.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomSymmetricTensorTypedTest, SquareElements) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    SymTensor T1(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    SymTensor T_sq_elem = T1.squareElements();
+    SPHERAL_ASSERT_EQ(T_sq_elem.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.xy(), 4.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.xz(), 9.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.yy(), 25.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.yz(), 36.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.zz(), 81.0);
+  EXEC_IN_SPACE_END()
+}
+
+REGISTER_TYPED_TEST_SUITE_P(GeomSymmetricTensorTypedTest, Ctor, Assignment, Accessors,
+                            Setters, GetSetRowsColumns, ZeroIdentity, UnaryMinus, AddSub,
+                            ScalarMulDiv, InPlaceAddSub, InPlaceScalarMulDiv, Comparison,
+                            Transpose, TraceDeterminant, DotProduct, DoubleDotProduct,
+                            Square, SquareElements);
+
+INSTANTIATE_TYPED_TEST_SUITE_P(GeomSymmetricTensor, GeomSymmetricTensorTypedTest,
+                               typename Spheral::Test<EXEC_TYPES>::Types, );

--- a/tests/cpp/Geometry/geomtensor_tests.cc
+++ b/tests/cpp/Geometry/geomtensor_tests.cc
@@ -1,0 +1,482 @@
+#include "test-basic-exec-policies.hh"
+#include "test-utilities.hh"
+
+#include "Geometry/GeomTensor.hh"
+#include "Geometry/GeomSymmetricTensor.hh"
+#include "Geometry/GeomVector.hh"
+
+using Tensor = Spheral::GeomTensor<3>;
+using SymTensor = Spheral::GeomSymmetricTensor<3>;
+using Vector = Spheral::GeomVector<3>;
+
+class GeomTensorTest : public ::testing::Test {};
+
+// Setting up Typed Test Suite for GeomTensor
+TYPED_TEST_SUITE_P(GeomTensorTypedTest);
+template <typename T> class GeomTensorTypedTest : public GeomTensorTest {};
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, Ctor) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1;
+    SPHERAL_ASSERT_EQ(T1.xx(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.yx(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.zx(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.zy(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 0.0);
+
+    Tensor T2(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    SPHERAL_ASSERT_EQ(T2.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T2.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T2.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T2.yx(), 4.0);
+    SPHERAL_ASSERT_EQ(T2.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T2.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T2.zx(), 7.0);
+    SPHERAL_ASSERT_EQ(T2.zy(), 8.0);
+    SPHERAL_ASSERT_EQ(T2.zz(), 9.0);
+
+    Tensor T3(T2);
+    SPHERAL_ASSERT_EQ(T3.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T3.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T3.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T3.yx(), 4.0);
+    SPHERAL_ASSERT_EQ(T3.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T3.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T3.zx(), 7.0);
+    SPHERAL_ASSERT_EQ(T3.zy(), 8.0);
+    SPHERAL_ASSERT_EQ(T3.zz(), 9.0);
+
+    SymTensor ST(1.0, 2.0, 3.0,
+                 2.0, 5.0, 6.0,
+                 3.0, 6.0, 9.0);
+    Tensor T4(ST);
+    SPHERAL_ASSERT_EQ(T4.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T4.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T4.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T4.yx(), 2.0);
+    SPHERAL_ASSERT_EQ(T4.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T4.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T4.zx(), 3.0);
+    SPHERAL_ASSERT_EQ(T4.zy(), 6.0);
+    SPHERAL_ASSERT_EQ(T4.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, Assignment) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T2;
+    T2 = T1;
+    SPHERAL_ASSERT_EQ(T2.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T2.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T2.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T2.yx(), 4.0);
+    SPHERAL_ASSERT_EQ(T2.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T2.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T2.zx(), 7.0);
+    SPHERAL_ASSERT_EQ(T2.zy(), 8.0);
+    SPHERAL_ASSERT_EQ(T2.zz(), 9.0);
+
+    SymTensor ST(1.0, 2.0, 3.0,
+                 2.0, 5.0, 6.0,
+                 3.0, 6.0, 9.0);
+    T2 = ST;
+    SPHERAL_ASSERT_EQ(T2.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T2.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T2.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T2.yx(), 2.0);
+    SPHERAL_ASSERT_EQ(T2.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T2.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T2.zx(), 3.0);
+    SPHERAL_ASSERT_EQ(T2.zy(), 6.0);
+    SPHERAL_ASSERT_EQ(T2.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, Accessors) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    SPHERAL_ASSERT_EQ(T1(0, 0), 1.0);
+    SPHERAL_ASSERT_EQ(T1(0, 1), 2.0);
+    SPHERAL_ASSERT_EQ(T1(0, 2), 3.0);
+    SPHERAL_ASSERT_EQ(T1(1, 0), 4.0);
+    SPHERAL_ASSERT_EQ(T1(1, 1), 5.0);
+    SPHERAL_ASSERT_EQ(T1(1, 2), 6.0);
+    SPHERAL_ASSERT_EQ(T1(2, 0), 7.0);
+    SPHERAL_ASSERT_EQ(T1(2, 1), 8.0);
+    SPHERAL_ASSERT_EQ(T1(2, 2), 9.0);
+
+    SPHERAL_ASSERT_EQ(T1[0], 1.0);
+    SPHERAL_ASSERT_EQ(T1[1], 2.0);
+    SPHERAL_ASSERT_EQ(T1[8], 9.0);
+
+    T1(0,0) = 10.0;
+    SPHERAL_ASSERT_EQ(T1.xx(), 10.0);
+    T1[1] = 20.0;
+    SPHERAL_ASSERT_EQ(T1.xy(), 20.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, Setters) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1;
+    T1.xx(1.0);
+    T1.xy(2.0);
+    T1.xz(3.0);
+    T1.yx(4.0);
+    T1.yy(5.0);
+    T1.yz(6.0);
+    T1.zx(7.0);
+    T1.zy(8.0);
+    T1.zz(9.0);
+    SPHERAL_ASSERT_EQ(T1.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T1.yx(), 4.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T1.zx(), 7.0);
+    SPHERAL_ASSERT_EQ(T1.zy(), 8.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, GetSetRowsColumns) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Vector row0 = T1.getRow(0);
+    SPHERAL_ASSERT_EQ(row0.x(), 1.0);
+    SPHERAL_ASSERT_EQ(row0.y(), 2.0);
+    SPHERAL_ASSERT_EQ(row0.z(), 3.0);
+
+    Vector col1 = T1.getColumn(1);
+    SPHERAL_ASSERT_EQ(col1.x(), 2.0);
+    SPHERAL_ASSERT_EQ(col1.y(), 5.0);
+    SPHERAL_ASSERT_EQ(col1.z(), 8.0);
+
+    Vector newRow(10.0, 11.0, 12.0);
+    T1.setRow(0, newRow);
+    SPHERAL_ASSERT_EQ(T1.xx(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 11.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 12.0);
+
+    Vector newCol(13.0, 14.0, 15.0);
+    T1.setColumn(1, newCol);
+    SPHERAL_ASSERT_EQ(T1.xy(), 13.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 14.0);
+    SPHERAL_ASSERT_EQ(T1.zy(), 15.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, ZeroIdentity) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    T1.Zero();
+    SPHERAL_ASSERT_EQ(T1.xx(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 0.0);
+
+    T1.Identity();
+    SPHERAL_ASSERT_EQ(T1.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 0.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 1.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, UnaryMinus) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T2 = -T1;
+    SPHERAL_ASSERT_EQ(T2.xx(), -1.0);
+    SPHERAL_ASSERT_EQ(T2.xy(), -2.0);
+    SPHERAL_ASSERT_EQ(T2.xz(), -3.0);
+    SPHERAL_ASSERT_EQ(T2.yx(), -4.0);
+    SPHERAL_ASSERT_EQ(T2.yy(), -5.0);
+    SPHERAL_ASSERT_EQ(T2.yz(), -6.0);
+    SPHERAL_ASSERT_EQ(T2.zx(), -7.0);
+    SPHERAL_ASSERT_EQ(T2.zy(), -8.0);
+    SPHERAL_ASSERT_EQ(T2.zz(), -9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, AddSub) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T2(9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+
+    Tensor T_add = T1 + T2;
+    SPHERAL_ASSERT_EQ(T_add.xx(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.xy(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.xz(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.yx(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.yz(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.zx(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.zy(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.zz(), 10.0);
+
+    Tensor T_sub = T1 - T2;
+    SPHERAL_ASSERT_EQ(T_sub.xx(), -8.0);
+    SPHERAL_ASSERT_EQ(T_sub.xy(), -6.0);
+    SPHERAL_ASSERT_EQ(T_sub.xz(), -4.0);
+    SPHERAL_ASSERT_EQ(T_sub.yx(), -2.0);
+    SPHERAL_ASSERT_EQ(T_sub.yy(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub.yz(), 2.0);
+    SPHERAL_ASSERT_EQ(T_sub.zx(), 4.0);
+    SPHERAL_ASSERT_EQ(T_sub.zy(), 6.0);
+    SPHERAL_ASSERT_EQ(T_sub.zz(), 8.0);
+
+    SymTensor ST(1.0, 2.0, 3.0,
+                 2.0, 5.0, 6.0,
+                 3.0, 6.0, 9.0);
+    T_add = T1 + ST;
+    SPHERAL_ASSERT_EQ(T_add.xx(), 2.0);
+    SPHERAL_ASSERT_EQ(T_add.xy(), 4.0);
+    SPHERAL_ASSERT_EQ(T_add.xz(), 6.0);
+    SPHERAL_ASSERT_EQ(T_add.yx(), 6.0);
+    SPHERAL_ASSERT_EQ(T_add.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.yz(), 12.0);
+    SPHERAL_ASSERT_EQ(T_add.zx(), 10.0);
+    SPHERAL_ASSERT_EQ(T_add.zy(), 14.0);
+    SPHERAL_ASSERT_EQ(T_add.zz(), 18.0);
+
+    T_sub = T1 - ST;
+    SPHERAL_ASSERT_EQ(T_sub.xx(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub.xy(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub.xz(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub.yx(), 2.0);
+    SPHERAL_ASSERT_EQ(T_sub.yy(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub.yz(), 0.0);
+    SPHERAL_ASSERT_EQ(T_sub.zx(), 4.0);
+    SPHERAL_ASSERT_EQ(T_sub.zy(), 2.0);
+    SPHERAL_ASSERT_EQ(T_sub.zz(), 0.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, ScalarMulDiv) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    double s = 2.0;
+
+    Tensor T_mul = T1 * s;
+    SPHERAL_ASSERT_EQ(T_mul.xx(), 2.0);
+    SPHERAL_ASSERT_EQ(T_mul.xy(), 4.0);
+    SPHERAL_ASSERT_EQ(T_mul.xz(), 6.0);
+    SPHERAL_ASSERT_EQ(T_mul.yx(), 8.0);
+    SPHERAL_ASSERT_EQ(T_mul.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T_mul.yz(), 12.0);
+    SPHERAL_ASSERT_EQ(T_mul.zx(), 14.0);
+    SPHERAL_ASSERT_EQ(T_mul.zy(), 16.0);
+    SPHERAL_ASSERT_EQ(T_mul.zz(), 18.0);
+
+    Tensor T_div = T1 / s;
+    SPHERAL_ASSERT_EQ(T_div.xx(), 0.5);
+    SPHERAL_ASSERT_EQ(T_div.xy(), 1.0);
+    SPHERAL_ASSERT_EQ(T_div.xz(), 1.5);
+    SPHERAL_ASSERT_EQ(T_div.yx(), 2.0);
+    SPHERAL_ASSERT_EQ(T_div.yy(), 2.5);
+    SPHERAL_ASSERT_EQ(T_div.yz(), 3.0);
+    SPHERAL_ASSERT_EQ(T_div.zx(), 3.5);
+    SPHERAL_ASSERT_EQ(T_div.zy(), 4.0);
+    SPHERAL_ASSERT_EQ(T_div.zz(), 4.5);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, InPlaceAddSub) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T2(9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+    
+    T1 += T2;
+    SPHERAL_ASSERT_EQ(T1.xx(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.yx(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.zx(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.zy(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 10.0);
+
+    T1 -= T2;
+    SPHERAL_ASSERT_EQ(T1.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T1.yx(), 4.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T1.zx(), 7.0);
+    SPHERAL_ASSERT_EQ(T1.zy(), 8.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, InPlaceScalarMulDiv) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    double s = 2.0;
+
+    T1 *= s;
+    SPHERAL_ASSERT_EQ(T1.xx(), 2.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 4.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 6.0);
+    SPHERAL_ASSERT_EQ(T1.yx(), 8.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 10.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 12.0);
+    SPHERAL_ASSERT_EQ(T1.zx(), 14.0);
+    SPHERAL_ASSERT_EQ(T1.zy(), 16.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 18.0);
+
+    T1 /= s;
+    SPHERAL_ASSERT_EQ(T1.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T1.xy(), 2.0);
+    SPHERAL_ASSERT_EQ(T1.xz(), 3.0);
+    SPHERAL_ASSERT_EQ(T1.yx(), 4.0);
+    SPHERAL_ASSERT_EQ(T1.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T1.yz(), 6.0);
+    SPHERAL_ASSERT_EQ(T1.zx(), 7.0);
+    SPHERAL_ASSERT_EQ(T1.zy(), 8.0);
+    SPHERAL_ASSERT_EQ(T1.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, Comparison) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T2(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T3(8.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+
+    SPHERAL_ASSERT_TRUE(T1 == T2);
+    SPHERAL_ASSERT_TRUE(T1 != T3);
+    SPHERAL_ASSERT_TRUE(T1 < T3);
+    SPHERAL_ASSERT_TRUE(T3 > T1);
+    SPHERAL_ASSERT_TRUE(T1 <= T2);
+    SPHERAL_ASSERT_TRUE(T1 >= T2);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, Transpose) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T_trans = T1.Transpose();
+    SPHERAL_ASSERT_EQ(T_trans.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T_trans.xy(), 4.0);
+    SPHERAL_ASSERT_EQ(T_trans.xz(), 7.0);
+    SPHERAL_ASSERT_EQ(T_trans.yx(), 2.0);
+    SPHERAL_ASSERT_EQ(T_trans.yy(), 5.0);
+    SPHERAL_ASSERT_EQ(T_trans.yz(), 8.0);
+    SPHERAL_ASSERT_EQ(T_trans.zx(), 3.0);
+    SPHERAL_ASSERT_EQ(T_trans.zy(), 6.0);
+    SPHERAL_ASSERT_EQ(T_trans.zz(), 9.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, TraceDeterminant) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    SPHERAL_ASSERT_EQ(T1.Trace(), 15.0);
+    SPHERAL_ASSERT_EQ(T1.Determinant(), 0.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, DotProduct) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T2(9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+    Tensor T_dot = T1.dot(T2);
+    // Expected values calculated manually
+    SPHERAL_ASSERT_EQ(T_dot.xx(), 30.0);
+    SPHERAL_ASSERT_EQ(T_dot.xy(), 24.0);
+    SPHERAL_ASSERT_EQ(T_dot.xz(), 18.0);
+    SPHERAL_ASSERT_EQ(T_dot.yx(), 84.0);
+    SPHERAL_ASSERT_EQ(T_dot.yy(), 69.0);
+    SPHERAL_ASSERT_EQ(T_dot.yz(), 54.0);
+    SPHERAL_ASSERT_EQ(T_dot.zx(), 138.0);
+    SPHERAL_ASSERT_EQ(T_dot.zy(), 114.0);
+    SPHERAL_ASSERT_EQ(T_dot.zz(), 90.0);
+
+    Vector V1(1.0, 2.0, 3.0);
+    Vector V_dot = T1.dot(V1);
+    SPHERAL_ASSERT_EQ(V_dot.x(), 14.0);
+    SPHERAL_ASSERT_EQ(V_dot.y(), 32.0);
+    SPHERAL_ASSERT_EQ(V_dot.z(), 50.0);
+  EXEC_IN_SPACE_END()
+}
+
+// TODO: Check this w/ Mike Owen
+GPU_TYPED_TEST_P(GeomTensorTypedTest, DoubleDotProduct) {
+  //using WORK_EXEC_POLICY = TypeParam;
+  //EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  //  Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+  //  Tensor T2(9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+  //  double ddot = T1.doubledot(T2);
+  //  // Expected value calculated manually
+  //  SPHERAL_ASSERT_EQ(ddot, 1.0*9.0 + 2.0*8.0 + 3.0*7.0 +
+  //                          4.0*6.0 + 5.0*5.0 + 6.0*4.0 +
+  //                          7.0*3.0 + 8.0*2.0 + 9.0*1.0);
+  //EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, Square) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T_sq = T1.square();
+    // Expected values calculated manually
+    SPHERAL_ASSERT_EQ(T_sq.xx(), 30.0);
+    SPHERAL_ASSERT_EQ(T_sq.xy(), 36.0);
+    SPHERAL_ASSERT_EQ(T_sq.xz(), 42.0);
+    SPHERAL_ASSERT_EQ(T_sq.yx(), 66.0);
+    SPHERAL_ASSERT_EQ(T_sq.yy(), 81.0);
+    SPHERAL_ASSERT_EQ(T_sq.yz(), 96.0);
+    SPHERAL_ASSERT_EQ(T_sq.zx(), 102.0);
+    SPHERAL_ASSERT_EQ(T_sq.zy(), 126.0);
+    SPHERAL_ASSERT_EQ(T_sq.zz(), 150.0);
+  EXEC_IN_SPACE_END()
+}
+
+GPU_TYPED_TEST_P(GeomTensorTypedTest, SquareElements) {
+  using WORK_EXEC_POLICY = TypeParam;
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+    Tensor T1(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor T_sq_elem = T1.squareElements();
+    SPHERAL_ASSERT_EQ(T_sq_elem.xx(), 1.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.xy(), 4.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.xz(), 9.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.yx(), 16.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.yy(), 25.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.yz(), 36.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.zx(), 49.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.zy(), 64.0);
+    SPHERAL_ASSERT_EQ(T_sq_elem.zz(), 81.0);
+  EXEC_IN_SPACE_END()
+}
+
+REGISTER_TYPED_TEST_SUITE_P(GeomTensorTypedTest, Ctor, Assignment, Accessors,
+                            Setters, GetSetRowsColumns, ZeroIdentity, UnaryMinus, AddSub,
+                            ScalarMulDiv, InPlaceAddSub, InPlaceScalarMulDiv, Comparison,
+                            Transpose, TraceDeterminant, DotProduct, DoubleDotProduct,
+                            Square, SquareElements);
+
+INSTANTIATE_TYPED_TEST_SUITE_P(GeomTensor, GeomTensorTypedTest,
+                               typename Spheral::Test<EXEC_TYPES>::Types, );

--- a/tests/cpp/include/test-basic-datatypes.hh
+++ b/tests/cpp/include/test-basic-datatypes.hh
@@ -14,8 +14,8 @@ using TEST_FIELD_DATATYPES = camp::list<
   ,double
   ,Spheral::Dim<3>::Vector
   //,Spheral::Dim<3>::Vector3d
-  //,Spheral::Dim<1>::Tensor
-  //Dim<1>::SymTensor,
+  ,Spheral::Dim<3>::Tensor
+  ,Spheral::Dim<3>::SymTensor
   ,Spheral::Dim<3>::ThirdRankTensor
   ,Spheral::Dim<3>::FourthRankTensor
   ,Spheral::Dim<3>::FifthRankTensor


### PR DESCRIPTION
# Summary

- This PR is a refactoring of `GeomTensor` & `GeomSymmetricTensor`:
  - Annotates Geom(Sym)Tensor with `SPHERAL_HOST_DEVICE` attributes macro.
  - Makes some changes to static variable usage in device code with explicit ctor calls and constexpr attributes.
  - Adds CPU & GPU unit testsing for Tensor types.
  - Makes Tensor types trivially copyable for use with `FieldView`.
  - Changes for warning squashing needed here will / have been moved to #387 .

- This PR satisfies #376 & #377 .
- It depends on #370 .

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. ([PR#159](https://rzlc.llnl.gov/gitlab/owen/LLNLSpheral/-/merge_requests/159))
- [x] LLNLSpheral PR has passed all tests.

