### PR TITLE
[GPU] FieldList

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,24 +5,29 @@ Version vYYYY.MM.p -- Release date YYYY-MM-DD
 Notable changes include:
 
   * New features / API changes:
-    * Spheral::FieldView allows for implicit data migration of Spheral::Field data.
-      * Implements FieldView datatypes as handles to be used for migrating data to and from the GPU.
-      * Unit testing for semantic behaviour, H/D copy, and allocation / deallocaiton across a range of common pattens.
-      * Unit testing to ensure implicitly copyable Spheral data types can be copied to and from the device correctly.
-    * GeomVector and Geom3Vector have been converted for use on the GPU.
-      * CPU & GPU unit testing of the public interface.
-    * RankNTensor (Third, Fourth, Fifth) have been refactored to execute on the GPU.
-    * Optimizations to RankTensor types:
-      * Stack allocation of tensor data; Static casting for CRTP implementation.
-    * GeomTensor & GeomSymmetricTensor have been refactored for use on the GPU.
-    * New Logging utility for runtime debug messages.
+    * GPU Poring Effort:
+      * Spheral::FieldView allows for implicit data migration of Spheral::Field data.
+        * Implements FieldView datatypes as handles to be used for migrating data to and from the GPU.
+        * Unit testing for semantic behaviour, H/D copy, and allocation / deallocaiton across a range of common pattens.
+        * Unit testing to ensure implicitly copyable Spheral data types can be copied to and from the device correctly.
+      * Spheral::FieldListView enables GPU access to field data while maintaining Field->FieldList associations across
+        execution spaces.
+        * Adds addition functionality to FieldView to expose chai api calls.
+        * Host/Device unit testing for a range of expected patterns and behaviours seen in Spheral.
+      * GeomVector and Geom3Vector have been converted for use on the GPU.
+        * CPU & GPU unit testing of the public interface.
+      * RankNTensor (Third, Fourth, Fifth) have been refactored to execute on the GPU.
+      * Optimizations to RankTensor types:
+        * Stack allocation of tensor data; Static casting for CRTP implementation.
+      * GeomTensor & GeomSymmetricTensor have been refactored for use on the GPU.
+      * New Logging utility for runtime debug messages.
 
-  * Build changes / improvements:
-    * A python virtual environment is installed in the spheral build dir, removing the
-      need to build the `install` target during regular development.
-    * `./spheral` and `./spheral-ats` have been moved to `/bin` for both build and installs.
-    * CMake directly handles all of the installation environment configuration and setup
-      during the install stage.
+    * Build changes / improvements:
+      * A python virtual environment is installed in the spheral build dir, removing the
+        need to build the `install` target during regular development.
+      * `./spheral` and `./spheral-ats` have been moved to `/bin` for both build and installs.
+      * CMake directly handles all of the installation environment configuration and setup
+        during the install stage.
     * The `ENABLE_TIMER` CMake option has been changed to `SPHERAL_ENABLE_TIMERS`.
 
   * Bug Fixes / improvements:

--- a/src/Field/CMakeLists.txt
+++ b/src/Field/CMakeLists.txt
@@ -31,6 +31,7 @@ set(Field_headers
     FieldListSet.hh
     FieldListSetInline.hh
     FieldListThreadWrapper.hh
+    FieldListView.hh
     GhostNodeIterator.hh
     GhostNodeIteratorInline.hh
     InternalNodeIterator.hh

--- a/src/Field/FieldList.hh
+++ b/src/Field/FieldList.hh
@@ -294,13 +294,23 @@ public:
         chai::Action,
         chai::ExecutionSpace) {};
 
-    return this->toView(func);
+    return this->toView(func, func);
   }
 
-  template<typename F>
-  ViewType toView(F&& extension)
+  template<typename FL>
+  ViewType toView(FL&& extension) {
+    auto func = [](
+        const chai::PointerRecord *,
+        chai::Action,
+        chai::ExecutionSpace) {};
+
+    return this->toView(std::forward<FL>(extension), func);
+  }
+
+  template<typename FL, typename F>
+  ViewType toView(FL&& extension, F&& field_extension)
   {
-    auto callback = getFieldListCallback(std::forward<F>(extension));
+    auto callback = getFieldListCallback(std::forward<FL>(extension));
 
     if (mFieldViews.size() == 0 && !mFieldViews.getPointer(chai::CPU, false)) {
       mFieldViews.allocate(size(), chai::CPU, callback);
@@ -310,7 +320,7 @@ public:
     }
 
     for (size_t i = 0; i < size(); ++i) {
-      mFieldViews[i] = mFieldPtrs[i]->toView();
+      mFieldViews[i] = mFieldPtrs[i]->toView(std::forward<F>(field_extension));
     }
 
     mFieldViews.registerTouch(chai::CPU);

--- a/src/Field/FieldList.hh
+++ b/src/Field/FieldList.hh
@@ -304,6 +304,8 @@ public:
     for (size_t i = 0; i < fl_size; ++i) {
       mFieldViews[i] = mFieldPtrs[i]->toView();
     }
+    mFieldViews.registerTouch(chai::CPU);
+    mFieldViews.setUserCallback(callback);
     return ViewType(mFieldViews);
   }
 

--- a/src/Field/FieldList.hh
+++ b/src/Field/FieldList.hh
@@ -287,76 +287,17 @@ public:
 
   // TODO: Good for debugging but not necessary
   using ViewType = FieldListView<Dimension, DataType>;
