### PR TITLE
Update to ROCM 7.1.0

### DIFF
--- a/cmake/Compilers.cmake
+++ b/cmake/Compilers.cmake
@@ -1,7 +1,7 @@
 message("-- C++ Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
 
 #-------------------------------------------------------------------------------
-# Optionally suppress compiler warnings
+# Set compiler options
 #-------------------------------------------------------------------------------
 
 option(ENABLE_WARNINGS "show compiler warnings" ON)
@@ -16,10 +16,10 @@ if (ENABLE_HIP)
   set(LANG_STR "HIP")
 endif()
 
-set(CXX_WARNING_FLAGS "")
+set(CXX_COMPILE_FLAGS "")
 if (ENABLE_WARNINGS)
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    list(APPEND CXX_WARNING_FLAGS -fdiagnostics-show-option -Wno-unused-command-line-argument -Wno-c++17-extensions)
+    list(APPEND CXX_COMPILE_FLAGS -fdiagnostics-show-option -Wno-unused-command-line-argument -Wno-c++17-extensions)
     if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 18.0.0)
       list(APPEND CXX_COMPILE_FLAGS -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments)
       if(CMAKE_CXX_COMPILER_VERSION LESS 20.0.0)
@@ -37,45 +37,62 @@ message("-- Compiler warnings ${ENABLE_WARNINGS}")
 
 if (ENABLE_WARNINGS_AS_ERRORS)
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-    list(APPEND CXX_WARNING_FLAGS /W4 /WX)
+    list(APPEND CXX_COMPILE_FLAGS /W4 /WX)
   else()
-    list(APPEND CXX_WARNING_FLAGS -Wall -Wextra -pedantic -Werror -Wl,--fatal-warnings)
+    list(APPEND CXX_COMPILE_FLAGS -Wall -Wextra -pedantic -Werror -Wl,--fatal-warnings)
   endif()
   message("-- Treating warnings as errors")
 endif()
 
 
 if (NOT ENABLE_UNUSED_VARIABLE_WARNINGS)
-  list(APPEND CXX_WARNING_FLAGS -Wno-unused-variable)
+  list(APPEND CXX_COMPILE_FLAGS -Wno-unused-variable)
 endif()
 message("-- Compiler unused variable warnings ${ENABLE_UNUSED_VARIABLE_WARNINGS}")
 
 
 if (NOT ENABLE_UNUSED_PARAMETER_WARNINGS)
-  list(APPEND CXX_WARNING_FLAGS -Wno-unused-parameter)
+  list(APPEND CXX_COMPILE_FLAGS -Wno-unused-parameter)
 endif()
 message("-- Compiler unused parameter warnings ${ENABLE_UNUSED_PARAMETER_WARNINGS}")
 
 
 if (NOT ENABLE_MISSING_INCLUDE_DIR_WARNINGS)
