### PR TITLE
Remove DEBUG compile def

### DIFF
--- a/cmake/CMakeDefinitions.cmake
+++ b/cmake/CMakeDefinitions.cmake
@@ -7,9 +7,6 @@ set(SPHERAL_COMPILE_DEFS )
 # If we're building debug default DBC to All
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   message("-- building Debug")
-  list(APPEND SPHERAL_COMPILE_DEFS "DEBUG=1")
-else()
-  list(APPEND SPHERAL_COMPILE_DEFS "DEBUG=0")
 endif()
 
 # The DBC flag

--- a/cmake/spheral/SpheralAddLibs.cmake
+++ b/cmake/spheral/SpheralAddLibs.cmake
@@ -124,15 +124,6 @@ function(spheral_add_cxx_library package_name _cxx_obj_list)
 
     # Add compile options
     target_compile_options(Spheral_${package_name} PRIVATE ${SPHERAL_CXX_FLAGS})
-
-    # The cmake export files have many repeating lines because of our use of object libs
-    # This cleans them up but not fully
-    set(_properties INTERFACE_COMPILE_OPTIONS)
-    foreach(_prop ${_properties})
-      get_target_property(temp_prop Spheral_${package_name} ${_prop})
-      list(REMOVE_DUPLICATES temp_prop)
-      set_target_properties(Spheral_${package_name} PROPERTIES ${_prop} "${temp_prop}")
-    endforeach()
   endif()
 
   target_include_directories(Spheral_${package_name} SYSTEM PRIVATE ${SPHERAL_SUBMOD_INCLUDES})

--- a/src/FileIO/HDF5IO.cc
+++ b/src/FileIO/HDF5IO.cc
@@ -7,12 +7,9 @@
 #include "HDF5IO.hh"
 #include "Utilities/DBC.hh"
 #include "Field/Field.hh"
+#include "Utilities/Logger.hh"
 
-#ifdef GNUCXX
-#include <strstream>
-#else
 #include <sstream>
-#endif
 
 namespace Spheral {
 
@@ -24,9 +21,7 @@ HDF5IO<Dimension>::HDF5IO():
   FileIO<Dimension>(),
   mFilePtr(0) {
 
-#ifdef DEBUG
-  cerr << "HDF5IO::HDF5IO()" << endl;
-#endif
+  DEBUG_LOG << "HDF5IO::HDF5IO()";
 
   initializeAccessMap();
 
@@ -43,9 +38,7 @@ template<typename Dimension>
 HDF5IO<Dimension>::HDF5IO(const string& fileName, AccessType access):
   FileIO<Dimension>(fileName, access),
   mFilePtr(0) {
-#ifdef DEBUG
-    cerr << "HDF5IO::HDF5IO(string, access)" << endl;
-#endif
+  DEBUG_LOG << "HDF5IO::HDF5IO(string, access)";
   initializeAccessMap();
 
   // Turn off error printing from HDF5 by default.
@@ -61,9 +54,7 @@ template<typename Dimension>
 HDF5IO<Dimension>::HDF5IO(const string& fileName, int access):
   FileIO<Dimension>(fileName, AccessType(access)),
   mFilePtr(0) {
-#ifdef DEBUG
-  cerr << "HDF5IO::HDF5IO(string, int)" << endl;
-#endif
+  DEBUG_LOG << "HDF5IO::HDF5IO(string, int)";
   initializeAccessMap();
 
   // Turn off error printing from HDF5 by default.
@@ -79,9 +70,7 @@ HDF5IO<Dimension>::HDF5IO(const string& fileName, int access):
 //------------------------------------------------------------------------------
 template<typename Dimension>
 HDF5IO<Dimension>::~HDF5IO() {
-#ifdef DEBUG
-  cerr << "HDF5IO::~HDF5IO" << endl;
-#endif
+  DEBUG_LOG << "HDF5IO::~HDF5IO";
   close();
 }
 
@@ -92,9 +81,7 @@ template<typename Dimension>
 void
 HDF5IO<Dimension>::open(const string& fileName, AccessType access) {
 
-#ifdef DEBUG
-  cerr << "HDF5IO::open(" << fileName << ", " << access << ")" << endl;
-#endif
+  DEBUG_LOG << "HDF5IO::open(" << fileName << ", " << access << ")";
 
   // If we currently have a file open and attached to this object, close it!
   close();
@@ -117,9 +104,7 @@ template<typename Dimension>
 void
 HDF5IO<Dimension>::close() {
 
-#ifdef DEBUG
-  cerr << "HDF5IO::close()" << endl;
-#endif
+  DEBUG_LOG << "HDF5IO::close()";
 
   if (mFilePtr != 0) {
     delete mFilePtr;
@@ -579,10 +564,10 @@ readGenericContainer(const IteratorType& begin,
 
     // Verify that the container is the correct size!
     if (distance(begin, end) != (int) dims[0]) {
-      cerr << "HDF5IO::readGenericContainer ERROR: input container wrong size."
-	   << endl
-	   << "  Container size: " << distance(begin, end) << endl
-	   << "    DataSet size: " << dims[1] << endl;
+      std::cerr << "HDF5IO::readGenericContainer ERROR: input container wrong size."
+                << std::endl
+                << "  Container size: " << distance(begin, end) << std::endl
+                << "    DataSet size: " << dims[1] << std::endl;
       return;
     }
 
@@ -665,9 +650,7 @@ HDF5IO<Dimension>::getH5Group(const string& pathName) {
 
     // Catch the case that this group does not yet exist, and create it.
     catch(FileIException error) {
-#ifdef DEBUG
-      cerr << "Caught file exception, creating group " << cumulativePath << endl;
-#endif
+      DEBUG_LOG << "Caught file exception, creating group " << cumulativePath;
       Group group = mFilePtr->createGroup(cumulativePath);
     }
   }
@@ -701,9 +684,7 @@ HDF5IO<Dimension>::readyToRead() const {
 template<typename Dimension>
 void
 HDF5IO<Dimension>::initializeAccessMap() {
-#ifdef DEBUG
-  cerr << "HDF5IO::initializeAccessMap()" << endl;
-#endif
+  DEBUG_LOG << "HDF5IO::initializeAccessMap()";
   mHDF5AccessTypes[Spheral::FileIO::Create] = H5F_ACC_TRUNC;
   mHDF5AccessTypes[Spheral::FileIO::Read] = H5F_ACC_RDONLY;
   mHDF5AccessTypes[Spheral::FileIO::Write] = H5F_ACC_RDWR;


### PR DESCRIPTION

# Summary

- This PR is a bugfix for #413 
- It does the following:
  - Removes the `DEBUG` compile flag.
  - Replaces debug print statements in HDF5IO.cc with DEBUG_LOG calls.
  - Removes logic to clean up INTERFACE_COMPILE_OPTIONS since this breaks sometimes.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#176)
- [x] LLNLSpheral PR has passed all tests.