-  ViewType toView()
-  {
-    auto func = [](
-        const chai::PointerRecord *,
-        chai::Action,
-        chai::ExecutionSpace) {};
-
-    return this->toView(func, func);
-  }
+  ViewType toView();
 
   template<typename FL>
-  ViewType toView(FL&& extension) {
-    auto func = [](
-        const chai::PointerRecord *,
-        chai::Action,
-        chai::ExecutionSpace) {};
-
-    return this->toView(std::forward<FL>(extension), func);
-  }
+  ViewType toView(FL&& extension);
 
   template<typename FL, typename F>
-  ViewType toView(FL&& extension, F&& field_extension)
-  {
-    auto callback = getFieldListCallback(std::forward<FL>(extension));
-
-    if (mFieldViews.size() == 0 && !mFieldViews.getPointer(chai::CPU, false)) {
-      mFieldViews.allocate(size(), chai::CPU, callback);
-    } else {
-      mFieldViews.setUserCallback(callback);
-      mFieldViews.reallocate(size());
-    }
-
-    for (size_t i = 0; i < size(); ++i) {
-      mFieldViews[i] = mFieldPtrs[i]->toView(std::forward<F>(field_extension));
-    }
-
-    mFieldViews.registerTouch(chai::CPU);
-
-    return ViewType(mFieldViews);
-  }
+  ViewType toView(FL&& extension, F&& field_extension);
 
 protected:
   template<typename F>
-  auto getFieldListCallback(F callback)
-  {
-    return [callback](
-      const chai::PointerRecord * record,
-      chai::Action action,
-      chai::ExecutionSpace space) {
-        if (action == chai::ACTION_MOVE) {
-          if (space == chai::CPU)
-            DEBUG_LOG << "FieldList : MOVED to the CPU";
-          if (space == chai::GPU)
-            DEBUG_LOG << "FieldList : MOVED to the GPU";
-        }
-        else if (action == chai::ACTION_ALLOC) {
-          if (space == chai::CPU)
-            DEBUG_LOG << "FieldList : ALLOC on the CPU";
-          if (space == chai::GPU)
-            DEBUG_LOG << "FieldList : ALLOC on the GPU";
-        }
-        else if (action == chai::ACTION_FREE) {
-          if (space == chai::CPU)
-            DEBUG_LOG << "FieldList : FREE on the CPU";
-          if (space == chai::GPU)
-            DEBUG_LOG << "FieldList : FREE on the GPU";
-        }
-        callback(record, action, space);
-      };
-  }
+  auto getFieldListCallback(F callback);
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/Field/FieldListInline.hh
+++ b/src/Field/FieldListInline.hh
@@ -1885,6 +1885,85 @@ operator*(const DataType& lhs,
   return result;
 }
 
+//------------------------------------------------------------------------------
+// View functions.
+//------------------------------------------------------------------------------
+template<typename Dimension, typename DataType>
+inline
+FieldListView<Dimension, DataType>
+FieldList<Dimension, DataType>::toView() {
+  auto func = [](
+      const chai::PointerRecord *,
+      chai::Action,
+      chai::ExecutionSpace) {};
+
+  return this->toView(func, func);
+}
+
+template<typename Dimension, typename DataType>
+template<typename FL>
+inline
+FieldListView<Dimension, DataType>
+FieldList<Dimension, DataType>::toView(FL&& extension) {
+  auto func = [](
+      const chai::PointerRecord *,
+      chai::Action,
+      chai::ExecutionSpace) {};
+
+  return this->toView(std::forward<FL>(extension), func);
+}
+
+template<typename Dimension, typename DataType>
+template<typename FL, typename F>
+inline
+FieldListView<Dimension, DataType>
+FieldList<Dimension, DataType>::toView(FL&& extension, F&& field_extension) {
+  auto callback = getFieldListCallback(std::forward<FL>(extension));
+
+  if (mFieldViews.size() == 0 && !mFieldViews.getPointer(chai::CPU, false)) {
+    mFieldViews.allocate(size(), chai::CPU, callback);
+  } else {
+    mFieldViews.setUserCallback(callback);
+    mFieldViews.reallocate(size());
+  }
+
+  for (size_t i = 0; i < size(); ++i) {
+    mFieldViews[i] = mFieldPtrs[i]->toView(std::forward<F>(field_extension));
+  }
+
+  mFieldViews.registerTouch(chai::CPU);
+
+  return ViewType(mFieldViews);
+}
+
+template<typename Dimension, typename DataType>
+template<typename F>
+inline
+auto FieldList<Dimension, DataType>::getFieldListCallback(F callback) {
+  return [callback](
+    const chai::PointerRecord * record,
+    chai::Action action,
+    chai::ExecutionSpace space) {
+      if (action == chai::ACTION_MOVE) {
+        if (space == chai::CPU)
+          DEBUG_LOG << "FieldList : MOVED to the CPU";
+        if (space == chai::GPU)
+          DEBUG_LOG << "FieldList : MOVED to the GPU";
+      } else if (action == chai::ACTION_ALLOC) {
+        if (space == chai::CPU)
+          DEBUG_LOG << "FieldList : ALLOC on the CPU";
+        if (space == chai::GPU)
+          DEBUG_LOG << "FieldList : ALLOC on the GPU";
+      } else if (action == chai::ACTION_FREE) {
+        if (space == chai::CPU)
+          DEBUG_LOG << "FieldList : FREE on the CPU";
+        if (space == chai::GPU)
+          DEBUG_LOG << "FieldList : FREE on the GPU";
+      }
+      callback(record, action, space);
+    };
+}
+
 // //------------------------------------------------------------------------------
 // // Absolute value.
 // //------------------------------------------------------------------------------

