### PR TITLE
[GPU] RankNTensor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,9 @@ Notable changes include:
       * Unit testing to ensure implicitly copyable Spheral data types can be copied to and from the device correctly.
     * GeomVector has been converted to be used on the GPU direclty.
       * CPU & GPU unit testing of the public interface.
+    * RankNTensor (Third, Fourth, Fifth) have been refactored to execute on the GPU.
+    * Optimizations to RankTensor types:
+      * Stack allocation of tensor data; Static casting for CRTP implementation.
     * New Logging utility for runtime debug messages.
 
   * Build changes / improvements:

--- a/src/Geometry/GeomFifthRankTensor.hh
+++ b/src/Geometry/GeomFifthRankTensor.hh
@@ -29,20 +29,20 @@ public:
   static const GeomFifthRankTensor zero;
 
   // Constructors.
-  GeomFifthRankTensor();
-  explicit GeomFifthRankTensor(const double val);
-  GeomFifthRankTensor(const GeomFifthRankTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomFifthRankTensor();
+  SPHERAL_HOST_DEVICE explicit GeomFifthRankTensor(const double val);
+  SPHERAL_HOST_DEVICE GeomFifthRankTensor(const GeomFifthRankTensor& rhs);
 
   // Destructor.
-  ~GeomFifthRankTensor();
+  SPHERAL_HOST_DEVICE ~GeomFifthRankTensor();
 
   // Assignment.
-  GeomFifthRankTensor& operator=(const GeomFifthRankTensor& rhs);
-  GeomFifthRankTensor& operator=(const double rhs);
+  SPHERAL_HOST_DEVICE GeomFifthRankTensor& operator=(const GeomFifthRankTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomFifthRankTensor& operator=(const double rhs);
 
   // Access the elements by indicies.
-  double operator()(const size_type i, const size_type j, const size_type k, const size_type m, const size_type n) const;
-  double& operator()(const size_type i, const size_type j, const size_type k, const size_type m, const size_type n);
+  SPHERAL_HOST_DEVICE double operator()(const size_type i, const size_type j, const size_type k, const size_type m, const size_type n) const;
+  SPHERAL_HOST_DEVICE double& operator()(const size_type i, const size_type j, const size_type k, const size_type m, const size_type n);
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/Geometry/GeomFifthRankTensor.hh
+++ b/src/Geometry/GeomFifthRankTensor.hh
@@ -29,15 +29,12 @@ public:
   static const GeomFifthRankTensor zero;
 
   // Constructors.
-  SPHERAL_HOST_DEVICE GeomFifthRankTensor();
+  SPHERAL_HOST_DEVICE GeomFifthRankTensor() = default;
   SPHERAL_HOST_DEVICE explicit GeomFifthRankTensor(const double val);
-  SPHERAL_HOST_DEVICE GeomFifthRankTensor(const GeomFifthRankTensor& rhs);
-
-  // Destructor.
-  SPHERAL_HOST_DEVICE ~GeomFifthRankTensor();
+  SPHERAL_HOST_DEVICE GeomFifthRankTensor(const GeomFifthRankTensor& rhs) = default;
 
   // Assignment.
-  SPHERAL_HOST_DEVICE GeomFifthRankTensor& operator=(const GeomFifthRankTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomFifthRankTensor& operator=(const GeomFifthRankTensor& rhs) = default;
   SPHERAL_HOST_DEVICE GeomFifthRankTensor& operator=(const double rhs);
 
   // Access the elements by indicies.

--- a/src/Geometry/GeomFifthRankTensor.hh
+++ b/src/Geometry/GeomFifthRankTensor.hh
@@ -18,11 +18,12 @@ namespace Spheral {
 
 template<int nDim>
 class GeomFifthRankTensor : public RankNTensor<nDim, 5, GeomFifthRankTensor<nDim> > {
+  using BaseType = RankNTensor<nDim, 5, GeomFifthRankTensor<nDim>>;
 
 public:
   //--------------------------- Public Interface ---------------------------//
-  typedef typename RankNTensor<nDim, 5, GeomFifthRankTensor>::size_type size_type;
-  static const size_type numElements;
+  using size_type = typename BaseType::size_type;
+  static constexpr size_type numElements = BaseType::numElements;
 
   // Useful static member data.
   static const GeomFifthRankTensor zero;
@@ -48,7 +49,6 @@ private:
   using RankNTensor<nDim, 5, GeomFifthRankTensor>::mElements;
 };
 
-template<int nDims> const typename GeomFifthRankTensor<nDims>::size_type GeomFifthRankTensor<nDims>::numElements = calcNumNRankElements<nDims, 5>();
 template<int nDims> const GeomFifthRankTensor<nDims> GeomFifthRankTensor<nDims>::zero = GeomFifthRankTensor<nDims>(0.0);
 
 }

--- a/src/Geometry/GeomFifthRankTensorInline.hh
+++ b/src/Geometry/GeomFifthRankTensorInline.hh
@@ -12,6 +12,7 @@ namespace Spheral {
 // Default constructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFifthRankTensor<nDim>::
 GeomFifthRankTensor():
@@ -22,6 +23,7 @@ GeomFifthRankTensor():
 // Construct with the given value filling the tensor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFifthRankTensor<nDim>::
 GeomFifthRankTensor(const double val):
@@ -32,6 +34,7 @@ GeomFifthRankTensor(const double val):
 // Copy constructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFifthRankTensor<nDim>::
 GeomFifthRankTensor(const GeomFifthRankTensor& rhs):
@@ -42,6 +45,7 @@ GeomFifthRankTensor(const GeomFifthRankTensor& rhs):
 // Destructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFifthRankTensor<nDim>::
 ~GeomFifthRankTensor() {
@@ -51,6 +55,7 @@ GeomFifthRankTensor<nDim>::
 // Assignment.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFifthRankTensor<nDim>&
 GeomFifthRankTensor<nDim>::
@@ -63,6 +68,7 @@ operator=(const GeomFifthRankTensor& rhs) {
 // Assignment (double).
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFifthRankTensor<nDim>&
 GeomFifthRankTensor<nDim>::
@@ -75,6 +81,7 @@ operator=(const double rhs) {
 // Access the elements by indicies.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomFifthRankTensor<nDim>::
@@ -88,6 +95,7 @@ operator()(const GeomFifthRankTensor::size_type i,
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double&
 GeomFifthRankTensor<nDim>::

--- a/src/Geometry/GeomFifthRankTensorInline.hh
+++ b/src/Geometry/GeomFifthRankTensorInline.hh
@@ -9,17 +9,6 @@
 namespace Spheral {
 
 //------------------------------------------------------------------------------
-// Default constructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomFifthRankTensor<nDim>::
-GeomFifthRankTensor():
-  RankNTensor<nDim, 5, GeomFifthRankTensor>() {
-}
-
-//------------------------------------------------------------------------------
 // Construct with the given value filling the tensor.
 //------------------------------------------------------------------------------
 template<int nDim>
@@ -28,40 +17,6 @@ inline
 GeomFifthRankTensor<nDim>::
 GeomFifthRankTensor(const double val):
   RankNTensor<nDim, 5, GeomFifthRankTensor>(val) {
-}
-
-//------------------------------------------------------------------------------
-// Copy constructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomFifthRankTensor<nDim>::
-GeomFifthRankTensor(const GeomFifthRankTensor& rhs):
-  RankNTensor<nDim, 5, GeomFifthRankTensor>(rhs) {
-}
-
-//------------------------------------------------------------------------------
-// Destructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomFifthRankTensor<nDim>::
-~GeomFifthRankTensor() {
-}
-
-//------------------------------------------------------------------------------
-// Assignment.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomFifthRankTensor<nDim>&
-GeomFifthRankTensor<nDim>::
-operator=(const GeomFifthRankTensor& rhs) {
-  RankNTensor<nDim, 5, GeomFifthRankTensor>::operator=(rhs);
-  return *this;
 }
 
 //------------------------------------------------------------------------------

--- a/src/Geometry/GeomFifthRankTensorInline.hh
+++ b/src/Geometry/GeomFifthRankTensorInline.hh
@@ -70,21 +70,21 @@ template<int nDim>
 inline
 GeomFifthRankTensor<nDim>
 operator*(const double lhs, const GeomFifthRankTensor<nDim>& rhs) {
-  return lhs * dynamic_cast<const RankNTensor<nDim, 5, GeomFifthRankTensor<nDim> >&>(rhs);
+  return lhs * static_cast<const RankNTensor<nDim, 5, GeomFifthRankTensor<nDim> >&>(rhs);
 }
 
 template<int nDim>
 inline
 ::std::istream&
 operator>>(std::istream& is, GeomFifthRankTensor<nDim>& rhs) {
-  return operator>>(is, dynamic_cast<const RankNTensor<nDim, 5, GeomFifthRankTensor<nDim> >&>(rhs));
+  return operator>>(is, static_cast<const RankNTensor<nDim, 5, GeomFifthRankTensor<nDim> >&>(rhs));
 }
 
 template<int nDim>
 inline
 ::std::ostream&
 operator<<(std::ostream& os, const GeomFifthRankTensor<nDim>& rhs) {
-  return operator<<(os, dynamic_cast<const RankNTensor<nDim, 5, GeomFifthRankTensor<nDim> >&>(rhs));
+  return operator<<(os, static_cast<const RankNTensor<nDim, 5, GeomFifthRankTensor<nDim> >&>(rhs));
 }
 
 }

--- a/src/Geometry/GeomFourthRankTensor.hh
+++ b/src/Geometry/GeomFourthRankTensor.hh
@@ -18,11 +18,12 @@ namespace Spheral {
 
 template<int nDim>
 class GeomFourthRankTensor : public RankNTensor<nDim, 4, GeomFourthRankTensor<nDim> > {
+  using BaseType = RankNTensor<nDim, 4, GeomFourthRankTensor<nDim>>;
 
 public:
   //--------------------------- Public Interface ---------------------------//
-  typedef typename RankNTensor<nDim, 4, GeomFourthRankTensor>::size_type size_type;
-  static const size_type numElements;
+  using size_type = typename BaseType::size_type;
+  static constexpr size_type numElements = BaseType::numElements;
 
   // Useful static member data.
   static const GeomFourthRankTensor zero;
@@ -48,7 +49,6 @@ private:
   using RankNTensor<nDim, 4, GeomFourthRankTensor>::mElements;
 };
 
-template<int nDims> const typename GeomFourthRankTensor<nDims>::size_type GeomFourthRankTensor<nDims>::numElements = calcNumNRankElements<nDims, 4>();
 template<int nDims> const GeomFourthRankTensor<nDims> GeomFourthRankTensor<nDims>::zero = GeomFourthRankTensor<nDims>(0.0);
 
 }

--- a/src/Geometry/GeomFourthRankTensor.hh
+++ b/src/Geometry/GeomFourthRankTensor.hh
@@ -29,20 +29,20 @@ public:
   static const GeomFourthRankTensor zero;
 
   // Constructors.
-  GeomFourthRankTensor();
-  explicit GeomFourthRankTensor(const double val);
-  GeomFourthRankTensor(const GeomFourthRankTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomFourthRankTensor();
+  SPHERAL_HOST_DEVICE explicit GeomFourthRankTensor(const double val);
+  SPHERAL_HOST_DEVICE GeomFourthRankTensor(const GeomFourthRankTensor& rhs);
 
   // Destructor.
-  ~GeomFourthRankTensor();
+  SPHERAL_HOST_DEVICE ~GeomFourthRankTensor();
 
   // Assignment.
-  GeomFourthRankTensor& operator=(const GeomFourthRankTensor& rhs);
-  GeomFourthRankTensor& operator=(const double rhs);
+  SPHERAL_HOST_DEVICE GeomFourthRankTensor& operator=(const GeomFourthRankTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomFourthRankTensor& operator=(const double rhs);
 
   // Access the elements by indicies.
-  double operator()(const size_type i, const size_type j, const size_type k, const size_type m) const;
-  double& operator()(const size_type i, const size_type j, const size_type k, const size_type m);
+  SPHERAL_HOST_DEVICE double operator()(const size_type i, const size_type j, const size_type k, const size_type m) const;
+  SPHERAL_HOST_DEVICE double& operator()(const size_type i, const size_type j, const size_type k, const size_type m);
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/Geometry/GeomFourthRankTensor.hh
+++ b/src/Geometry/GeomFourthRankTensor.hh
@@ -29,15 +29,12 @@ public:
   static const GeomFourthRankTensor zero;
 
   // Constructors.
-  SPHERAL_HOST_DEVICE GeomFourthRankTensor();
+  SPHERAL_HOST_DEVICE GeomFourthRankTensor() = default;
   SPHERAL_HOST_DEVICE explicit GeomFourthRankTensor(const double val);
-  SPHERAL_HOST_DEVICE GeomFourthRankTensor(const GeomFourthRankTensor& rhs);
-
-  // Destructor.
-  SPHERAL_HOST_DEVICE ~GeomFourthRankTensor();
+  SPHERAL_HOST_DEVICE GeomFourthRankTensor(const GeomFourthRankTensor& rhs) = default;
 
   // Assignment.
-  SPHERAL_HOST_DEVICE GeomFourthRankTensor& operator=(const GeomFourthRankTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomFourthRankTensor& operator=(const GeomFourthRankTensor& rhs) = default;
   SPHERAL_HOST_DEVICE GeomFourthRankTensor& operator=(const double rhs);
 
   // Access the elements by indicies.

--- a/src/Geometry/GeomFourthRankTensorInline.hh
+++ b/src/Geometry/GeomFourthRankTensorInline.hh
@@ -68,21 +68,21 @@ template<int nDim>
 inline
 GeomFourthRankTensor<nDim>
 operator*(const double lhs, const GeomFourthRankTensor<nDim>& rhs) {
-  return lhs * dynamic_cast<const RankNTensor<nDim, 4, GeomFourthRankTensor<nDim> >&>(rhs);
+  return lhs * static_cast<const RankNTensor<nDim, 4, GeomFourthRankTensor<nDim> >&>(rhs);
 }
 
 template<int nDim>
 inline
 ::std::istream&
 operator>>(std::istream& is, GeomFourthRankTensor<nDim>& rhs) {
-  return operator>>(is, dynamic_cast<const RankNTensor<nDim, 4, GeomFourthRankTensor<nDim> >&>(rhs));
+  return operator>>(is, static_cast<const RankNTensor<nDim, 4, GeomFourthRankTensor<nDim> >&>(rhs));
 }
 
 template<int nDim>
 inline
 ::std::ostream&
 operator<<(std::ostream& os, const GeomFourthRankTensor<nDim>& rhs) {
-  return operator<<(os, dynamic_cast<const RankNTensor<nDim, 4, GeomFourthRankTensor<nDim> >&>(rhs));
+  return operator<<(os, static_cast<const RankNTensor<nDim, 4, GeomFourthRankTensor<nDim> >&>(rhs));
 }
 
 }

--- a/src/Geometry/GeomFourthRankTensorInline.hh
+++ b/src/Geometry/GeomFourthRankTensorInline.hh
@@ -12,6 +12,7 @@ namespace Spheral {
 // Default constructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFourthRankTensor<nDim>::
 GeomFourthRankTensor():
@@ -22,6 +23,7 @@ GeomFourthRankTensor():
 // Construct with the given value filling the tensor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFourthRankTensor<nDim>::
 GeomFourthRankTensor(const double val):
@@ -32,6 +34,7 @@ GeomFourthRankTensor(const double val):
 // Copy constructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFourthRankTensor<nDim>::
 GeomFourthRankTensor(const GeomFourthRankTensor& rhs):
@@ -42,6 +45,7 @@ GeomFourthRankTensor(const GeomFourthRankTensor& rhs):
 // Destructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFourthRankTensor<nDim>::
 ~GeomFourthRankTensor() {
@@ -51,6 +55,7 @@ GeomFourthRankTensor<nDim>::
 // Assignment.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFourthRankTensor<nDim>&
 GeomFourthRankTensor<nDim>::
@@ -63,6 +68,7 @@ operator=(const GeomFourthRankTensor& rhs) {
 // Assignment (double).
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomFourthRankTensor<nDim>&
 GeomFourthRankTensor<nDim>::
@@ -75,6 +81,7 @@ operator=(const double rhs) {
 // Access the elements by indicies.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomFourthRankTensor<nDim>::
@@ -87,6 +94,7 @@ operator()(const GeomFourthRankTensor::size_type i,
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double&
 GeomFourthRankTensor<nDim>::

--- a/src/Geometry/GeomFourthRankTensorInline.hh
+++ b/src/Geometry/GeomFourthRankTensorInline.hh
@@ -9,17 +9,6 @@
 namespace Spheral {
 
 //------------------------------------------------------------------------------
-// Default constructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomFourthRankTensor<nDim>::
-GeomFourthRankTensor():
-  RankNTensor<nDim, 4, GeomFourthRankTensor>() {
-}
-
-//------------------------------------------------------------------------------
 // Construct with the given value filling the tensor.
 //------------------------------------------------------------------------------
 template<int nDim>
@@ -28,40 +17,6 @@ inline
 GeomFourthRankTensor<nDim>::
 GeomFourthRankTensor(const double val):
   RankNTensor<nDim, 4, GeomFourthRankTensor>(val) {
-}
-
-//------------------------------------------------------------------------------
-// Copy constructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomFourthRankTensor<nDim>::
-GeomFourthRankTensor(const GeomFourthRankTensor& rhs):
-  RankNTensor<nDim, 4, GeomFourthRankTensor>(rhs) {
-}
-
-//------------------------------------------------------------------------------
-// Destructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomFourthRankTensor<nDim>::
-~GeomFourthRankTensor() {
-}
-
-//------------------------------------------------------------------------------
-// Assignment.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomFourthRankTensor<nDim>&
-GeomFourthRankTensor<nDim>::
-operator=(const GeomFourthRankTensor& rhs) {
-  RankNTensor<nDim, 4, GeomFourthRankTensor>::operator=(rhs);
-  return *this;
 }
 
 //------------------------------------------------------------------------------

--- a/src/Geometry/GeomThirdRankTensor.hh
+++ b/src/Geometry/GeomThirdRankTensor.hh
@@ -29,15 +29,12 @@ public:
   static const GeomThirdRankTensor zero;
 
   // Constructors.
-  SPHERAL_HOST_DEVICE GeomThirdRankTensor();
+  SPHERAL_HOST_DEVICE GeomThirdRankTensor() = default;
   SPHERAL_HOST_DEVICE explicit GeomThirdRankTensor(const double val);
-  SPHERAL_HOST_DEVICE GeomThirdRankTensor(const GeomThirdRankTensor& rhs);
-
-  // Destructor.
-  SPHERAL_HOST_DEVICE ~GeomThirdRankTensor();
+  SPHERAL_HOST_DEVICE GeomThirdRankTensor(const GeomThirdRankTensor& rhs) = default;
 
   // Assignment.
-  SPHERAL_HOST_DEVICE GeomThirdRankTensor& operator=(const GeomThirdRankTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomThirdRankTensor& operator=(const GeomThirdRankTensor& rhs) = default;
   SPHERAL_HOST_DEVICE GeomThirdRankTensor& operator=(const double rhs);
 
   // Access the elements by indicies.

--- a/src/Geometry/GeomThirdRankTensor.hh
+++ b/src/Geometry/GeomThirdRankTensor.hh
@@ -18,11 +18,12 @@ namespace Spheral {
 
 template<int nDim>
 class GeomThirdRankTensor : public RankNTensor<nDim, 3, GeomThirdRankTensor<nDim> > {
+  using BaseType = RankNTensor<nDim, 3, GeomThirdRankTensor<nDim>>;
 
 public:
   //--------------------------- Public Interface ---------------------------//
-  typedef typename RankNTensor<nDim, 3, GeomThirdRankTensor>::size_type size_type;
-  static const size_type numElements;
+  using size_type = typename BaseType::size_type;
+  static constexpr size_type numElements = BaseType::numElements;
 
   // Useful static member data.
   static const GeomThirdRankTensor zero;
@@ -49,7 +50,6 @@ private:
 };
 
 
-template<int nDims> const typename GeomThirdRankTensor<nDims>::size_type GeomThirdRankTensor<nDims>::numElements = calcNumNRankElements<nDims, 3>();
 template<int nDims> const GeomThirdRankTensor<nDims> GeomThirdRankTensor<nDims>::zero = GeomThirdRankTensor<nDims>(0.0);
 
 }

--- a/src/Geometry/GeomThirdRankTensor.hh
+++ b/src/Geometry/GeomThirdRankTensor.hh
@@ -29,20 +29,20 @@ public:
   static const GeomThirdRankTensor zero;
 
   // Constructors.
-  GeomThirdRankTensor();
-  explicit GeomThirdRankTensor(const double val);
-  GeomThirdRankTensor(const GeomThirdRankTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomThirdRankTensor();
+  SPHERAL_HOST_DEVICE explicit GeomThirdRankTensor(const double val);
+  SPHERAL_HOST_DEVICE GeomThirdRankTensor(const GeomThirdRankTensor& rhs);
 
   // Destructor.
-  ~GeomThirdRankTensor();
+  SPHERAL_HOST_DEVICE ~GeomThirdRankTensor();
 
   // Assignment.
-  GeomThirdRankTensor& operator=(const GeomThirdRankTensor& rhs);
-  GeomThirdRankTensor& operator=(const double rhs);
+  SPHERAL_HOST_DEVICE GeomThirdRankTensor& operator=(const GeomThirdRankTensor& rhs);
+  SPHERAL_HOST_DEVICE GeomThirdRankTensor& operator=(const double rhs);
 
   // Access the elements by indicies.
-  double operator()(const size_type i, const size_type j, const size_type k) const;
-  double& operator()(const size_type i, const size_type j, const size_type k);
+  SPHERAL_HOST_DEVICE double operator()(const size_type i, const size_type j, const size_type k) const;
+  SPHERAL_HOST_DEVICE double& operator()(const size_type i, const size_type j, const size_type k);
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/Geometry/GeomThirdRankTensorInline.hh
+++ b/src/Geometry/GeomThirdRankTensorInline.hh
@@ -66,21 +66,21 @@ template<int nDim>
 inline
 GeomThirdRankTensor<nDim>
 operator*(const double lhs, const GeomThirdRankTensor<nDim>& rhs) {
-  return lhs * dynamic_cast<const RankNTensor<nDim, 3, GeomThirdRankTensor<nDim> >&>(rhs);
+  return lhs * static_cast<const RankNTensor<nDim, 3, GeomThirdRankTensor<nDim> >&>(rhs);
 }
 
 template<int nDim>
 inline
 ::std::istream&
 operator>>(std::istream& is, GeomThirdRankTensor<nDim>& rhs) {
-  return operator>>(is, dynamic_cast<RankNTensor<nDim, 3, GeomThirdRankTensor<nDim> >&>(rhs));
+  return operator>>(is, static_cast<RankNTensor<nDim, 3, GeomThirdRankTensor<nDim> >&>(rhs));
 }
 
 template<int nDim>
 inline
 ::std::ostream&
 operator<<(std::ostream& os, const GeomThirdRankTensor<nDim>& rhs) {
-  return operator<<(os, dynamic_cast<const RankNTensor<nDim, 3, GeomThirdRankTensor<nDim> >&>(rhs));
+  return operator<<(os, static_cast<const RankNTensor<nDim, 3, GeomThirdRankTensor<nDim> >&>(rhs));
 }
 
 }

--- a/src/Geometry/GeomThirdRankTensorInline.hh
+++ b/src/Geometry/GeomThirdRankTensorInline.hh
@@ -12,6 +12,7 @@ namespace Spheral {
 // Default constructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomThirdRankTensor<nDim>::
 GeomThirdRankTensor():
@@ -22,6 +23,7 @@ GeomThirdRankTensor():
 // Construct with the given value filling the tensor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomThirdRankTensor<nDim>::
 GeomThirdRankTensor(const double val):
@@ -32,6 +34,7 @@ GeomThirdRankTensor(const double val):
 // Copy constructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomThirdRankTensor<nDim>::
 GeomThirdRankTensor(const GeomThirdRankTensor& rhs):
@@ -42,6 +45,7 @@ GeomThirdRankTensor(const GeomThirdRankTensor& rhs):
 // Destructor.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomThirdRankTensor<nDim>::
 ~GeomThirdRankTensor() {
@@ -51,6 +55,7 @@ GeomThirdRankTensor<nDim>::
 // Assignment.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomThirdRankTensor<nDim>&
 GeomThirdRankTensor<nDim>::
@@ -63,6 +68,7 @@ operator=(const GeomThirdRankTensor& rhs) {
 // Assignment (double).
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 GeomThirdRankTensor<nDim>&
 GeomThirdRankTensor<nDim>::
@@ -75,6 +81,7 @@ operator=(const double rhs) {
 // Access the elements by indicies.
 //------------------------------------------------------------------------------
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double
 GeomThirdRankTensor<nDim>::
@@ -86,6 +93,7 @@ operator()(const GeomThirdRankTensor::size_type i,
 }
 
 template<int nDim>
+SPHERAL_HOST_DEVICE
 inline
 double&
 GeomThirdRankTensor<nDim>::

--- a/src/Geometry/GeomThirdRankTensorInline.hh
+++ b/src/Geometry/GeomThirdRankTensorInline.hh
@@ -9,17 +9,6 @@
 namespace Spheral {
 
 //------------------------------------------------------------------------------
-// Default constructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomThirdRankTensor<nDim>::
-GeomThirdRankTensor():
-  RankNTensor<nDim, 3, GeomThirdRankTensor>() {
-}
-
-//------------------------------------------------------------------------------
 // Construct with the given value filling the tensor.
 //------------------------------------------------------------------------------
 template<int nDim>
@@ -28,40 +17,6 @@ inline
 GeomThirdRankTensor<nDim>::
 GeomThirdRankTensor(const double val):
   RankNTensor<nDim, 3, GeomThirdRankTensor>(val) {
-}
-
-//------------------------------------------------------------------------------
-// Copy constructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomThirdRankTensor<nDim>::
-GeomThirdRankTensor(const GeomThirdRankTensor& rhs):
-  RankNTensor<nDim, 3, GeomThirdRankTensor>(rhs) {
-}
-
-//------------------------------------------------------------------------------
-// Destructor.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomThirdRankTensor<nDim>::
-~GeomThirdRankTensor() {
-}
-
-//------------------------------------------------------------------------------
-// Assignment.
-//------------------------------------------------------------------------------
-template<int nDim>
-SPHERAL_HOST_DEVICE
-inline
-GeomThirdRankTensor<nDim>&
-GeomThirdRankTensor<nDim>::
-operator=(const GeomThirdRankTensor& rhs) {
-  RankNTensor<nDim, 3, GeomThirdRankTensor>::operator=(rhs);
-  return *this;
 }
 
 //------------------------------------------------------------------------------

--- a/src/Geometry/RankNTensor.hh
+++ b/src/Geometry/RankNTensor.hh
@@ -24,6 +24,7 @@ public:
   // Useful static member data.
   static const size_type nrank;
   static const size_type nDimensions;
+  static constexpr size_type numElements = FastMath::calcPower(nDim, rank);
 
   // Constructors.
   RankNTensor();
@@ -87,7 +88,7 @@ public:
 
 protected:
   //--------------------------- Protected Interface ---------------------------//
-  double* mElements;
+  double mElements[numElements];
 };
 
 // Forward declare the global functions.
@@ -100,7 +101,6 @@ template<int nDim, int rank, typename Descendant> ::std::ostream& operator<<(std
 template<int nDim, int rank, typename Descendant> const typename RankNTensor<nDim, rank, Descendant>::size_type RankNTensor<nDim, rank, Descendant>::nrank = rank;
 template<int nDim, int rank, typename Descendant> const typename RankNTensor<nDim, rank, Descendant>::size_type RankNTensor<nDim, rank, Descendant>::nDimensions = nDim;
 
-template<int nDims, unsigned rank> constexpr int calcNumNRankElements() {return FastMath::calcPower(nDims, rank);}
 }
 
 #ifndef __GCCXML__

--- a/src/Geometry/RankNTensor.hh
+++ b/src/Geometry/RankNTensor.hh
@@ -27,15 +27,12 @@ public:
   static constexpr size_type numElements = FastMath::calcPower(nDim, rank);
 
   // Constructors.
-  SPHERAL_HOST_DEVICE RankNTensor();
+  SPHERAL_HOST_DEVICE RankNTensor() = default;
   SPHERAL_HOST_DEVICE explicit RankNTensor(const double val);
-  SPHERAL_HOST_DEVICE RankNTensor(const RankNTensor& rhs);
-
-  // Destructor.
-  SPHERAL_HOST_DEVICE virtual ~RankNTensor();
+  SPHERAL_HOST_DEVICE RankNTensor(const RankNTensor& rhs) = default;
 
   // Assignment.
-  SPHERAL_HOST_DEVICE RankNTensor& operator=(const RankNTensor& rhs);
+  SPHERAL_HOST_DEVICE RankNTensor& operator=(const RankNTensor& rhs) = default;
   SPHERAL_HOST_DEVICE RankNTensor& operator=(const double rhs);
 
   // More C++ style indexing.

--- a/src/Geometry/RankNTensor.hh
+++ b/src/Geometry/RankNTensor.hh
@@ -27,64 +27,64 @@ public:
   static constexpr size_type numElements = FastMath::calcPower(nDim, rank);
 
   // Constructors.
-  RankNTensor();
-  explicit RankNTensor(const double val);
-  RankNTensor(const RankNTensor& rhs);
+  SPHERAL_HOST_DEVICE RankNTensor();
+  SPHERAL_HOST_DEVICE explicit RankNTensor(const double val);
+  SPHERAL_HOST_DEVICE RankNTensor(const RankNTensor& rhs);
 
   // Destructor.
-  virtual ~RankNTensor();
+  SPHERAL_HOST_DEVICE virtual ~RankNTensor();
 
   // Assignment.
-  RankNTensor& operator=(const RankNTensor& rhs);
-  RankNTensor& operator=(const double rhs);
+  SPHERAL_HOST_DEVICE RankNTensor& operator=(const RankNTensor& rhs);
+  SPHERAL_HOST_DEVICE RankNTensor& operator=(const double rhs);
 
   // More C++ style indexing.
-  double operator[](size_type index) const;
-  double& operator[](size_type index);
+  SPHERAL_HOST_DEVICE double operator[](size_type index) const;
+  SPHERAL_HOST_DEVICE double& operator[](size_type index);
 
   // Iterator access to the raw data.
-  iterator begin();
-  iterator end();
+  SPHERAL_HOST_DEVICE iterator begin();
+  SPHERAL_HOST_DEVICE iterator end();
 
-  const_iterator begin() const;
-  const_iterator end() const;
+  SPHERAL_HOST_DEVICE const_iterator begin() const;
+  SPHERAL_HOST_DEVICE const_iterator end() const;
 
   // Zero out the tensor.
-  void Zero();
+  SPHERAL_HOST_DEVICE void Zero();
 
   // Assorted operations.
-  Descendant operator-() const;
+  SPHERAL_HOST_DEVICE Descendant operator-() const;
 
-  Descendant& operator+=(const RankNTensor& rhs);
-  Descendant& operator-=(const RankNTensor& rhs);
+  SPHERAL_HOST_DEVICE Descendant& operator+=(const RankNTensor& rhs);
+  SPHERAL_HOST_DEVICE Descendant& operator-=(const RankNTensor& rhs);
 
-  Descendant operator+(const RankNTensor& rhs) const;
-  Descendant operator-(const RankNTensor& rhs) const;
+  SPHERAL_HOST_DEVICE Descendant operator+(const RankNTensor& rhs) const;
+  SPHERAL_HOST_DEVICE Descendant operator-(const RankNTensor& rhs) const;
 
-  Descendant& operator*=(const double rhs);
-  Descendant& operator/=(const double rhs);
+  SPHERAL_HOST_DEVICE Descendant& operator*=(const double rhs);
+  SPHERAL_HOST_DEVICE Descendant& operator/=(const double rhs);
 
-  Descendant operator*(const double rhs) const;
-  Descendant operator/(const double rhs) const;
+  SPHERAL_HOST_DEVICE Descendant operator*(const double rhs) const;
+  SPHERAL_HOST_DEVICE Descendant operator/(const double rhs) const;
 
-  bool operator==(const RankNTensor& rhs) const;
-  bool operator!=(const RankNTensor& rhs) const;
-  bool operator<(const RankNTensor& rhs) const;
-  bool operator>(const RankNTensor& rhs) const;
-  bool operator<=(const RankNTensor& rhs) const;
-  bool operator>=(const RankNTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator==(const RankNTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator!=(const RankNTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<(const RankNTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>(const RankNTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator<=(const RankNTensor& rhs) const;
+  SPHERAL_HOST_DEVICE bool operator>=(const RankNTensor& rhs) const;
 
-  bool operator==(const double rhs) const;
-  bool operator!=(const double rhs) const;
+  SPHERAL_HOST_DEVICE bool operator==(const double rhs) const;
+  SPHERAL_HOST_DEVICE bool operator!=(const double rhs) const;
 
-  double doubledot(const RankNTensor<nDim, rank, Descendant>& rhs) const;
+  SPHERAL_HOST_DEVICE double doubledot(const RankNTensor<nDim, rank, Descendant>& rhs) const;
 
   // Return a tensor where each element is the square of the corresponding 
   // element of this tensor.
-  Descendant squareElements() const;
+  SPHERAL_HOST_DEVICE Descendant squareElements() const;
 
   // Return the max absolute element.
-  double maxAbsElement() const;
+  SPHERAL_HOST_DEVICE double maxAbsElement() const;
 
 protected:
   //--------------------------- Protected Interface ---------------------------//

--- a/src/Geometry/RankNTensor.hh
+++ b/src/Geometry/RankNTensor.hh
@@ -88,7 +88,7 @@ public:
 
 protected:
   //--------------------------- Protected Interface ---------------------------//
-  double mElements[numElements];
+  double mElements[numElements] = {};
 };
 
 // Forward declare the global functions.

--- a/src/Geometry/RankNTensorInline.hh
+++ b/src/Geometry/RankNTensorInline.hh
@@ -112,7 +112,7 @@ inline
 Descendant
 RankNTensor<nDim, rank, Descendant>::
 operator-() const {
-  Descendant result(dynamic_cast<const Descendant&>(*this));
+  Descendant result(static_cast<const Descendant&>(*this));
   result *= -1.0;
   return result;
 }
@@ -127,7 +127,7 @@ Descendant&
 RankNTensor<nDim,rank, Descendant>::
 operator+=(const RankNTensor& rhs) {
   for (size_type i = 0; i != numElements; ++i) mElements[i] += rhs.mElements[i];
-  return dynamic_cast<Descendant&>(*this);
+  return static_cast<Descendant&>(*this);
 }
 
 //------------------------------------------------------------------------------
@@ -140,7 +140,7 @@ Descendant&
 RankNTensor<nDim,rank, Descendant>::
 operator-=(const RankNTensor& rhs) {
   for (size_type i = 0; i != numElements; ++i) mElements[i] -= rhs.mElements[i];
-  return dynamic_cast<Descendant&>(*this);
+  return static_cast<Descendant&>(*this);
 }
 
 //------------------------------------------------------------------------------
@@ -152,7 +152,7 @@ inline
 Descendant
 RankNTensor<nDim,rank, Descendant>::
 operator+(const RankNTensor& rhs) const {
-  Descendant result(dynamic_cast<const Descendant&>(*this));
+  Descendant result(static_cast<const Descendant&>(*this));
   result += rhs;
   return result;
 }
@@ -166,7 +166,7 @@ inline
 Descendant
 RankNTensor<nDim,rank, Descendant>::
 operator-(const RankNTensor& rhs) const {
-  Descendant result(dynamic_cast<const Descendant&>(*this));
+  Descendant result(static_cast<const Descendant&>(*this));
   result -= rhs;
   return result;
 }
@@ -181,7 +181,7 @@ Descendant&
 RankNTensor<nDim,rank, Descendant>::
 operator*=(const double rhs) {
   for (size_type i = 0; i != numElements; ++i) mElements[i] *= rhs;
-  return dynamic_cast<Descendant&>(*this);
+  return static_cast<Descendant&>(*this);
 }
 
 //------------------------------------------------------------------------------
@@ -195,7 +195,7 @@ RankNTensor<nDim,rank, Descendant>::
 operator/=(const double rhs) {
   REQUIRE(rhs != 0.0);
   for (size_type i = 0; i != numElements; ++i) mElements[i] /= rhs;
-  return dynamic_cast<Descendant&>(*this);
+  return static_cast<Descendant&>(*this);
 }
 
 //------------------------------------------------------------------------------
@@ -207,7 +207,7 @@ inline
 Descendant
 RankNTensor<nDim,rank, Descendant>::
 operator*(const double rhs) const {
-  Descendant result(dynamic_cast<const Descendant&>(*this));
+  Descendant result(static_cast<const Descendant&>(*this));
   result *= rhs;
   return result;
 }
@@ -222,7 +222,7 @@ Descendant
 RankNTensor<nDim,rank, Descendant>::
 operator/(const double rhs) const {
   REQUIRE(rhs != 0.0);
-  Descendant result(dynamic_cast<const Descendant&>(*this));
+  Descendant result(static_cast<const Descendant&>(*this));
   result /= rhs;
   return result;
 }
@@ -359,7 +359,7 @@ inline
 Descendant
 RankNTensor<nDim,rank, Descendant>::
 squareElements() const {
-  Descendant result(dynamic_cast<const Descendant&>(*this));
+  Descendant result(static_cast<const Descendant&>(*this));
   for (size_type i = 1; i != numElements; ++i) 
     *(result.begin() + i) *= mElements[i];
   return result;
@@ -391,7 +391,7 @@ inline
 Descendant
 operator*(const double lhs,
           const RankNTensor<nDim, rank, Descendant>& rhs) {
-  Descendant result(dynamic_cast<const Descendant&>(rhs));
+  Descendant result(static_cast<const Descendant&>(rhs));
   result *= lhs;
   return result;
 }

--- a/src/Geometry/RankNTensorInline.hh
+++ b/src/Geometry/RankNTensorInline.hh
@@ -15,7 +15,7 @@ SPHERAL_HOST_DEVICE
 inline
 RankNTensor<nDim,rank, Descendant>::
 RankNTensor(const double val) {
-  std::fill(begin(), end(), val);
+  for (size_t i = 0; i < numElements; ++i) mElements[i] = val;
 }
 
 //------------------------------------------------------------------------------
@@ -27,7 +27,7 @@ inline
 RankNTensor<nDim,rank, Descendant>&
 RankNTensor<nDim,rank, Descendant>::
 operator=(const double rhs) {
-  std::fill(begin(), end(), rhs);
+  for (size_t i = 0; i < numElements; ++i) mElements[i] = rhs;
   return *this;
 }
 
@@ -100,7 +100,7 @@ inline
 void
 RankNTensor<nDim,rank, Descendant>::
 Zero() {
-  std::fill(mElements, mElements + numElements, 0.0);
+  for (size_t i = 0; i < numElements; ++i) mElements[i] = 0.0;
 }
 
 //------------------------------------------------------------------------------

--- a/src/Geometry/RankNTensorInline.hh
+++ b/src/Geometry/RankNTensorInline.hh
@@ -374,8 +374,8 @@ inline
 double
 RankNTensor<nDim,rank, Descendant>::
 maxAbsElement() const {
-  double result = mElements[0];
-  for (size_type i = 1; i != numElements; ++i) result = std::max(result, mElements[i]);
+  double result = std::abs(mElements[0]);
+  for (size_type i = 1; i < numElements; ++i) result = std::max(result, std::abs(mElements[i]));
   return result;
 }
 

--- a/src/Geometry/RankNTensorInline.hh
+++ b/src/Geometry/RankNTensorInline.hh
@@ -8,15 +8,6 @@
 namespace Spheral {
 
 //------------------------------------------------------------------------------
-// Default constructor.
-//------------------------------------------------------------------------------
-template<int nDim, int rank, typename Descendant>
-SPHERAL_HOST_DEVICE
-inline
-RankNTensor<nDim,rank, Descendant>::
-RankNTensor() {}
-
-//------------------------------------------------------------------------------
 // Construct with the given value filling the tensor.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
@@ -25,40 +16,6 @@ inline
 RankNTensor<nDim,rank, Descendant>::
 RankNTensor(const double val) {
   std::fill(begin(), end(), val);
-}
-
-//------------------------------------------------------------------------------
-// Copy constructor.
-//------------------------------------------------------------------------------
-template<int nDim, int rank, typename Descendant>
-SPHERAL_HOST_DEVICE
-inline
-RankNTensor<nDim,rank, Descendant>::
-RankNTensor(const RankNTensor& ten){
-  std::copy(ten.begin(), ten.end(), this->begin());
-}
-
-//------------------------------------------------------------------------------
-// Destructor.
-//------------------------------------------------------------------------------
-template<int nDim, int rank, typename Descendant>
-SPHERAL_HOST_DEVICE
-inline
-RankNTensor<nDim,rank, Descendant>::
-~RankNTensor() {
-}
-
-//------------------------------------------------------------------------------
-// Assignment.
-//------------------------------------------------------------------------------
-template<int nDim, int rank, typename Descendant>
-SPHERAL_HOST_DEVICE
-inline
-RankNTensor<nDim,rank, Descendant>&
-RankNTensor<nDim,rank, Descendant>::
-operator=(const RankNTensor& rhs) {
-  if (this != &rhs) std::copy(rhs.begin(), rhs.end(), this->begin());
-  return *this;
 }
 
 //------------------------------------------------------------------------------

--- a/src/Geometry/RankNTensorInline.hh
+++ b/src/Geometry/RankNTensorInline.hh
@@ -13,10 +13,7 @@ namespace Spheral {
 template<int nDim, int rank, typename Descendant>
 inline
 RankNTensor<nDim,rank, Descendant>::
-RankNTensor():
-  mElements(new double[Descendant::numElements]) {
-  std::fill(mElements, mElements + Descendant::numElements, 0.0);
-}
+RankNTensor() {}
 
 //------------------------------------------------------------------------------
 // Construct with the given value filling the tensor.
@@ -24,9 +21,8 @@ RankNTensor():
 template<int nDim, int rank, typename Descendant>
 inline
 RankNTensor<nDim,rank, Descendant>::
-RankNTensor(const double val):
-  mElements(new double[Descendant::numElements]) {
-  std::fill(mElements, mElements + Descendant::numElements, val);
+RankNTensor(const double val) {
+  std::fill(begin(), end(), val);
 }
 
 //------------------------------------------------------------------------------
@@ -35,9 +31,8 @@ RankNTensor(const double val):
 template<int nDim, int rank, typename Descendant>
 inline
 RankNTensor<nDim,rank, Descendant>::
-RankNTensor(const RankNTensor& ten):
-  mElements(new double[Descendant::numElements]) {
-  std::copy(ten.begin(), ten.begin() + Descendant::numElements, this->begin());
+RankNTensor(const RankNTensor& ten){
+  std::copy(ten.begin(), ten.end(), this->begin());
 }
 
 //------------------------------------------------------------------------------
@@ -47,7 +42,6 @@ template<int nDim, int rank, typename Descendant>
 inline
 RankNTensor<nDim,rank, Descendant>::
 ~RankNTensor() {
-  delete [] mElements;
 }
 
 //------------------------------------------------------------------------------
@@ -58,7 +52,7 @@ inline
 RankNTensor<nDim,rank, Descendant>&
 RankNTensor<nDim,rank, Descendant>::
 operator=(const RankNTensor& rhs) {
-  if (this != &rhs) std::copy(rhs.begin(), rhs.begin() + Descendant::numElements, this->begin());
+  if (this != &rhs) std::copy(rhs.begin(), rhs.end(), this->begin());
   return *this;
 }
 
@@ -70,7 +64,7 @@ inline
 RankNTensor<nDim,rank, Descendant>&
 RankNTensor<nDim,rank, Descendant>::
 operator=(const double rhs) {
-  std::fill(mElements, mElements + Descendant::numElements, rhs);
+  std::fill(begin(), end(), rhs);
   return *this;
 }
 
@@ -81,7 +75,7 @@ template<int nDim, int rank, typename Descendant>
 inline
 double
 RankNTensor<nDim, rank, Descendant>::operator[](typename RankNTensor<nDim, rank, Descendant>::size_type index) const {
-  REQUIRE(index < Descendant::numElements);
+  REQUIRE(index < numElements);
   return *(begin() + index);
 }
 
@@ -89,7 +83,7 @@ template<int nDim, int rank, typename Descendant>
 inline
 double&
 RankNTensor<nDim, rank, Descendant>::operator[](typename RankNTensor<nDim, rank, Descendant>::size_type index) {
-  REQUIRE(index < Descendant::numElements);
+  REQUIRE(index < numElements);
   return *(begin() + index);
 }
 
@@ -109,7 +103,7 @@ inline
 typename RankNTensor<nDim,rank, Descendant>::iterator
 RankNTensor<nDim,rank, Descendant>::
 end() {
-  return mElements + Descendant::numElements;
+  return mElements + numElements;
 }
 
 template<int nDim, int rank, typename Descendant>
@@ -125,7 +119,7 @@ inline
 typename RankNTensor<nDim,rank, Descendant>::const_iterator
 RankNTensor<nDim,rank, Descendant>::
 end() const {
-  return mElements + Descendant::numElements;
+  return mElements + numElements;
 }
 
 //------------------------------------------------------------------------------
@@ -136,7 +130,7 @@ inline
 void
 RankNTensor<nDim,rank, Descendant>::
 Zero() {
-  std::fill(mElements, mElements + Descendant::numElements, 0.0);
+  std::fill(mElements, mElements + numElements, 0.0);
 }
 
 //------------------------------------------------------------------------------
@@ -160,7 +154,7 @@ inline
 Descendant&
 RankNTensor<nDim,rank, Descendant>::
 operator+=(const RankNTensor& rhs) {
-  for (size_type i = 0; i != Descendant::numElements; ++i) mElements[i] += rhs.mElements[i];
+  for (size_type i = 0; i != numElements; ++i) mElements[i] += rhs.mElements[i];
   return dynamic_cast<Descendant&>(*this);
 }
 
@@ -172,7 +166,7 @@ inline
 Descendant&
 RankNTensor<nDim,rank, Descendant>::
 operator-=(const RankNTensor& rhs) {
-  for (size_type i = 0; i != Descendant::numElements; ++i) mElements[i] -= rhs.mElements[i];
+  for (size_type i = 0; i != numElements; ++i) mElements[i] -= rhs.mElements[i];
   return dynamic_cast<Descendant&>(*this);
 }
 
@@ -210,7 +204,7 @@ inline
 Descendant&
 RankNTensor<nDim,rank, Descendant>::
 operator*=(const double rhs) {
-  for (size_type i = 0; i != Descendant::numElements; ++i) mElements[i] *= rhs;
+  for (size_type i = 0; i != numElements; ++i) mElements[i] *= rhs;
   return dynamic_cast<Descendant&>(*this);
 }
 
@@ -223,7 +217,7 @@ Descendant&
 RankNTensor<nDim,rank, Descendant>::
 operator/=(const double rhs) {
   REQUIRE(rhs != 0.0);
-  for (size_type i = 0; i != Descendant::numElements; ++i) mElements[i] /= rhs;
+  for (size_type i = 0; i != numElements; ++i) mElements[i] /= rhs;
   return dynamic_cast<Descendant&>(*this);
 }
 
@@ -264,7 +258,7 @@ RankNTensor<nDim,rank, Descendant>::
 operator==(const RankNTensor& rhs) const {
   bool result = mElements[0] == rhs.mElements[0];
   size_type i = 1;
-  while (i != Descendant::numElements and result) {
+  while (i != numElements and result) {
     result = result and (mElements[i] == rhs.mElements[i]);
     ++i;
   }
@@ -336,7 +330,7 @@ RankNTensor<nDim,rank, Descendant>::
 operator==(const double rhs) const {
   bool result = mElements[0] == rhs;
   size_type i = 1;
-  while (i != Descendant::numElements and result) {
+  while (i != numElements and result) {
     result = result and (mElements[i] == rhs);
     ++i;
   }
@@ -363,7 +357,7 @@ double
 RankNTensor<nDim,rank, Descendant>::
 doubledot(const RankNTensor& rhs) const {
   double result = mElements[0] * rhs.mElements[0];
-  for (size_type i = 1; i != Descendant::numElements; ++i) 
+  for (size_type i = 1; i != numElements; ++i) 
     result += mElements[i] * rhs.mElements[i];
   return result;
 }
@@ -377,7 +371,7 @@ Descendant
 RankNTensor<nDim,rank, Descendant>::
 squareElements() const {
   Descendant result(dynamic_cast<const Descendant&>(*this));
-  for (size_type i = 1; i != Descendant::numElements; ++i) 
+  for (size_type i = 1; i != numElements; ++i) 
     *(result.begin() + i) *= mElements[i];
   return result;
 }
@@ -391,7 +385,7 @@ double
 RankNTensor<nDim,rank, Descendant>::
 maxAbsElement() const {
   double result = mElements[0];
-  for (size_type i = 1; i != Descendant::numElements; ++i) result = std::max(result, mElements[i]);
+  for (size_type i = 1; i != numElements; ++i) result = std::max(result, mElements[i]);
   return result;
 }
 

--- a/src/Geometry/RankNTensorInline.hh
+++ b/src/Geometry/RankNTensorInline.hh
@@ -11,6 +11,7 @@ namespace Spheral {
 // Default constructor.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 RankNTensor<nDim,rank, Descendant>::
 RankNTensor() {}
@@ -19,6 +20,7 @@ RankNTensor() {}
 // Construct with the given value filling the tensor.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 RankNTensor<nDim,rank, Descendant>::
 RankNTensor(const double val) {
@@ -29,6 +31,7 @@ RankNTensor(const double val) {
 // Copy constructor.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 RankNTensor<nDim,rank, Descendant>::
 RankNTensor(const RankNTensor& ten){
@@ -39,6 +42,7 @@ RankNTensor(const RankNTensor& ten){
 // Destructor.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 RankNTensor<nDim,rank, Descendant>::
 ~RankNTensor() {
@@ -48,6 +52,7 @@ RankNTensor<nDim,rank, Descendant>::
 // Assignment.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 RankNTensor<nDim,rank, Descendant>&
 RankNTensor<nDim,rank, Descendant>::
@@ -60,6 +65,7 @@ operator=(const RankNTensor& rhs) {
 // Assignment (double).
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 RankNTensor<nDim,rank, Descendant>&
 RankNTensor<nDim,rank, Descendant>::
@@ -72,6 +78,7 @@ operator=(const double rhs) {
 // Return the (index) element using the bracket operator.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 double
 RankNTensor<nDim, rank, Descendant>::operator[](typename RankNTensor<nDim, rank, Descendant>::size_type index) const {
@@ -80,6 +87,7 @@ RankNTensor<nDim, rank, Descendant>::operator[](typename RankNTensor<nDim, rank,
 }
 
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 double&
 RankNTensor<nDim, rank, Descendant>::operator[](typename RankNTensor<nDim, rank, Descendant>::size_type index) {
@@ -91,6 +99,7 @@ RankNTensor<nDim, rank, Descendant>::operator[](typename RankNTensor<nDim, rank,
 // Iterators.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 typename RankNTensor<nDim,rank, Descendant>::iterator
 RankNTensor<nDim,rank, Descendant>::
@@ -99,6 +108,7 @@ begin() {
 }
 
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 typename RankNTensor<nDim,rank, Descendant>::iterator
 RankNTensor<nDim,rank, Descendant>::
@@ -107,6 +117,7 @@ end() {
 }
 
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 typename RankNTensor<nDim,rank, Descendant>::const_iterator
 RankNTensor<nDim,rank, Descendant>::
@@ -115,6 +126,7 @@ begin() const {
 }
 
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 typename RankNTensor<nDim,rank, Descendant>::const_iterator
 RankNTensor<nDim,rank, Descendant>::
@@ -126,6 +138,7 @@ end() const {
 // Zero out the tensor.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 void
 RankNTensor<nDim,rank, Descendant>::
@@ -137,6 +150,7 @@ Zero() {
 // Negative.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant
 RankNTensor<nDim, rank, Descendant>::
@@ -150,6 +164,7 @@ operator-() const {
 // In place addition.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant&
 RankNTensor<nDim,rank, Descendant>::
@@ -162,6 +177,7 @@ operator+=(const RankNTensor& rhs) {
 // In place subtraction.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant&
 RankNTensor<nDim,rank, Descendant>::
@@ -174,6 +190,7 @@ operator-=(const RankNTensor& rhs) {
 // Addition.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant
 RankNTensor<nDim,rank, Descendant>::
@@ -187,6 +204,7 @@ operator+(const RankNTensor& rhs) const {
 // Subtraction.
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant
 RankNTensor<nDim,rank, Descendant>::
@@ -200,6 +218,7 @@ operator-(const RankNTensor& rhs) const {
 // In place multiplication (double).
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant&
 RankNTensor<nDim,rank, Descendant>::
@@ -212,6 +231,7 @@ operator*=(const double rhs) {
 // In place division (double).
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant&
 RankNTensor<nDim,rank, Descendant>::
@@ -225,6 +245,7 @@ operator/=(const double rhs) {
 // Multiplication (double).
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant
 RankNTensor<nDim,rank, Descendant>::
@@ -238,6 +259,7 @@ operator*(const double rhs) const {
 // Division (double).
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant
 RankNTensor<nDim,rank, Descendant>::
@@ -252,6 +274,7 @@ operator/(const double rhs) const {
 // ==
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 bool
 RankNTensor<nDim,rank, Descendant>::
@@ -269,6 +292,7 @@ operator==(const RankNTensor& rhs) const {
 // !=
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 bool
 RankNTensor<nDim,rank, Descendant>::
@@ -280,6 +304,7 @@ operator!=(const RankNTensor& rhs) const {
 // <
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 bool
 RankNTensor<nDim,rank, Descendant>::
@@ -291,6 +316,7 @@ operator<(const RankNTensor& rhs) const {
 // >
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 bool
 RankNTensor<nDim,rank, Descendant>::
@@ -302,6 +328,7 @@ operator>(const RankNTensor& rhs) const {
 // <=
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 bool
 RankNTensor<nDim,rank, Descendant>::
@@ -313,6 +340,7 @@ operator<=(const RankNTensor& rhs) const {
 // >=
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 bool
 RankNTensor<nDim,rank, Descendant>::
@@ -324,6 +352,7 @@ operator>=(const RankNTensor& rhs) const {
 // == (double)
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 bool
 RankNTensor<nDim,rank, Descendant>::
@@ -341,6 +370,7 @@ operator==(const double rhs) const {
 // != (double)
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 bool
 RankNTensor<nDim,rank, Descendant>::
@@ -352,6 +382,7 @@ operator!=(const double rhs) const {
 // doubledot
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 double
 RankNTensor<nDim,rank, Descendant>::
@@ -366,6 +397,7 @@ doubledot(const RankNTensor& rhs) const {
 // squareElements
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 Descendant
 RankNTensor<nDim,rank, Descendant>::
@@ -380,6 +412,7 @@ squareElements() const {
 // maxAbsElement
 //------------------------------------------------------------------------------
 template<int nDim, int rank, typename Descendant>
+SPHERAL_HOST_DEVICE
 inline
 double
 RankNTensor<nDim,rank, Descendant>::

--- a/tests/cpp/Field/CMakeLists.txt
+++ b/tests/cpp/Field/CMakeLists.txt
@@ -15,6 +15,6 @@ spheral_add_test(
 spheral_add_test(
   NAME fieldview_datatype_tests
   SOURCES fieldview_datatype_tests.cc
-  DEPENDS_ON Spheral_NodeList Spheral_Geometry Spheral_Hydro Spheral_DataOutput Spheral_Utilities
+  DEPENDS_ON Spheral_NodeList Spheral_Geometry Spheral_Hydro Spheral_DataOutput Spheral_Utilities Spheral_Distributed
   #DEBUG_LINKER
 )

--- a/tests/cpp/Geometry/CMakeLists.txt
+++ b/tests/cpp/Geometry/CMakeLists.txt
@@ -4,3 +4,10 @@ spheral_add_test(
   DEPENDS_ON Spheral_Utilities
   #DEBUG_LINKER
 )
+
+spheral_add_test(
+  NAME rankntensor_test
+  SOURCES rankntensor_tests.cc
+  DEPENDS_ON Spheral_Utilities
+  #DEBUG_LINKER
+)

--- a/tests/cpp/Geometry/rankntensor_test_types.hh
+++ b/tests/cpp/Geometry/rankntensor_test_types.hh
@@ -1,0 +1,23 @@
+#ifndef SPHERAL_RANKNTENSOR_TEST_TYPES_HH
+#define SPHERAL_RANKNTENSOR_TEST_TYPES_HH
+
+#include "test-base.hh"
+#include "test-basic-exec-policies.hh"
+
+#include "Geometry/GeomFifthRankTensor.hh"
+#include "Geometry/GeomFourthRankTensor.hh"
+#include "Geometry/GeomThirdRankTensor.hh"
+
+/*
+ * Instantiate the typed test suite for different Rank-N tensor types.
+ */
+using RANK_N_TENSOR_TYPES = camp::list<
+  Spheral::GeomThirdRankTensor<3>
+  ,Spheral::GeomFourthRankTensor<3>
+  ,Spheral::GeomFifthRankTensor<3>
+>;
+
+using RANK_N_TENSOR_TEST_TYPES = Spheral::Test<
+  camp::cartesian_product<EXEC_TYPES, RANK_N_TENSOR_TYPES>>::Types;
+
+#endif //  SPHERAL_RANKNTENSOR_TEST_TYPES_HH

--- a/tests/cpp/Geometry/rankntensor_tests.cc
+++ b/tests/cpp/Geometry/rankntensor_tests.cc
@@ -1,0 +1,297 @@
+#include "rankntensor_test_types.hh"
+#include "test-utilities.hh"
+
+#include "Geometry/RankNTensor.hh"
+
+/*
+ * Test fixture for Rank-N Tensor tests.
+ */
+class RankNTensorTest : public ::testing::Test {};
+
+/*
+ * Typed test suite for Rank-N Tensors.
+ */
+template <typename T>
+class RankNTensorTypedTest : public RankNTensorTest {};
+TYPED_TEST_SUITE_P(RankNTensorTypedTest);
+
+/*
+ * Test case for the constructor of a Rank-N tensor.
+ * Verifies that the constructor correctly initializes the tensor elements.
+ * A tensor `t` is created, and the test asserts that all elements are
+ * initialized to 0.0.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, Ctor) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t[i], 0.0);
+  }
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for the assignment operators of a Rank-N tensor.
+ * Verifies that both scalar and tensor assignment work correctly.
+ * It first assigns a scalar value to all elements of a tensor `t` and asserts
+ * the result. It then assigns another tensor `u` to `t` and asserts that `t`'s
+ * elements match `u`'s.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, Assignment) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t;
+  t = 5.0;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t[i], 5.0);
+  }
+
+  TensorType u(1.0);
+  t = u;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t[i], 1.0);
+  }
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for the element accessors of a Rank-N tensor.
+ * Verifies that the square bracket operator correctly accesses and modifies
+ * tensor elements. It asserts that `t[i]` returns the correct values, and then
+ * modifies elements using this accessor and asserts the new values.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, Accessors) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    t[i] = i;
+  }
+
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t[i], i);
+  }
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for the Zero() method of a Rank-N tensor.
+ * Verifies that the Zero() method correctly sets all elements of the tensor to
+ * 0.0. A tensor `t` is initialized with non-zero values, Zero() is called,
+ * and the test asserts that all elements are now 0.0.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, Zero) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t(1.0);
+  t.Zero();
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t[i], 0.0);
+  }
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for the unary minus operator of a Rank-N tensor.
+ * Verifies that the unary minus operator correctly negates all elements of the
+ * tensor. A tensor `t2` is created by negating `t1`, and the test asserts that
+ * each element of `t2` is the negated value of the corresponding element in
+ * `t1`.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, UnaryMinus) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t1(1.0);
+  TensorType t2 = -t1;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t2[i], -1.0);
+  }
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for Rank-N tensor addition and subtraction.
+ * Verifies that the addition and subtraction operators produce the correct
+ * results. It asserts that the elements of `t1 + t2` and `t2 - t1` are the
+ * sums and differences of the elements of `t1` and `t2`.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, AddSub) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t1(1.0);
+  TensorType t2(2.0);
+
+  TensorType t_add = t1 + t2;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t_add[i], 3.0);
+  }
+
+  TensorType t_sub = t2 - t1;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t_sub[i], 1.0);
+  }
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for Rank-N tensor scalar multiplication and division.
+ * Verifies that scalar multiplication and division operators produce the
+ * correct results. It asserts that the elements of `t * s` and `t / s` are the
+ * product and quotient of the elements of `t` and a scalar `s`.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, ScalarMulDiv) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t(1.0);
+  double s = 2.0;
+
+  TensorType t_mul = t * s;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t_mul[i], 2.0);
+  }
+
+  TensorType t_div = t / s;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t_div[i], 0.5);
+  }
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for Rank-N tensor in-place addition and subtraction.
+ * Verifies that the `+=` and `-=` operators produce the correct results. It
+ * asserts that `t1 += t2` and `t1 -= t2` correctly modify the elements of `t1`.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, InPlaceAddSub) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t1(1.0);
+  TensorType t2(2.0);
+
+  t1 += t2;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t1[i], 3.0);
+  }
+
+  t1 -= t2;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t1[i], 1.0);
+  }
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for Rank-N tensor in-place scalar multiplication and division.
+ * Verifies that the `*=` and `/=` operators produce the correct results. It
+ * asserts that `t *= s` and `t /= s` correctly modify the elements of `t`.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, InPlaceScalarMulDiv) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t(1.0);
+  double s = 2.0;
+
+  t *= s;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t[i], 2.0);
+  }
+
+  t /= s;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    SPHERAL_ASSERT_EQ(t[i], 1.0);
+  }
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for Rank-N tensor comparison operators.
+ * Verifies that the `==`, `!=`, `<`, `>`, `<=`, and `>=` operators produce the
+ * correct boolean results. It asserts the outcomes of comparing several
+ * tensors.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, Comparison) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t1(1.0);
+  TensorType t2(1.0);
+  TensorType t3(2.0);
+  TensorType t4(0.0);
+
+  SPHERAL_ASSERT_TRUE(t1 == t2);
+  SPHERAL_ASSERT_TRUE(t1 != t3);
+  SPHERAL_ASSERT_TRUE(t1 < t3);
+  SPHERAL_ASSERT_TRUE(t3 > t1);
+  SPHERAL_ASSERT_TRUE(t1 <= t2);
+  SPHERAL_ASSERT_TRUE(t1 >= t2);
+  SPHERAL_ASSERT_TRUE(t4 < t1);
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for the Rank-N tensor double dot product.
+ * Verifies that the `doubledot()` method calculates the correct double dot
+ * product of two tensors. It asserts that `t1.doubledot(t2)` equals the sum of
+ * the products of their corresponding elements.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, DoubleDot) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t1(2.0);
+  TensorType t2(3.0);
+  double dot_product = t1.doubledot(t2);
+  SPHERAL_ASSERT_EQ(dot_product, 2.0 * 3.0 * TensorType::numElements);
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Test case for the Rank-N tensor element-wise statistics.
+ * Verifies that `maxAbsElement` calculates the correct value. It asserts the
+ * result for a tensor with positive and negative elements.
+ */
+GPU_TYPED_TEST_P(RankNTensorTypedTest, ElementStats) {
+  using WORK_EXEC_POLICY = typename camp::at<TypeParam, camp::num<0>>::type;
+  using TensorType = typename camp::at<TypeParam, camp::num<1>>::type;
+
+  EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
+  TensorType t;
+  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
+    t[i] = (i % 2 == 0) ? i : -i;
+  }
+  SPHERAL_ASSERT_EQ(t.maxAbsElement(), TensorType::numElements - 1);
+  EXEC_IN_SPACE_END()
+}
+
+/*
+ * Register all typed tests for the Rank-N tensor test suite.
+ */
+REGISTER_TYPED_TEST_SUITE_P(RankNTensorTypedTest, Ctor, Assignment, Accessors,
+                            Zero, UnaryMinus, AddSub, ScalarMulDiv,
+                            InPlaceAddSub, InPlaceScalarMulDiv, Comparison,
+                            DoubleDot, ElementStats);
+
+
+INSTANTIATE_TYPED_TEST_SUITE_P(RankNTensor, RankNTensorTypedTest,
+                               RANK_N_TENSOR_TEST_TYPES, );

--- a/tests/cpp/Geometry/rankntensor_tests.cc
+++ b/tests/cpp/Geometry/rankntensor_tests.cc
@@ -277,9 +277,10 @@ GPU_TYPED_TEST_P(RankNTensorTypedTest, ElementStats) {
 
   EXEC_IN_SPACE_BEGIN(WORK_EXEC_POLICY)
   TensorType t;
-  for (typename TensorType::size_type i = 0; i < TensorType::numElements; ++i) {
-    t[i] = (i % 2 == 0) ? i : -i;
+  for (size_t i = 0; i < TensorType::numElements; ++i) {
+    t[i] = (i % 2 == 0) ? i : -(double)i;
   }
+
   SPHERAL_ASSERT_EQ(t.maxAbsElement(), TensorType::numElements - 1);
   EXEC_IN_SPACE_END()
 }

--- a/tests/cpp/include/test-base.hh
+++ b/tests/cpp/include/test-base.hh
@@ -2,6 +2,7 @@
 #define SPHERAL_TEST_BASE_HH
 
 #include "gtest/gtest.h"
+#include "camp/camp.hpp"
 
 namespace Spheral {
 

--- a/tests/cpp/include/test-basic-datatypes.hh
+++ b/tests/cpp/include/test-basic-datatypes.hh
@@ -16,9 +16,9 @@ using TEST_FIELD_DATATYPES = camp::list<
   //,Spheral::Dim<3>::Vector3d
   //,Spheral::Dim<1>::Tensor
   //Dim<1>::SymTensor,
-  //Dim<1>::ThirdRankTensor,
-  //Dim<1>::FourthRankTensor,
-  //Dim<1>::FifthRankTensor
+  ,Spheral::Dim<3>::ThirdRankTensor
+  ,Spheral::Dim<3>::FourthRankTensor
+  ,Spheral::Dim<3>::FifthRankTensor
 >;
 // clang-format on
 


### PR DESCRIPTION
# Summary

This PR refactors the `RankNTensor` base class and its derived `GeomThirdRankTensor`, `GeomFourthRankTensor`, and `GeomFifthRankTensor` types to enable GPU compatibility and introduce performance optimizations.

Key changes include:

*   **GPU Compatibility:**
    *   Applied `SPHERAL_HOST_DEVICE` attribute macros to constructors, operators, and methods to allow these types to be used seamlessly on both CPU and GPU.
    *   Replaced `std::fill` and `std::copy` with explicit loops in `RankNTensorInline.hh`.
*   **Performance Optimizations:**
    *   Changed the internal storage of `RankNTensor` from a dynamically allocated `double*` to a statically allocated `double[]` array. This eliminates heap allocations and deallocations, which are costly.
    *   Updated `numElements` to be a `static constexpr` member, allowing its calculation at compile time.
    *   Replaced `dynamic_cast` with `static_cast` where appropriate for improved performance and GPU compatibility.
*   **Testing:**
    *   Added comprehensive unit tests for `RankNTensor` functionality, including GPU-specific tests.
    *   Updated `fieldview_datatype_tests` to include the N-Rank Tensor types.
*   **Minor Fixes:**
    *   Corrected `maxAbsElement` to return the absolute maximum element.
------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. ([PR#160](https://rzlc.llnl.gov/gitlab/owen/LLNLSpheral/-/merge_requests/160))
- [x] LLNLSpheral PR has passed all tests.