-  list(APPEND CXX_WARNING_FLAGS -Wno-missing-include-dirs)
+  list(APPEND CXX_COMPILE_FLAGS -Wno-missing-include-dirs)
 endif()
 message("-- Compiler missing include dir warnings ${ENABLE_MISSING_INCLUDE_DIR_WARNINGS}")
 
 set(CUDA_WARNING_FLAGS -Xcudafe=\"--diag_suppress=esa_on_defaulted_function_ignored\")
 
-set_property(GLOBAL PROPERTY SPHERAL_CXX_FLAGS
-  "$<$<COMPILE_LANGUAGE:${LANG_STR}>:${CXX_WARNING_FLAGS}>")
-message("-- Using CXX warning flags ${CXX_WARNING_FLAGS}")
+if (SPHERAL_ENABLE_RDC AND ENABLE_HIP)
+  list(APPEND CXX_COMPILE_FLAGS -fgpu-rdc)
+endif()
+
+set_property(GLOBAL PROPERTY SPHERAL_CXX_FLAGS "${SPHERAL_CXX_FLAGS}"
+  "$<$<COMPILE_LANGUAGE:${LANG_STR}>:${CXX_COMPILE_FLAGS}>")
+message("-- Using CXX compile flags ${CXX_COMPILE_FLAGS}")
 
 # Currently unused
 set_property(GLOBAL PROPERTY SPHERAL_CUDA_FLAGS
   "$<$<COMPILE_LANGUAGE:CUDA>:${CUDA_WARNING_FLAGS}>")
 
 #-------------------------------------------------------------------------------
+# Set link options
+#-------------------------------------------------------------------------------
+
+set(CXX_LINK_FLAGS "")
+
+if (SPHERAL_ENABLE_RDC AND ENABLE_HIP)
+  list(APPEND CXX_LINK_FLAGS -fgpu-rdc)
+endif()
+
+set_property(GLOBAL PROPERTY SPHERAL_LINK_FLAGS "${CXX_LINK_FLAGS}")
+message("-- Using link flags ${CXX_LINK_FLAGS}")
+
+#-------------------------------------------------------------------------------
 # PYB11 Target Flags
 #-------------------------------------------------------------------------------
-set(SPHERAL_PYB11_FLAGS ${CXX_WARNING_FLAGS})
+set(SPHERAL_PYB11_FLAGS ${CXX_COMPILE_FLAGS})
 list(APPEND SPHERAL_PYB11_FLAGS
   -O1
   -Wno-unused-local-typedefs 

--- a/cmake/Compilers.cmake
+++ b/cmake/Compilers.cmake
@@ -21,7 +21,13 @@ if (ENABLE_WARNINGS)
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     list(APPEND CXX_WARNING_FLAGS -fdiagnostics-show-option -Wno-unused-command-line-argument -Wno-c++17-extensions)
     if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 18.0.0)
-      list(APPEND CXX_WARNING_FLAGS -Wno-enum-constexpr-conversion -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments)
+      list(APPEND CXX_COMPILE_FLAGS -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments)
+      if(CMAKE_CXX_COMPILER_VERSION LESS 20.0.0)
+        list(APPEND CXX_COMPILE_FLAGS -Wno-enum-constexpr-conversion)
+        # We build some Fortran code from outside sources (like the Helmholtz EOS) that
+        # cause building errors if the compiler is too picky...
+        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wno-missing-include-dirs")
+      endif()
     endif()
   endif()
 else()
@@ -65,10 +71,6 @@ message("-- Using CXX warning flags ${CXX_WARNING_FLAGS}")
 # Currently unused
 set_property(GLOBAL PROPERTY SPHERAL_CUDA_FLAGS
   "$<$<COMPILE_LANGUAGE:CUDA>:${CUDA_WARNING_FLAGS}>")
-
-# We build some Fortran code from outside sources (like the Helmholtz EOS) that
-# cause building errors if the compiler is too picky...
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wno-missing-include-dirs")
 
 #-------------------------------------------------------------------------------
 # PYB11 Target Flags

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/compilers.yaml
@@ -1,4 +1,3 @@
-# CMake has an issue with the 7.1.0 Fortran compilers, hacking to 6.4.3
 compilers::
 - compiler:
       spec: rocmcc@=7.1.0

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/compilers.yaml
@@ -1,11 +1,12 @@
+# CMake has an issue with the 7.1.0 Fortran compilers, hacking to 6.4.3
 compilers::
 - compiler:
-      spec: rocmcc@=6.2.0
+      spec: rocmcc@=7.1.0
       paths:
-        cc:  /usr/tce/packages/rocmcc/rocmcc-6.2.0-magic/bin/amdclang
-        cxx: /usr/tce/packages/rocmcc/rocmcc-6.2.0-magic/bin/amdclang++
-        f77: /usr/tce/packages/rocmcc/rocmcc-6.2.0-magic/bin/amdflang
-        fc:  /usr/tce/packages/rocmcc/rocmcc-6.2.0-magic/bin/amdflang
+        cc:  /usr/tce/packages/rocmcc/rocmcc-7.1.0-magic/bin/amdclang
+        cxx: /usr/tce/packages/rocmcc/rocmcc-7.1.0-magic/bin/amdclang++
+        f77: /usr/tce/packages/rocmcc/rocmcc-7.1.0-magic/bin/amdflang
+        fc:  /usr/tce/packages/rocmcc/rocmcc-7.1.0-magic/bin/amdflang
       flags: {}
       operating_system: rhel8
       target: x86_64

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/packages.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/packages.yaml
@@ -29,45 +29,45 @@ packages:
   cray-mpich:
     buildable: false
     externals:
-    - spec: cray-mpich@8.1.31%rocmcc@6.2.0
-      prefix: /usr/tce/packages/cray-mpich/cray-mpich-8.1.31-rocmcc-6.2.0-magic
+    - spec: cray-mpich@9.0.1%rocmcc@7.1.0
+      prefix: /usr/tce/packages/cray-mpich/cray-mpich-9.0.1-rocmcc-7.1.0-magic
 
   hip:
-    version: [6.2.0]
+    version: [7.1.0]
     buildable: false
     externals:
-    - spec: hip@6.2.0%rocmcc@6.2.0
-      prefix: /usr/tce/packages/rocmcc/rocmcc-6.2.0-magic/
+    - spec: hip@7.1.0%rocmcc@7.1.0
+      prefix: /usr/tce/packages/rocmcc/rocmcc-7.1.0-magic/
   llvm-amdgpu:
-    version: [6.2.0]
+    version: [7.1.0]
     buildable: false
     externals:
-    - spec: llvm-amdgpu@6.2.0%rocmcc@6.2.0
-      prefix: /usr/tce/packages/rocmcc/rocmcc-6.2.0-magic/llvm
+    - spec: llvm-amdgpu@7.1.0%rocmcc@7.1.0
+      prefix: /usr/tce/packages/rocmcc/rocmcc-7.1.0-magic/llvm
   hsa-rocr-dev:
-    version: [6.2.0]
+    version: [7.1.0]
     buildable: false
     externals:
-    - spec: hsa-rocr-dev@6.2.0%rocmcc@6.2.0
-      prefix: /usr/tce/packages/rocmcc/rocm-6.2.0-magic/
+    - spec: hsa-rocr-dev@7.1.0%rocmcc@7.1.0
+      prefix: /usr/tce/packages/rocmcc/rocm-7.1.0-magic/
   rocminfo:
-    version: [6.2.0]
+    version: [7.1.0]
     buildable: false
     externals:
-    - spec: rocminfo@6.2.0%rocmcc@6.2.0
-      prefix: /usr/tce/packages/rocmcc/rocm-6.2.0-magic/
+    - spec: rocminfo@7.1.0%rocmcc@7.1.0
+      prefix: /usr/tce/packages/rocmcc/rocm-7.1.0-magic/
   rocm-device-libs:
-    version: [6.2.0]
+    version: [7.1.0]
     buildable: false
     externals:
-    - spec: rocm-device-libs@6.2.0%rocmcc@6.2.0
-      prefix: /usr/tce/packages/rocmcc/rocm-6.2.0-magic/
+    - spec: rocm-device-libs@7.1.0%rocmcc@7.1.0
+      prefix: /usr/tce/packages/rocmcc/rocm-7.1.0-magic/
   rocprim:
-    version: [6.2.0]
+    version: [7.1.0]
     buildable: false
     externals:
-    - spec: rocprim@6.2.0%rocmcc@6.2.0
-      prefix: /usr/tce/packages/rocmcc/rocm-6.2.0-magic/
+    - spec: rocprim@7.1.0%rocmcc@7.1.0
+      prefix: /usr/tce/packages/rocmcc/rocm-7.1.0-magic/
 
 # ------ SYSTEM LIBS -------
   py-decorator:

--- a/scripts/spack/packages/boost/package.py
+++ b/scripts/spack/packages/boost/package.py
@@ -1,0 +1,13 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+from spack.pkg.builtin.boost import Boost as BuiltinBoost
+
+
+class Boost(BuiltinBoost):
+        # TODO: This file can be removed in spack 1.0+
+        version("1.87.0", sha256="af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89")

--- a/scripts/spack/packages/camp/package.py
+++ b/scripts/spack/packages/camp/package.py
@@ -10,4 +10,5 @@ from spack.pkg.builtin.camp import Camp as BuiltinCamp
 
 class Camp(BuiltinCamp):
 
+    version("2025.12.0", tag="v2025.12.0", submodules=False)
     version("2025.03.0", tag="v2025.03.0", submodules=False)

--- a/scripts/spack/packages/chai/package.py
+++ b/scripts/spack/packages/chai/package.py
@@ -10,6 +10,9 @@ from spack.pkg.builtin.chai import Chai as BuiltinChai
 
 class Chai(BuiltinChai):
 
-    version("develop", commit="b7babdc0c333baa68e53b026c63d65c48c8d8eb1", submodules=False)
-    depends_on("raja@2025.03.0", type="build", when="+raja")
-    depends_on("umpire@2025.03.1", type="build")
+    version("2025.12.0", tag="v2025.12.0", submodules=False)
+    version("dev", commit="b7babdc0c333baa68e53b026c63d65c48c8d8eb1", submodules=False)
+    depends_on("raja@2025.12.0", type="build", when="@2025.12.0+raja")
+    depends_on("umpire@2025.12.0", type="build", when="@2025.12.0")
+    depends_on("raja@2025.03.0", type="build", when="@dev+raja")
+    depends_on("umpire@2025.03.1", type="build", when="@dev")

--- a/scripts/spack/packages/leos/package.py
+++ b/scripts/spack/packages/leos/package.py
@@ -25,10 +25,10 @@ class Leos(CachedCMakePackage, CudaPackage, ROCmPackage):
     fileUrl = 'file://' + fileLoc
     url = os.path.join(fileUrl, "leos-8.4.1.tar.gz")
 
-    version("8.5.2", sha256="0fd104fd8599c5349d5156a433df0aa04880c01eb0105c9318493fc17b3b5a6f")
+    version("8.5.2", sha256="0fd104fd8599c5349d5156a433df0aa04880c01eb0105c9318493fc17b3b5a6f", preferred=True)
     version("8.5.1", sha256="a072e48100bca21a594c6725158a0a7128f65ee4ce2aaa0be6e8fe55d3eff96a")
     version("8.5.0", sha256="49b6549ce5fbca8afdd58f2266591f6ce68341b2f37bf4302c08c217a353362a")
-    version("8.4.2", sha256="08eb87580e30d7a1db72b1e1a457652dda9535df1c0caf7b5badb9cadf39f2a9", preferred=True)
+    version("8.4.2", sha256="08eb87580e30d7a1db72b1e1a457652dda9535df1c0caf7b5badb9cadf39f2a9")#, preferred=True)
     version("8.4.1", sha256="93abeea9e336e3a81cc6cc9de10b2a2fd61eda2a89abece50cac80fef58ec38b")
     version("8.4.0", sha256="233333d0ac1bd0fa3a4eb756248c6c996b98bccb8dd957d9fac9e744fb6ede6b")
     version("8.3.5", sha256="60d8298a5fc0dc056f33b39f664aab5ef75b4c4a4b3e1b80b22d769b39175db8")

--- a/scripts/spack/packages/raja/package.py
+++ b/scripts/spack/packages/raja/package.py
@@ -36,9 +36,10 @@ class Raja(BuiltinRaja):
         entries = super().initconfig_package_entries()
 
         # C++17
-        if (spec.satisfies("@2024.07.0:")
+        if (spec.satisfies("@2025.12.0:") or
+            (spec.satisfies("@2024.07.0:")
             and spec.satisfies("+sycl")
-            or spec.satisfies("^rocprim@7.0:")):
+            or spec.satisfies("^rocprim@7.0:"))):
             entries = [f for f in entries if "BLT_CXX_STD" not in f]
             entries.append(cmake_cache_string("BLT_CXX_STD", "c++17"))
 

--- a/scripts/spack/packages/raja/package.py
+++ b/scripts/spack/packages/raja/package.py
@@ -10,5 +10,36 @@ from spack.pkg.builtin.raja import Raja as BuiltinRaja
 
 class Raja(BuiltinRaja):
 
-    version("2025.03.0", tag="v2025.03.0", submodules=False)
-    depends_on("camp@2025.03.0", type="build")
+    version("2025.12.0", tag="v2025.12.0")
+    version("2025.03.0", tag="v2025.03.0")
+    
+    depends_on("camp@2025.12.0", type="build", when="@2025.12.0")
+    depends_on("camp@2025.03.0", type="build", when="@2025.03.0")
+
+    def initconfig_hardware_entries(self):
+        spec = self.spec
+        entries = super().initconfig_hardware_entries()
+
+        if spec.satisfies("+rocm"):
+            entries = [f for f in entries if "HIP_HIPCC_FLAGS" not in f]
+            hipcc_flags = []
+            if self.spec.satisfies("^rocprim@7.0:"):
+                hipcc_flags.append("-std=c++17")
+            elif self.spec.satisfies("@0.14.0:"):
+                hipcc_flags.append("-std=c++14")
+            entries.append(cmake_cache_string("HIP_HIPCC_FLAGS", " ".join(hipcc_flags)))
+
+        return entries
+
+    def initconfig_package_entries(self):
+        spec = self.spec
+        entries = super().initconfig_package_entries()
+
+        # C++17
+        if (spec.satisfies("@2024.07.0:")
+            and spec.satisfies("+sycl")
+            or spec.satisfies("^rocprim@7.0:")):
+            entries = [f for f in entries if "BLT_CXX_STD" not in f]
+            entries.append(cmake_cache_string("BLT_CXX_STD", "c++17"))
+
+        return entries

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -197,6 +197,11 @@ class Spheral(CachedCMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies('+rocm'):
             entries.append(cmake_cache_option("ENABLE_HIP", True))
             entries.append(cmake_cache_string("ROCM_PATH", spec["hip"].prefix))
+            if spec.satisfies("^hip@7.1.0"):
+                fortran_libs = "FortranRuntime;FortranCommon;FortranDecimal"
+                fortran_lib_dir = os.path.join(spec["hip"].prefix, "lib/llvm/lib")
+                entries.append(cmake_cache_string("CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES", fortran_lib_dir))
+                entries.append(cmake_cache_string("CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES", fortran_libs))
 
         if spec.satisfies('+cuda'):
             entries.append(cmake_cache_option("ENABLE_CUDA", True))

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -197,11 +197,12 @@ class Spheral(CachedCMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies('+rocm'):
             entries.append(cmake_cache_option("ENABLE_HIP", True))
             entries.append(cmake_cache_string("ROCM_PATH", spec["hip"].prefix))
-            if spec.satisfies("^hip@7.1.0"):
-                fortran_libs = "FortranRuntime;FortranCommon;FortranDecimal"
-                fortran_lib_dir = os.path.join(spec["hip"].prefix, "lib/llvm/lib")
-                entries.append(cmake_cache_string("CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES", fortran_lib_dir))
-                entries.append(cmake_cache_string("CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES", fortran_libs))
+
+        if spec.satisfies("%llvm-amdgpu@7.1.0"):
+            fortran_libs = "FortranRuntime;FortranCommon;FortranDecimal"
+            fortran_lib_dir = os.path.join(spec["llvm-amdgpu"].prefix, "lib/llvm/lib")
+            entries.append(cmake_cache_string("CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES", fortran_lib_dir))
+            entries.append(cmake_cache_string("CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES", fortran_libs))
 
         if spec.satisfies('+cuda'):
             entries.append(cmake_cache_option("ENABLE_CUDA", True))

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -50,7 +50,7 @@ class Spheral(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('cmake@3.21.0:', type='build')
 
-    depends_on('boost@1.85.0 +system +filesystem -atomic -container -coroutine -chrono -context -date_time -exception -fiber -graph -iostreams -locale -log -math -mpi -program_options -python -random -regex -test -thread -timer -wave +pic', type='build')
+    depends_on('boost@1.87.0 +system +filesystem -atomic -container -coroutine -chrono -context -date_time -exception -fiber -graph -iostreams -locale -log -math -mpi -program_options -python -random -regex -test -thread -timer -wave +pic', type='build')
 
     depends_on('zlib@1.3 +shared +pic', type='build')
 
@@ -64,7 +64,7 @@ class Spheral(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('silo+python +hdf5', type='build')
 
-    depends_on('chai@develop+raja', type='build')
+    depends_on('chai@2025.12.0+raja', type='build')
 
     depends_on('conduit@0.9.1 +shared +hdf5~hdf5_compat -test ~parmetis', type='build')
 
@@ -110,7 +110,7 @@ class Spheral(CachedCMakePackage, CudaPackage, ROCmPackage):
     for ctpl in debug_tpl_list:
         depends_on(f"{ctpl} build_type=Debug", when="build_type=Debug")
 
-    depends_on('leos@8.4.2+filters+yaml~xml+silo', type='build', when='+leos')
+    depends_on('leos@8.5.2+filters+yaml~xml+silo', type='build', when='+leos')
     depends_on('leos build_type=Debug', when='+leos build_type=Debug')
     # TODO: Get leos working with +rocm variant using 8.5.2
     # if LEOSpresent:

--- a/scripts/spack/packages/spheral/package.py
+++ b/scripts/spack/packages/spheral/package.py
@@ -198,9 +198,9 @@ class Spheral(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_HIP", True))
             entries.append(cmake_cache_string("ROCM_PATH", spec["hip"].prefix))
 
-        if spec.satisfies("%llvm-amdgpu@7.1.0"):
+        if spec.satisfies("%rocmcc@7.1.0"):
             fortran_libs = "FortranRuntime;FortranCommon;FortranDecimal"
-            fortran_lib_dir = os.path.join(spec["llvm-amdgpu"].prefix, "lib/llvm/lib")
+            fortran_lib_dir = os.path.join(spec["rocmcc"].prefix, "lib/llvm/lib")
             entries.append(cmake_cache_string("CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES", fortran_lib_dir))
             entries.append(cmake_cache_string("CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES", fortran_libs))
 

--- a/scripts/spack/packages/umpire/package.py
+++ b/scripts/spack/packages/umpire/package.py
@@ -10,5 +10,7 @@ from spack.pkg.builtin.umpire import Umpire as BuiltinUmpire
 
 class Umpire(BuiltinUmpire):
 
+    version("2025.12.0", tag="v2025.12.0", submodules=False)
     version("2025.03.1", tag="v2025.03.1", submodules=False)
-    depends_on("camp@2025.03.0", type="build")
+    depends_on("camp@2025.12.0", type="build", when="@2025.12.0")
+    depends_on("camp@2025.03.0", type="build", when="@2025.03.0")

--- a/src/Utilities/StrideIterator.hh
+++ b/src/Utilities/StrideIterator.hh
@@ -8,26 +8,59 @@
 #ifndef __Spheral_StrideIterator__
 #define __Spheral_StrideIterator__
 
+#include <cstddef>
 #include <iterator>
+#include <type_traits>
 
 namespace Spheral {
 
 template<typename T, size_t stride>
-class StrideIterator: public std::iterator<std::random_access_iterator_tag, T> {
+class StrideIterator {
 public:
-  StrideIterator(T* ptr): mptr(ptr)                  {}
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type = std::remove_cv_t<T>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = T*;
+  using reference = T&;
 
-  T& operator*()                               const { return *mptr; }
-  StrideIterator& operator++()                       { mptr += stride; return *this; }
-  StrideIterator operator++(int)                     { StrideIterator tmp = *this; ++(*this); return tmp; }
-  StrideIterator& operator--()                       { mptr -= stride; return *this; }
-  StrideIterator operator--(int)                     { StrideIterator tmp = *this; --(*this); return tmp; }
+  constexpr StrideIterator() noexcept: mptr(nullptr) {}
+  constexpr explicit StrideIterator(pointer ptr) noexcept: mptr(ptr) {}
 
-  bool operator==(const StrideIterator& other) const { return mptr == other.mptr; }
-  bool operator!=(const StrideIterator& other) const { return !(*this == other); }
+  template<typename U, typename = std::enable_if_t<std::is_convertible_v<U*, T*>>>
+  constexpr StrideIterator(const StrideIterator<U, stride>& rhs) noexcept:
+    mptr(rhs.mptr) {}
+
+  constexpr reference operator*() const noexcept            { return *mptr; }
+  constexpr pointer operator->() const noexcept             { return mptr; }
+
+  constexpr StrideIterator& operator++() noexcept           { mptr += stride; return *this; }
+  constexpr StrideIterator operator++(int) noexcept         { auto tmp = *this; ++(*this); return tmp; }
+  constexpr StrideIterator& operator--() noexcept           { mptr -= stride; return *this; }
+  constexpr StrideIterator operator--(int) noexcept         { auto tmp = *this; --(*this); return tmp; }
+
+  constexpr StrideIterator& operator+=(difference_type n) noexcept { mptr += n*stride; return *this; }
+  constexpr StrideIterator& operator-=(difference_type n) noexcept { mptr -= n*stride; return *this; }
+  constexpr StrideIterator operator+(difference_type n) const noexcept { auto tmp = *this; return tmp += n; }
+  constexpr StrideIterator operator-(difference_type n) const noexcept { auto tmp = *this; return tmp -= n; }
+
+  constexpr reference operator[](difference_type n) const noexcept  { return *(*this + n); }
+
+  constexpr bool operator==(const StrideIterator& other) const noexcept { return mptr == other.mptr; }
+  constexpr bool operator!=(const StrideIterator& other) const noexcept { return mptr != other.mptr; }
+  constexpr bool operator<(const StrideIterator& other) const noexcept  { return mptr < other.mptr; }
+  constexpr bool operator>(const StrideIterator& other) const noexcept  { return mptr > other.mptr; }
+  constexpr bool operator<=(const StrideIterator& other) const noexcept { return mptr <= other.mptr; }
+  constexpr bool operator>=(const StrideIterator& other) const noexcept { return mptr >= other.mptr; }
+
+  constexpr difference_type operator-(const StrideIterator& other) const noexcept {
+    return (mptr - other.mptr)/static_cast<difference_type>(stride);
+  }
+
+  friend constexpr StrideIterator operator+(difference_type n, StrideIterator it) noexcept { return it += n; }
 
 private:
-  T* mptr;
+  template<typename, size_t> friend class StrideIterator;
+  pointer mptr;
 };
 
 }


### PR DESCRIPTION

# Summary

- This PR is an update.
- It does the following:
  - Updates the following versions:
     - ROCM 6.2.0 to 7.1.0.
     - Boost 1.85.0 to 1.87.0.
     - LEOs 8.4.2 to 8.5.2.
     - Umpire, Camp, and RAJA from 2025.03.0 to 2025.12.0.
     - Chai from a non-version to 2025.12.0. 

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#195)
- [ ] LLNLSpheral PR has passed all tests.