--- a/src/Field/FieldListInline.hh
+++ b/src/Field/FieldListInline.hh
@@ -122,13 +122,7 @@ FieldList(const FieldList<Dimension, DataType>& rhs):
 template<typename Dimension, typename DataType>
 inline
 FieldList<Dimension, DataType>::~FieldList() {
-
-//   // Unregister this FieldList from each Field we point to.
-//   if (storageType() == FieldStorageType::ReferenceFields) {
-//     for (iterator fieldPtrItr = begin(); fieldPtrItr != end(); ++fieldPtrItr) 
-//       unregisterFromField(**fieldPtrItr);
-//   }
-
+  mFieldViews.free();
 }
 
 //------------------------------------------------------------------------------

--- a/src/Field/FieldListView.hh
+++ b/src/Field/FieldListView.hh
@@ -1,0 +1,39 @@
+#ifndef __Spheral_FieldListView_hh__
+#define __Spheral_FieldListView_hh__
+
+#include "chai/ManagedArray.hpp"
+#include "config.hh"
+
+namespace Spheral {
+
+template <typename Dimension, typename DataType>
+class FieldListView {
+
+  using ElementType = FieldView<Dimension, DataType>;
+  using ContainerType = chai::ManagedArray<ElementType>;
+  ContainerType mData;
+
+public:
+
+  FieldListView(const ContainerType& d) : mData(d) {}
+  SPHERAL_HOST_DEVICE DataType& operator()(const size_t fieldIndex,
+                                           const size_t nodeIndx) {
+    return mData[fieldIndex][nodeIndx];
+  }
+  SPHERAL_HOST_DEVICE DataType& operator()(const size_t fieldIndex,
+                                           const size_t nodeIndx) const {
+    return mData[fieldIndex][nodeIndx];
+  }
+  SPHERAL_HOST_DEVICE ElementType operator[](const size_t index) {
+    return mData[index];
+  }
+  SPHERAL_HOST_DEVICE ElementType operator[](const size_t index) const {
+    return mData[index];
+  }
+  void move(chai::ExecutionSpace space) { mData.move(space); }
+  SPHERAL_HOST_DEVICE size_t size() const { return mData.size(); }
+  SPHERAL_HOST_DEVICE ElementType* data() const { return mData.data(); }
+  //SPHERAL_HOST ElementType* data(chai::ExecutionSpace space, bool do_move = true) const { return mData.data(space, do_move); }
+};
+} // namespace Spheral
+#endif // __Spheral_FieldListView_hh__

--- a/src/Field/FieldListView.hh
+++ b/src/Field/FieldListView.hh
@@ -51,7 +51,7 @@ public:
     mData.registerTouch(space);
     if (recursive) {
       for (auto d : mData) {
-        d.registerTouch(space);
+        d.touch(space);
       }
     }
   }

--- a/src/Field/FieldListView.hh
+++ b/src/Field/FieldListView.hh
@@ -16,24 +16,45 @@ class FieldListView {
 public:
 
   FieldListView(const ContainerType& d) : mData(d) {}
+
   SPHERAL_HOST_DEVICE DataType& operator()(const size_t fieldIndex,
                                            const size_t nodeIndx) {
     return mData[fieldIndex][nodeIndx];
   }
+
   SPHERAL_HOST_DEVICE DataType& operator()(const size_t fieldIndex,
                                            const size_t nodeIndx) const {
     return mData[fieldIndex][nodeIndx];
   }
+
   SPHERAL_HOST_DEVICE ElementType operator[](const size_t index) {
     return mData[index];
   }
+
   SPHERAL_HOST_DEVICE ElementType operator[](const size_t index) const {
     return mData[index];
   }
+
   void move(chai::ExecutionSpace space) { mData.move(space); }
+
   SPHERAL_HOST_DEVICE size_t size() const { return mData.size(); }
+
   SPHERAL_HOST_DEVICE ElementType* data() const { return mData.data(); }
-  //SPHERAL_HOST ElementType* data(chai::ExecutionSpace space, bool do_move = true) const { return mData.data(space, do_move); }
+
+  SPHERAL_HOST
+  ElementType* data(chai::ExecutionSpace space, bool do_move = true) const {
+    return mData.data(space, do_move);
+  }
+
+  SPHERAL_HOST
+  void touch(chai::ExecutionSpace space, bool recursive = true) {
+    mData.registerTouch(space);
+    if (recursive) {
+      for (auto d : mData) {
+        d.registerTouch(space);
+      }
+    }
+  }
 };
 } // namespace Spheral
 #endif // __Spheral_FieldListView_hh__

--- a/src/Field/FieldListView.hh
+++ b/src/Field/FieldListView.hh
@@ -35,7 +35,14 @@ public:
     return mData[index];
   }
 
-  void move(chai::ExecutionSpace space) { mData.move(space); }
+  void move(chai::ExecutionSpace space, bool recursive = true) {
+    mData.move(space);
+    if (recursive) {
+      for (auto d: mData) {
+        d.move(space);
+      }
+    }
+  }
 
   SPHERAL_HOST_DEVICE size_t size() const { return mData.size(); }
 

