### PR TITLE
Fix permissions for Docker image action in GitHub

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,6 +11,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - name: Checkout repository

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,7 @@ Notable changes include:
     * Updating boost function calls to std library implementations where possible.
     * Switched the CZ CI to use Dane instead of Ruby.
       * Increased the number of threads for certain memory intensive tests to prevent OOM error.
+    * Updated GitHub actions since GitLab mirror changed.
 
 Version v2025.06.1 -- Release date 2025-07-21
 ==============================================

--- a/tests/performance.py
+++ b/tests/performance.py
@@ -44,7 +44,7 @@ mpi_enabled = SpheralConfigs.enable_mpi()
 # Retrieve the host name and remove any numbers
 temp_uname = os.uname()
 hostname = temp_uname[1].rstrip("0123456789")
-mac_procs = {"rzhound": 112, "rzwhippet": 112, "ruby": 56,
+mac_procs = {"rzhound": 112, "rzwhippet": 112, "dane": 112,
              "rzadams": 84, "rzvernal": 64, "tioga": 64,
              "rzansel": 40, "lassen": 40, "rzgenie": 36}
 # Find out how many nodes our allocation has grabbed


### PR DESCRIPTION
# Summary

- This PR is a correction to allow GitHub to update the package repo on a merge to develop.
- It does the following:
  - Sets specific permissions for the docker image workflow.

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#167)
- [ ] LLNLSpheral PR has passed all tests.

