### PR TITLE
Add guards for Chai callback functions

### DIFF
--- a/src/Utilities/CubicHermiteInterpolator.hh
+++ b/src/Utilities/CubicHermiteInterpolator.hh
@@ -10,6 +10,7 @@
 
 #include "CubicHermiteInterpolatorView.hh"
 #include "chai/ManagedArray.hpp"
+#include "chai/config.hpp"
 #include "config.hh"
 
 #include <cstddef>
@@ -60,10 +61,12 @@ public:
 
   CubicHermiteInterpolatorView view() { return static_cast<CubicHermiteInterpolatorView>(*this); }
 
+#ifndef CHAI_DISABLE_RM
   template<typename F> inline
   void setUserCallback(F&& extension) {
     mVals.setUserCallback(getNPLCallback(std::forward<F>(extension)));
   }
+#endif
 
 protected:
   template<typename F>

--- a/src/Utilities/QuadraticInterpolator.hh
+++ b/src/Utilities/QuadraticInterpolator.hh
@@ -11,6 +11,7 @@
 
 #include "QuadraticInterpolatorView.hh"
 #include "chai/ManagedArray.hpp"
+#include "chai/config.hpp"
 #include "config.hh"
 
 #include <cstddef>
@@ -35,10 +36,12 @@ public:
 
   QuadraticInterpolatorView view() { return static_cast<QuadraticInterpolatorView>(*this); }
 
+#ifndef CHAI_DISABLE_RM
   template<typename F> inline
   void setUserCallback(F&& extension) {
     mcoeffs.setUserCallback(getNPLCallback(std::forward<F>(extension)));
   }
+#endif
 
 protected:
   template<typename F>


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- It does the following:
  - Adds CHAI_DISABLE_RM guard for interpolator callback functions.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#183)
- [x] LLNLSpheral PR has passed all tests.