--- a/src/Field/FieldView.hh
+++ b/src/Field/FieldView.hh
@@ -6,8 +6,8 @@
 
 namespace Spheral {
 
-template <typename Dimension, typename DataType> class FieldView {
-
+template <typename Dimension, typename DataType>
+class FieldView : public chai::CHAICopyable{
 
   using ContainerType = typename chai::ManagedArray<DataType>;
 
@@ -44,6 +44,21 @@ public:
 
   SPHERAL_HOST_DEVICE
   DataType *data() const { return mData.getActivePointer(); }
+
+  SPHERAL_HOST
+  DataType *data(chai::ExecutionSpace space, bool do_move = true) const {
+    return mData.data(space, do_move);
+  }
+
+  SPHERAL_HOST_DEVICE
+  void shallowCopy(FieldView const& other) const {
+    mData.shallowCopy(other.mData);
+  }
+
+  SPHERAL_HOST
+  void touch(chai::ExecutionSpace space) {
+    mData.registerTouch(space);
+  }
 };
 
 } // namespace Spheral

--- a/src/Field/FieldView.hh
+++ b/src/Field/FieldView.hh
@@ -50,6 +50,8 @@ public:
     return mData.data(space, do_move);
   }
 
+  void move(chai::ExecutionSpace space) { mData.move(space); }
+
   SPHERAL_HOST_DEVICE
   void shallowCopy(FieldView const& other) const {
     mData.shallowCopy(other.mData);

--- a/tests/cpp/Field/CMakeLists.txt
+++ b/tests/cpp/Field/CMakeLists.txt
@@ -18,3 +18,10 @@ spheral_add_test(
   DEPENDS_ON Spheral_NodeList Spheral_Geometry Spheral_Hydro Spheral_DataOutput Spheral_Utilities Spheral_Distributed
   #DEBUG_LINKER
 )
+
+spheral_add_test(
+  NAME fieldlistview_tests
+  SOURCES fieldlistview_tests.cc
+  DEPENDS_ON Spheral_NodeList Spheral_Geometry Spheral_Hydro Spheral_DataOutput Spheral_Utilities
+  #DEBUG_LINKER
+)

--- a/tests/cpp/Field/fieldlistview_tests.cc
+++ b/tests/cpp/Field/fieldlistview_tests.cc
@@ -76,9 +76,12 @@ GPU_TYPED_TEST_P(FieldListViewTypedTest, DefaultConstructor) {
   if (typeid(RAJA::seq_exec) != typeid(TypeParam)) {
     ref_count.HToDCopies = 1;
     ref_count.DNumAlloc = 1;
+    ref_count.HNumFree = 1;
     ref_count.DNumFree = 1;
+  } else {
+    ref_count.HNumFree = 1;
   }
-  gcounts.compareCounters(ref_count);
+  COMP_COUNTERS(gcounts, ref_count);
 }
 
 // TODO: Add test for having multiple FL contain the same field

--- a/tests/cpp/Field/fieldlistview_tests.cc
+++ b/tests/cpp/Field/fieldlistview_tests.cc
@@ -3,6 +3,7 @@
 // #define SPHERAL_ENABLE_LOGGER
 
 #include "chai/ExecutionSpaces.hpp"
+#include "chai/Types.hpp"
 #include "test-basic-exec-policies.hh"
 #include "test-utilities.hh"
 
@@ -12,6 +13,7 @@
 #include "Field/FieldList.hh"
 #include "Field/FieldView.hh"
 #include "Field/FieldListView.hh"
+#include <Utilities/Logger.hh>
 
 using DIM3 = Spheral::Dim<3>;
 using FieldBase = Spheral::FieldBase<DIM3>;
@@ -49,7 +51,7 @@ public:
 TYPED_TEST_SUITE_P(FieldListViewTypedTest);
 template <typename T> class FieldListViewTypedTest : public FieldListViewTest {};
 
-GPU_TYPED_TEST_P(FieldListViewTypedTest, DefaultConstructor) {
+GPU_TYPED_TEST_P(FieldListViewTypedTest, BasicCapture) {
 
   const double val = 4.;
   NodeList_t nl = gpu_this->createNodeList(N);
@@ -69,25 +71,136 @@ GPU_TYPED_TEST_P(FieldListViewTypedTest, DefaultConstructor) {
         SPHERAL_ASSERT_EQ(fl_v.size(), numFields);
         SPHERAL_ASSERT_EQ(fl_v[i].size(), N);
       });
-    fl_v.touch(chai::CPU, true);
   }
 
   GPUCounters ref_count;
   if (typeid(RAJA::seq_exec) != typeid(TypeParam)) {
     ref_count.HToDCopies = 1;
+    ref_count.HNumAlloc = 1;
     ref_count.DNumAlloc = 1;
     ref_count.HNumFree = 1;
     ref_count.DNumFree = 1;
   } else {
+    ref_count.HNumAlloc = 1;
     ref_count.HNumFree = 1;
   }
   COMP_COUNTERS(gpu_this->gcounts, ref_count);
 }
 
 // TODO: Add test for having multiple FL contain the same field
-// TODO: Add test where toView is called in multiple scopes for the same FL
+
+GPU_TYPED_TEST_P(FieldListViewTypedTest, MultiScopeAndTouch) {
+
+  const double val = 4.;
+  NodeList_t nl = gpu_this->createNodeList(N);
+  {
+    FieldDouble field("TestField1", nl, val);
+    FieldDouble field2("TestField2", nl, val);
+    FieldListDouble field_list;
+
+    field_list.appendField(field);
+    field_list.appendField(field2);
+
+    const size_t numFields = field_list.size() ;
+
+    { // Scope 1
+    auto fl_v = field_list.toView(gpu_this->callback());
+
+    DEBUG_LOG << "Start Kernel 1";
+    RAJA::forall<TypeParam>(TRS_UINT(0, numFields),
+      [=] SPHERAL_HOST_DEVICE (size_t i) {
+        SPHERAL_ASSERT_EQ(fl_v.size(), numFields);
+        SPHERAL_ASSERT_EQ(fl_v[i].size(), N);
+      });
+    DEBUG_LOG << "Stop Kernel 1";
+
+    fl_v.touch(chai::CPU, true);
+    } // Scope 1
+
+    { // Scope 2
+    auto fl_v = field_list.toView(gpu_this->callback());
+
+    DEBUG_LOG << "Start Kernel 2";
+    RAJA::forall<TypeParam>(TRS_UINT(0, numFields),
+      [=] SPHERAL_HOST_DEVICE (size_t i) {
+        SPHERAL_ASSERT_EQ(fl_v.size(), numFields);
+        SPHERAL_ASSERT_EQ(fl_v[i].size(), N);
+      });
+    DEBUG_LOG << "Stop Kernel 2";
+    } // Scope 2
+  }
+
+  GPUCounters ref_count;
+  if (typeid(RAJA::seq_exec) != typeid(TypeParam)) {
+    ref_count.HToDCopies = 2;
+    ref_count.HNumAlloc = 2;
+    ref_count.DNumAlloc = 2;
+    ref_count.HNumFree = 2;
+    ref_count.DNumFree = 2;
+  } else {
+    ref_count.HNumAlloc = 2;
+    ref_count.HNumFree = 2;
+  }
+
+  COMP_COUNTERS(gpu_this->gcounts, ref_count);
+}
+
+GPU_TYPED_TEST_P(FieldListViewTypedTest, MultiScopeNoTouch) {
+
+  const double val = 4.;
+  NodeList_t nl = gpu_this->createNodeList(N);
+  {
+    FieldDouble field("TestField1", nl, val);
+    FieldDouble field2("TestField2", nl, val);
+    FieldListDouble field_list;
+
+    field_list.appendField(field);
+    field_list.appendField(field2);
+
+    const size_t numFields = field_list.size() ;
+
+    { // Scope 1
+    auto fl_v = field_list.toView(gpu_this->callback());
+
+    DEBUG_LOG << "Start Kernel 1";
+    RAJA::forall<TypeParam>(TRS_UINT(0, numFields),
+      [=] SPHERAL_HOST_DEVICE (size_t i) {
+        SPHERAL_ASSERT_EQ(fl_v.size(), numFields);
+        SPHERAL_ASSERT_EQ(fl_v[i].size(), N);
+      });
+    DEBUG_LOG << "Stop Kernel 1";
+    } // Scope 1
+
+    { // Scope 2
+    auto fl_v = field_list.toView(gpu_this->callback());
+
+    DEBUG_LOG << "Start Kernel 2";
+    RAJA::forall<TypeParam>(TRS_UINT(0, numFields),
+      [=] SPHERAL_HOST_DEVICE (size_t i) {
+        SPHERAL_ASSERT_EQ(fl_v.size(), numFields);
+        SPHERAL_ASSERT_EQ(fl_v[i].size(), N);
+      });
+    DEBUG_LOG << "Stop Kernel 2";
+    } // Scope 2
+  }
+
+  GPUCounters ref_count;
+  if (typeid(RAJA::seq_exec) != typeid(TypeParam)) {
+    ref_count.HToDCopies = 2;
+    ref_count.HNumAlloc = 2;
+    ref_count.DNumAlloc = 2;
+    ref_count.HNumFree = 2;
+    ref_count.DNumFree = 2;
+  } else {
+    ref_count.HNumAlloc = 2;
+    ref_count.HNumFree = 2;
+  }
+
+  COMP_COUNTERS(gpu_this->gcounts, ref_count);
+}
+
 // TODO: Add test where 
-REGISTER_TYPED_TEST_SUITE_P(FieldListViewTypedTest, DefaultConstructor);
+REGISTER_TYPED_TEST_SUITE_P(FieldListViewTypedTest, BasicCapture, MultiScopeAndTouch, MultiScopeNoTouch);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(FieldListView, FieldListViewTypedTest,
                                typename Spheral::Test<EXEC_TYPES>::Types, );

--- a/tests/cpp/Field/fieldlistview_tests.cc
+++ b/tests/cpp/Field/fieldlistview_tests.cc
@@ -30,8 +30,8 @@ public:
   GPUCounters fl_count;
   GPUCounters f_count;
 
-  NodeList_t createNodeList(size_t count) {
-    return NodeList_t("DataNodeList", count, 0);
+  NodeList_t createNodeList(std::string name = "NL", size_t count = N) {
+    return NodeList_t(name, count, 0);
   }
 
   // Increment variables for each action and space
@@ -67,10 +67,11 @@ template <typename T> class FieldListViewTypedTest : public FieldListViewTest {}
 GPU_TYPED_TEST_P(FieldListViewTypedTest, BasicCapture) {
 
   const double val = 4.;
-  NodeList_t nl = gpu_this->createNodeList(N);
+  NodeList_t nl1 = gpu_this->createNodeList("NL1");
+  NodeList_t nl2 = gpu_this->createNodeList("NL2");
   {
-    FieldDouble field("TestField1", nl, val);
-    FieldDouble field2("TestField2", nl, val);
+    FieldDouble field("TestField1", nl1, val);
+    FieldDouble field2("TestField2", nl2, val);
     FieldListDouble field_list;
 
     field_list.appendField(field);
@@ -105,10 +106,11 @@ GPU_TYPED_TEST_P(FieldListViewTypedTest, BasicCapture) {
 GPU_TYPED_TEST_P(FieldListViewTypedTest, MultiScopeAndTouch) {
 
   const double val = 4.;
-  NodeList_t nl = gpu_this->createNodeList(N);
+  NodeList_t nl1 = gpu_this->createNodeList("NL1");
+  NodeList_t nl2 = gpu_this->createNodeList("NL2");
   {
-    FieldDouble field("TestField1", nl, val);
-    FieldDouble field2("TestField2", nl, val);
+    FieldDouble field("TestField1", nl1, val);
+    FieldDouble field2("TestField2", nl2, val);
     FieldListDouble field_list;
 
     field_list.appendField(field);
@@ -160,10 +162,11 @@ GPU_TYPED_TEST_P(FieldListViewTypedTest, MultiScopeAndTouch) {
 GPU_TYPED_TEST_P(FieldListViewTypedTest, MultiScopeNoTouch) {
 
   const double val = 4.;
-  NodeList_t nl = gpu_this->createNodeList(N);
+  NodeList_t nl1 = gpu_this->createNodeList("NL1");
+  NodeList_t nl2 = gpu_this->createNodeList("NL2");
   {
-    FieldDouble field("TestField1", nl, val);
-    FieldDouble field2("TestField2", nl, val);
+    FieldDouble field("TestField1", nl1, val);
+    FieldDouble field2("TestField2", nl2, val);
     FieldListDouble field_list;
 
     field_list.appendField(field);

--- a/tests/cpp/Field/fieldlistview_tests.cc
+++ b/tests/cpp/Field/fieldlistview_tests.cc
@@ -1,0 +1,60 @@
+#include "chai/ExecutionSpaces.hpp"
+#include "test-basic-exec-policies.hh"
+#include "test-utilities.hh"
+
+#include "Field/Field.hh"
+#include "NodeList/NodeList.hh"
+
+#include "Field/FieldList.hh"
+#include "Field/FieldView.hh"
+#include "Field/FieldListView.hh"
+
+using DIM3 = Spheral::Dim<3>;
+using FieldBase = Spheral::FieldBase<DIM3>;
+using FieldDouble = Spheral::Field<DIM3, double>;
+using FieldViewDouble = Spheral::FieldView<DIM3, double>;
+using FieldListDouble = Spheral::FieldList<DIM3, double>;
+using NodeList_t = Spheral::NodeList<DIM3>;
+
+class FieldListViewTest : public ::testing::Test {
+public:
+  NodeList_t createNodeList(size_t count) {
+    return NodeList_t("DataNodeList", count, 0);
+  }
+  int someInt = 5;
+
+  void SetUp() override {}
+};
+
+// Setting up G Test for Field
+TYPED_TEST_SUITE_P(FieldListViewTypedTest);
+template <typename T> class FieldListViewTypedTest : public FieldListViewTest {};
+
+GPU_TYPED_TEST_P(FieldListViewTypedTest, DefaultConstructor) {
+  const int N = 10;
+  const double val = 4.;
+  std::string field_name = "Field::NodeListValCtor";
+  NodeList_t nl = gpu_this->createNodeList(N);
+  FieldDouble field(field_name, nl, val);
+  FieldListDouble field_list;
+  field_list.appendField(field);
+  auto fl_v = field_list.toView();
+  printf("cpu fv %p\n", (void*)(fl_v.data()));
+  auto f_v = field_list[0].toView();
+  RAJA::forall<TypeParam>(
+       TRS_UINT(0, N),
+       [=] SPHERAL_HOST_DEVICE(size_t i) {
+         printf("gpu %p\n", (void*)(fl_v.data()));
+         //printf("%zu %zu\n", i, fl_v[0].size());
+         SPHERAL_ASSERT_EQ(fl_v[0].size(), N);
+       });
+  // EXEC_IN_SPACE_BEGIN(TypeParam)
+  //   SPHERAL_ASSERT_EQ(fl_v(0, 0), 4.0);
+  // EXEC_IN_SPACE_END()
+  // fl_v.move(chai::CPU);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(FieldListViewTypedTest, DefaultConstructor);
+
+INSTANTIATE_TYPED_TEST_SUITE_P(FieldListView, FieldListViewTypedTest,
+                               typename Spheral::Test<EXEC_TYPES>::Types, );

--- a/tests/cpp/Field/fieldlistview_tests.cc
+++ b/tests/cpp/Field/fieldlistview_tests.cc
@@ -1,3 +1,7 @@
+// Debug log printing can be quickly enabled for this unit test by uncommenting the
+// definition below even if Spheral was not configured w/ SPHERAL_ENABLE_LOGGER=On.
+// #define SPHERAL_ENABLE_LOGGER
+
 #include "chai/ExecutionSpaces.hpp"
 #include "test-basic-exec-policies.hh"
 #include "test-utilities.hh"
@@ -16,28 +20,28 @@ using FieldViewDouble = Spheral::FieldView<DIM3, double>;
 using FieldListDouble = Spheral::FieldList<DIM3, double>;
 using NodeList_t = Spheral::NodeList<DIM3>;
 
-static GPUCounters gcounts;
-
-// Increment variables for each action and space
-static auto callback = [](const chai::PointerRecord *,
-                          chai::Action action,
-                          chai::ExecutionSpace space) {
-      if (action == chai::ACTION_MOVE) {
-        (space == chai::CPU) ?
-          gcounts.DToHCopies++ : gcounts.HToDCopies++;
-      } else if (action == chai::ACTION_ALLOC) {
-        (space == chai::CPU) ?
-          gcounts.HNumAlloc++ : gcounts.DNumAlloc++;
-      } else if (action == chai::ACTION_FREE) {
-        (space == chai::CPU) ?
-          gcounts.HNumFree++ : gcounts.DNumFree++;
-      }
-};
+// Default Testing Size.
+static constexpr int N = 100;
 
 class FieldListViewTest : public ::testing::Test {
 public:
+  GPUCounters gcounts;
+
   NodeList_t createNodeList(size_t count) {
     return NodeList_t("DataNodeList", count, 0);
+  }
+
+  // Increment variables for each action and space
+  auto callback() {
+    return [&](const chai::PointerRecord *, chai::Action action,
+                            chai::ExecutionSpace space) {
+    if (action == chai::ACTION_MOVE)
+      (space == chai::CPU) ? gcounts.DToHCopies++ : gcounts.HToDCopies++;
+    if (action == chai::ACTION_ALLOC)
+      (space == chai::CPU) ? gcounts.HNumAlloc++ : gcounts.DNumAlloc++;
+    if (action == chai::ACTION_FREE)
+      (space == chai::CPU) ? gcounts.HNumFree++ : gcounts.DNumFree++;
+    };
   }
 };
 
@@ -46,32 +50,28 @@ TYPED_TEST_SUITE_P(FieldListViewTypedTest);
 template <typename T> class FieldListViewTypedTest : public FieldListViewTest {};
 
 GPU_TYPED_TEST_P(FieldListViewTypedTest, DefaultConstructor) {
-  gcounts.resetCounters();
-  const int N = 10;
+
   const double val = 4.;
-  std::string field_name = "Field::NodeListValCtor";
   NodeList_t nl = gpu_this->createNodeList(N);
   {
-    FieldDouble field(field_name, nl, val);
-    FieldDouble field2("Field2", nl, val);
+    FieldDouble field("TestField1", nl, val);
+    FieldDouble field2("TestField2", nl, val);
     FieldListDouble field_list;
 
     field_list.appendField(field);
     field_list.appendField(field2);
 
     const size_t numFields = field_list.size() ;
-    auto fl_v = field_list.toView(callback);
+    auto fl_v = field_list.toView(gpu_this->callback());
 
-    RAJA::forall<TypeParam>
-      (TRS_UINT(0, N),
-       [=] SPHERAL_HOST_DEVICE(size_t i) {
-         SPHERAL_ASSERT_EQ(fl_v.size(), numFields);
-         for (size_t l = 0; l < numFields; ++l) {
-           SPHERAL_ASSERT_EQ(fl_v[l].size(), N);
-         }
-       });
+    RAJA::forall<TypeParam>(TRS_UINT(0, numFields),
+      [=] SPHERAL_HOST_DEVICE (size_t i) {
+        SPHERAL_ASSERT_EQ(fl_v.size(), numFields);
+        SPHERAL_ASSERT_EQ(fl_v[i].size(), N);
+      });
     fl_v.touch(chai::CPU, true);
   }
+
   GPUCounters ref_count;
   if (typeid(RAJA::seq_exec) != typeid(TypeParam)) {
     ref_count.HToDCopies = 1;
@@ -81,7 +81,7 @@ GPU_TYPED_TEST_P(FieldListViewTypedTest, DefaultConstructor) {
   } else {
     ref_count.HNumFree = 1;
   }
-  COMP_COUNTERS(gcounts, ref_count);
+  COMP_COUNTERS(gpu_this->gcounts, ref_count);
 }
 
 // TODO: Add test for having multiple FL contain the same field

--- a/tests/cpp/include/test-utilities.hh
+++ b/tests/cpp/include/test-utilities.hh
@@ -88,6 +88,7 @@ using LOOP_EXEC_POLICY = RAJA::seq_exec;
     SPHERAL_ASSERT_EQ_MSG(LHS.HNumFree,   RHS.HNumFree, "Failed HNumFree\n");\
     SPHERAL_ASSERT_EQ_MSG(LHS.DNumFree,   RHS.DNumFree, "Failed DNumFree\n")
 
+// Counter : { H->D Copy, D->H Copy, H Alloc, D Alloc, H Free, D Free }
 struct GPUCounters {
   int HToDCopies = 0, DToHCopies = 0;
   int HNumAlloc = 0, DNumAlloc = 0;

--- a/tests/cpp/include/test-utilities.hh
+++ b/tests/cpp/include/test-utilities.hh
@@ -1,5 +1,5 @@
-#ifndef SPHERAL_TEST_UTIILITIES_HH
-#define SPHERAL_TEST_UTIILITIES_HH
+#ifndef SPHERAL_TEST_UTILITIES_HH
+#define SPHERAL_TEST_UTILITIES_HH
 
 #include "RAJA/RAJA.hpp"
 #include "assert.h"
@@ -20,12 +20,19 @@ using LOOP_EXEC_POLICY = RAJA::seq_exec;
 #if !defined(SPHERAL_GPU_ACTIVE)
 
 #define SPHERAL_ASSERT_EQ(LHS, RHS) ASSERT_EQ(LHS, RHS);
+#define SPHERAL_ASSERT_EQ_MSG(LHS, RHS, MSG) ASSERT_EQ(LHS, RHS);
 #define SPHERAL_ASSERT_NE(LHS, RHS) ASSERT_NE(LHS, RHS);
 #define SPHERAL_ASSERT_TRUE(VAL) ASSERT_TRUE(VAL);
 #define SPHERAL_ASSERT_FALSE(VAL) ASSERT_FALSE(VAL);
 #define SPHERAL_ASSERT_FLOAT_EQ(LHS, RHS) ASSERT_FLOAT_EQ(LHS, RHS);
 
 #else
+
+#define SPHERAL_ASSERT_EQ_MSG(LHS, RHS, MSG)                                   \
+  if (LHS != RHS) {                                                            \
+    printf(MSG);                                                               \
+    assert(0);                                                                 \
+  }
 
 #define SPHERAL_ASSERT_EQ(LHS, RHS)                                            \
   if (LHS != RHS) {                                                            \
@@ -74,12 +81,12 @@ using LOOP_EXEC_POLICY = RAJA::seq_exec;
   static void gpu_test_##X##Y(TestFixture *gpu_this)
 
 #define COMP_COUNTERS(LHS, RHS) \
-    SPHERAL_ASSERT_EQ_MSG(LHS.HToDCopies, RHS.HToDCopies); \
-    SPHERAL_ASSERT_EQ_MSG(LHS.DToHCopies, RHS.DToHCopies); \
-    SPHERAL_ASSERT_EQ_MSG(LHS.HNumAlloc,  RHS.HNumAlloc); \
-    SPHERAL_ASSERT_EQ_MSG(LHS.DNumAlloc,  RHS.DNumAlloc); \
-    SPHERAL_ASSERT_EQ_MSG(LHS.HNumFree,   RHS.HNumFree); \
-    SPHERAL_ASSERT_EQ_MSG(LHS.DNumFree,   RHS.DNumFree); 
+    SPHERAL_ASSERT_EQ_MSG(LHS.HToDCopies, RHS.HToDCopies, "Failed HToDCopies\n");\
+    SPHERAL_ASSERT_EQ_MSG(LHS.DToHCopies, RHS.DToHCopies, "Failed DToHCopies\n");\
+    SPHERAL_ASSERT_EQ_MSG(LHS.HNumAlloc,  RHS.HNumAlloc, "Failed HNumAlloc\n");\
+    SPHERAL_ASSERT_EQ_MSG(LHS.DNumAlloc,  RHS.DNumAlloc, "Failed DNumAlloc\n");\
+    SPHERAL_ASSERT_EQ_MSG(LHS.HNumFree,   RHS.HNumFree, "Failed HNumFree\n");\
+    SPHERAL_ASSERT_EQ_MSG(LHS.DNumFree,   RHS.DNumFree, "Failed DNumFree\n")
 
 struct GPUCounters {
   int HToDCopies = 0, DToHCopies = 0;


### PR DESCRIPTION
# Summary

This PR introduces `FieldListView` and enhances `FieldView` to facilitate GPU-accelerated operations on `FieldList` and `Field` objects.

## Key Changes

- **Introduced `FieldListView`:** which enables GPU access to field data while maintaining Field -> FieldList associations across execution spaces.
- **`FieldList`:**
    - Added `mFieldViews` (`chai::ManagedArray<FieldView>`) to `FieldList` for managing GPU-accessible views of its contained fields.
    - Implemented `toView()` methods in `FieldList` to convert it into a `FieldListView`, handling `chai` allocations and data population.
    - Integrated `chai` callbacks within `toView()` for logging and debugging memory actions (alloc, free, move) on both host and device.
    - Ensured proper deallocation of `mFieldViews` in the `FieldList` destructor.
- **`FieldView`:**
    - `FieldView` now inherits from `chai::CHAICopyable`, allowing implicit copies of `FieldListView` to trigger inner `FieldView` copies to/from the device.
    - Added `data()` overload for `chai::ExecutionSpace` and `shallowCopy()` and `touch()` methods for better `chai` integration.
- **Testing:**
    - Added `fieldlistview_tests` with dedicated unit tests for `FieldListView` behaviour.
    - Introduced `GPUCounters` and associated callback mechanisms to rigorously track and verify `chai` memory operations (allocations, deallocations, and copies between host and device) for both `FieldList` and individual `Field` objects within the `FieldListView` context.
    - Included test cases for basic capture, multi-scope behavior with and without explicit `touch` operations.


------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. ([PR#157](https://rzlc.llnl.gov/gitlab/owen/LLNLSpheral/-/merge_requests/157))
- [x] LLNLSpheral PR has passed all tests.

