### PR TITLE
Creating View class for PairwiseField

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,11 @@
-Version X.X.X -- Release date XXX
+Version vYYYY.MM.p -- Release date YYYY-MM-DD
 ==============================================
   * Important Notes:
 
 Notable changes include:
 
   * New features / API changes:
+    * Added view class for PairwiseField (PairwiseFieldView)
 
   * Bug fixes
 

--- a/src/Neighbor/CMakeLists.txt
+++ b/src/Neighbor/CMakeLists.txt
@@ -34,6 +34,7 @@ set(Neighbor_headers
     PairwiseFieldElementAccessor.hh
     PairwiseFieldInline.hh
     PairwiseFieldElementAccessor.hh
+    PairwiseFieldView.hh
     )
 
 spheral_add_obj_library(Neighbor SPHERAL_OBJ_LIBS)

--- a/src/Neighbor/PairwiseField.hh
+++ b/src/Neighbor/PairwiseField.hh
@@ -7,15 +7,11 @@
 //
 // Created by J. Michael Owen, Wed Nov 20 14:44:44 PST 2024
 //----------------------------------------------------------------------------//
-#ifndef _Spheral_NeighborSpace_PairwiseField_hh_
-#define _Spheral_NeighborSpace_PairwiseField_hh_
+#ifndef _Spheral_NeighborSpace_PairwiseField_
+#define _Spheral_NeighborSpace_PairwiseField_
 
-#include "Neighbor/PairwiseFieldElementAccessor.hh"
-#include "Utilities/DataTypeTraits.hh"
-#include "Utilities/StrideIterator.hh"
-#include "Utilities/DBC.hh"
+#include "Neighbor/PairwiseFieldView.hh"
 
-#include <vector>
 #include <memory>
 
 namespace Spheral {
@@ -26,9 +22,11 @@ struct NodePairIdxType;
 class NodePairList;
 
 template<typename Dimension, typename Value, size_t numElements=1>
-class PairwiseField {
+class PairwiseField: public PairwiseFieldView<Dimension, Value, numElements> {
 public:
   //--------------------------- Public Interface ---------------------------//
+  using ViewType = PairwiseFieldView<Dimension, Value, numElements>;
+
   using ContainerType = std::vector<Value>;
   using value_type = typename ContainerType::value_type;
   using SelfType = PairwiseField<Dimension, Value, numElements>;
@@ -38,46 +36,43 @@ public:
   using iterator = StrideIterator<Value, numElements>;
   using const_iterator = StrideIterator<const Value, numElements>;
 
+  // Bring in various methods hidden in PairwiseFieldView
+  using PairwiseFieldView<Dimension, Value, numElements>::operator();
+  using PairwiseFieldView<Dimension, Value, numElements>::operator[];
+
   // Constructors, destructors
   PairwiseField(const ConnectivityMap<Dimension>& connectivity);
-  PairwiseField(const PairwiseField& rhs)                       = default;
-  ~PairwiseField()                                              = default;
-  PairwiseField& operator=(const PairwiseField& rhs)            = default;
+  PairwiseField(const PairwiseField& rhs);
+  virtual ~PairwiseField();
+  PairwiseField& operator=(const PairwiseField& rhs);
 
-  // Access the data
-  const_reference operator[](const size_t k) const              { REQUIRE(!mPairsPtr.expired()); return Accessor::at(mValues, k); }
-  const_reference operator()(const size_t k) const              { return (*this)[k]; }
+  // Access the data using Node pair information
   const_reference operator()(const NodePairIdxType& x) const;
-
-  reference       operator[](const size_t k)                    { REQUIRE(!mPairsPtr.expired()); return Accessor::at(mValues, k); }
-  reference       operator()(const size_t k)                    { return (*this)[k]; }
   reference       operator()(const NodePairIdxType& x);
 
-  // Comparators
-  bool operator==(const PairwiseField& rhs) const               { REQUIRE(!mPairsPtr.expired()); return mValues == rhs.mValues; }
-  bool operator!=(const PairwiseField& rhs) const               { REQUIRE(!mPairsPtr.expired()); return mValues != rhs.mValues; }
-
   // Iterators
-  const_iterator begin() const                                  { REQUIRE(!mPairsPtr.expired()); return const_iterator(&(*mValues.begin())); }
-  const_iterator end() const                                    { REQUIRE(!mPairsPtr.expired()); return const_iterator(&(*mValues.end())); }
+  const_iterator begin() const                                  { REQUIRE(!mPairsPtr.expired()); return const_iterator(&(*mArray.begin())); }
+  const_iterator end() const                                    { REQUIRE(!mPairsPtr.expired()); return const_iterator(&(*mArray.end())); }
 
-  iterator begin()                                              { REQUIRE(!mPairsPtr.expired()); return iterator(&(*mValues.begin())); }
-  iterator end()                                                { REQUIRE(!mPairsPtr.expired()); return iterator(&(*mValues.end())); }
+  iterator begin()                                              { REQUIRE(!mPairsPtr.expired()); return iterator(&(*mArray.begin())); }
+  iterator end()                                                { REQUIRE(!mPairsPtr.expired()); return iterator(&(*mArray.end())); }
 
   // Other methods
   const NodePairList& pairs() const;
-  size_t size() const                                           { REQUIRE(!mPairsPtr.expired()); return mValues.size()/numElements; }
-
-  // Zero the Field
-  void Zero()                                                   { for (auto& x: mValues) x = DataTypeTraits<Value>::zero(); }
+  
+  // Get the view (for trivially copyable types)
+  ViewType view()                                               { return static_cast<ViewType>(*this); }
 
   // Forbidden methods
   PairwiseField()                                               = delete;
 
 private:
   //--------------------------- Private Interface ---------------------------//
+  using PairwiseFieldView<Dimension, Value, numElements>::mSpan;
   std::weak_ptr<NodePairList> mPairsPtr;
-  ContainerType mValues;
+  ContainerType mArray;
+
+  void assignDataSpan();
 };
 
 }

--- a/src/Neighbor/PairwiseField.hh
+++ b/src/Neighbor/PairwiseField.hh
@@ -22,10 +22,10 @@ struct NodePairIdxType;
 class NodePairList;
 
 template<typename Dimension, typename Value, size_t numElements=1>
-class PairwiseField: public PairwiseFieldView<Dimension, Value, numElements> {
+class PairwiseField: public PairwiseFieldView<Value, numElements> {
 public:
   //--------------------------- Public Interface ---------------------------//
-  using ViewType = PairwiseFieldView<Dimension, Value, numElements>;
+  using ViewType = PairwiseFieldView<Value, numElements>;
 
   using ContainerType = std::vector<Value>;
   using value_type = typename ContainerType::value_type;
@@ -37,11 +37,12 @@ public:
   using const_iterator = StrideIterator<const Value, numElements>;
 
   // Bring in various methods hidden in PairwiseFieldView
-  using PairwiseFieldView<Dimension, Value, numElements>::operator();
-  using PairwiseFieldView<Dimension, Value, numElements>::operator[];
+  using ViewType::operator();
+  using ViewType::operator[];
 
   // Constructors, destructors
   PairwiseField(const ConnectivityMap<Dimension>& connectivity);
+  PairwiseField(std::shared_ptr<NodePairList> pairsPtr);
   PairwiseField(const PairwiseField& rhs);
   virtual ~PairwiseField();
   PairwiseField& operator=(const PairwiseField& rhs);
@@ -68,7 +69,7 @@ public:
 
 private:
   //--------------------------- Private Interface ---------------------------//
-  using PairwiseFieldView<Dimension, Value, numElements>::mSpan;
+  using ViewType::mSpan;
   std::weak_ptr<NodePairList> mPairsPtr;
   ContainerType mArray;
 

--- a/src/Neighbor/PairwiseFieldElementAccessor.hh
+++ b/src/Neighbor/PairwiseFieldElementAccessor.hh
@@ -34,8 +34,8 @@ struct ElementAccessor {
   using value_type      = typename ContainerTraits<ContainerType>::value_type*;
   using reference       = typename ContainerTraits<ContainerType>::value_type*;
   using const_reference = const typename ContainerTraits<ContainerType>::value_type*;
-  SPHERAL_HOST_DEVICE static reference        at(      ContainerType& values, const size_t k) { REQUIRE(stride*k < values.size()); return &values[stride*k]; }
-  SPHERAL_HOST_DEVICE static const_reference  at(const ContainerType& values, const size_t k) { REQUIRE(stride*k < values.size()); return &values[stride*k]; }
+  SPHERAL_HOST_DEVICE static reference  at(      ContainerType& values, const size_t k) { REQUIRE(stride*k < values.size()); return &values[stride*k]; }
+  SPHERAL_HOST_DEVICE static reference  at(const ContainerType& values, const size_t k) { REQUIRE(stride*k < values.size()); return &values[stride*k]; }
 };
 
 // When we only have one element per index, return it by reference
@@ -45,8 +45,8 @@ struct ElementAccessor<T, 1u> {
   using value_type      = typename ContainerTraits<ContainerType>::value_type&;
   using reference       = typename ContainerTraits<ContainerType>::value_type&;
   using const_reference = const typename ContainerTraits<ContainerType>::value_type&;
-  SPHERAL_HOST_DEVICE static reference        at(      ContainerType& values, const size_t k) { REQUIRE(k < values.size()); return values[k]; }
-  SPHERAL_HOST_DEVICE static const_reference  at(const ContainerType& values, const size_t k) { REQUIRE(k < values.size()); return values[k]; }
+  SPHERAL_HOST_DEVICE static reference  at(      ContainerType& values, const size_t k) { REQUIRE(k < values.size()); return values[k]; }
+  SPHERAL_HOST_DEVICE static reference  at(const ContainerType& values, const size_t k) { REQUIRE(k < values.size()); return values[k]; }
 };
 
 }

--- a/src/Neighbor/PairwiseFieldElementAccessor.hh
+++ b/src/Neighbor/PairwiseFieldElementAccessor.hh
@@ -11,30 +11,42 @@
 #define _Spheral_NeighborSpace_PairwiseFieldElementAccessor__
 
 #include "Utilities/DBC.hh"
+#include "chai/ManagedArray.hpp"
 
 namespace Spheral {
 namespace PairwiseFieldDetail {
+
+// Trait class to work around missing information in ManagedArray
+template<typename Container>
+struct ContainerTraits {
+  using value_type = typename Container::value_type;
+};
+
+template<typename Value>
+struct ContainerTraits<chai::ManagedArray<Value>> {
+  using value_type = Value;
+};
 
 // General case, returns by pointer
 template<typename T, size_t stride>
 struct ElementAccessor {
   using ContainerType   = typename T::ContainerType;
-  using value_type      = typename ContainerType::value_type*;
-  using reference       = typename ContainerType::value_type*;
-  using const_reference = const typename ContainerType::value_type*;
-  static reference        at(      ContainerType& values, const size_t k) { REQUIRE(stride*k < values.size()); return &values[stride*k]; }
-  static const_reference  at(const ContainerType& values, const size_t k) { REQUIRE(stride*k < values.size()); return &values[stride*k]; }
+  using value_type      = typename ContainerTraits<ContainerType>::value_type*;
+  using reference       = typename ContainerTraits<ContainerType>::value_type*;
+  using const_reference = const typename ContainerTraits<ContainerType>::value_type*;
+  SPHERAL_HOST_DEVICE static reference        at(      ContainerType& values, const size_t k) { REQUIRE(stride*k < values.size()); return &values[stride*k]; }
+  SPHERAL_HOST_DEVICE static const_reference  at(const ContainerType& values, const size_t k) { REQUIRE(stride*k < values.size()); return &values[stride*k]; }
 };
 
 // When we only have one element per index, return it by reference
 template<typename T>
 struct ElementAccessor<T, 1u> {
   using ContainerType   = typename T::ContainerType;
-  using value_type      = typename ContainerType::value_type&;
-  using reference       = typename ContainerType::value_type&;
-  using const_reference = const typename ContainerType::value_type&;
-  static reference        at(      ContainerType& values, const size_t k) { REQUIRE(k < values.size()); return values[k]; }
-  static const_reference  at(const ContainerType& values, const size_t k) { REQUIRE(k < values.size()); return values[k]; }
+  using value_type      = typename ContainerTraits<ContainerType>::value_type&;
+  using reference       = typename ContainerTraits<ContainerType>::value_type&;
+  using const_reference = const typename ContainerTraits<ContainerType>::value_type&;
+  SPHERAL_HOST_DEVICE static reference        at(      ContainerType& values, const size_t k) { REQUIRE(k < values.size()); return values[k]; }
+  SPHERAL_HOST_DEVICE static const_reference  at(const ContainerType& values, const size_t k) { REQUIRE(k < values.size()); return values[k]; }
 };
 
 }

--- a/src/Neighbor/PairwiseFieldInline.hh
+++ b/src/Neighbor/PairwiseFieldInline.hh
@@ -13,12 +13,20 @@
 namespace Spheral {
 
 //------------------------------------------------------------------------------
-// Constructor
+// Constructor (connectivity)
 //------------------------------------------------------------------------------
 template<typename Dimension, typename Value, size_t numElements>
 PairwiseField<Dimension, Value, numElements>::PairwiseField(const ConnectivityMap<Dimension>& connectivity):
-  PairwiseFieldView<Dimension, Value, numElements>(),
-  mPairsPtr(connectivity.nodePairListPtr()),
+  PairwiseField<Dimension, Value, numElements>(connectivity.nodePairListPtr()) {
+}
+
+//------------------------------------------------------------------------------
+// Constructor (pairs)
+//------------------------------------------------------------------------------
+template<typename Dimension, typename Value, size_t numElements>
+PairwiseField<Dimension, Value, numElements>::PairwiseField(std::shared_ptr<NodePairList> pairsPtr):
+  PairwiseFieldView<Value, numElements>(),
+  mPairsPtr(pairsPtr),
   mArray() {
   if (auto p = mPairsPtr.lock()) {
     mArray.resize(numElements * p->size());
@@ -36,7 +44,7 @@ PairwiseField<Dimension, Value, numElements>::PairwiseField(const ConnectivityMa
 template<typename Dimension, typename Value, size_t numElements>
 inline
 PairwiseField<Dimension, Value, numElements>::PairwiseField(const PairwiseField& rhs):
-  PairwiseFieldView<Dimension, Value, numElements>(),
+  PairwiseFieldView<Value, numElements>(),
   mPairsPtr(rhs.mPairsPtr),
   mArray(rhs.mArray) {
   assignDataSpan();

--- a/src/Neighbor/PairwiseFieldInline.hh
+++ b/src/Neighbor/PairwiseFieldInline.hh
@@ -17,13 +17,58 @@ namespace Spheral {
 //------------------------------------------------------------------------------
 template<typename Dimension, typename Value, size_t numElements>
 PairwiseField<Dimension, Value, numElements>::PairwiseField(const ConnectivityMap<Dimension>& connectivity):
+  PairwiseFieldView<Dimension, Value, numElements>(),
   mPairsPtr(connectivity.nodePairListPtr()),
-  mValues() {
+  mArray() {
   if (auto p = mPairsPtr.lock()) {
-    mValues.resize(numElements * p->size());
+    mArray.resize(numElements * p->size());
   } else {
     VERIFY2(false, "PairwiseField constructed with invalid NodePairList");
   }
+  assignDataSpan();
+}
+
+//------------------------------------------------------------------------------
+// Copy Constructor.
+// Note we deliberately do not use the View copy constructor here, but
+// instead reassign its span view in our own assignDataSpan call.
+//------------------------------------------------------------------------------
+template<typename Dimension, typename Value, size_t numElements>
+inline
+PairwiseField<Dimension, Value, numElements>::PairwiseField(const PairwiseField& rhs):
+  PairwiseFieldView<Dimension, Value, numElements>(),
+  mPairsPtr(rhs.mPairsPtr),
+  mArray(rhs.mArray) {
+  assignDataSpan();
+  DEBUG_LOG << "PairwiseField::copy : " << rhs.mArray.data() << " -> " << mArray.data() << " : " << rhs.mSpan.data() << " -> " << mSpan.data();
+}
+
+//------------------------------------------------------------------------------
+// Destructor
+//------------------------------------------------------------------------------
+template<typename Dimension, typename Value, size_t numElements>
+inline
+PairwiseField<Dimension, Value, numElements>::
+~PairwiseField() {
+  DEBUG_LOG << " --> PairwiseField::~PairwiseField() " << this;
+#ifndef SPHERAL_UNIFIED_MEMORY
+  mSpan.free();
+#endif
+}
+
+//------------------------------------------------------------------------------
+// Assignment operator
+//------------------------------------------------------------------------------
+template<typename Dimension, typename Value, size_t numElements>
+inline
+PairwiseField<Dimension, Value, numElements>&
+PairwiseField<Dimension, Value, numElements>::operator=(const PairwiseField& rhs) {
+  if (this != &rhs) {
+    mArray = rhs.mArray;
+    assignDataSpan();
+  }
+  DEBUG_LOG << "PairwiseField::assign : " << rhs.mArray.data() << " -> " << mArray.data() << " : " << rhs.mSpan.data() << " -> " <<  mSpan.data();
+  return *this;
 }
 
 //------------------------------------------------------------------------------
@@ -37,7 +82,7 @@ PairwiseField<Dimension, Value, numElements>::operator()(const NodePairIdxType& 
   if (!p) {
     VERIFY2(false, "PairwiseField ERROR: attempt to index with invalid pair " << x);
   }
-  return Accessor::at(mValues, p->index(x));
+  return Accessor::at(mArray, p->index(x));
 }
 
 template<typename Dimension, typename Value, size_t numElements>
@@ -48,7 +93,7 @@ PairwiseField<Dimension, Value, numElements>::operator()(const NodePairIdxType& 
   if (!p) {
     VERIFY2(false, "PairwiseField ERROR: attempt to index with invalid pair " << x);
   }
-  return Accessor::at(mValues, p->index(x));
+  return Accessor::at(mArray, p->index(x));
 }
 
 //------------------------------------------------------------------------------
@@ -63,6 +108,26 @@ PairwiseField<Dimension, Value, numElements>::pairs() const {
     VERIFY2(false, "Orphaned PairwiseField without NodePairList");
   }
   return *p;
+}
+
+//------------------------------------------------------------------------------
+// Assign the view span
+//------------------------------------------------------------------------------
+template<typename Dimension, typename Value, size_t numElements>
+inline
+void
+PairwiseField<Dimension, Value, numElements>::assignDataSpan() {
+#ifdef SPHERAL_UNIFIED_MEMORY
+  mSpan = mArray;
+#else
+  if (mSpan.size() != mArray.size() or
+      mSpan.data(chai::CPU, false) != mArray.data()) {
+    DEBUG_LOG << "PairwiseField::assignDataSpan " << this;
+    initMAView(mSpan, mArray);
+  }
+  mSpan.registerTouch(chai::CPU);
+#endif
+  ENSURE(mSpan.size() == mArray.size() and (mArray.empty() or mSpan.data() == &mArray[0]));
 }
 
 }

--- a/src/Neighbor/PairwiseFieldView.hh
+++ b/src/Neighbor/PairwiseFieldView.hh
@@ -1,0 +1,81 @@
+//---------------------------------Spheral++----------------------------------//
+// PairwiseFieldView -- view class for PairwiseField
+//
+// Stores a value per node pair in a NodePairList. Because connectivity is
+// allowed to change step to step in our meshfree methods, PairwiseField is
+// ephemeral and will be invalidated when topology is updated.
+//
+// Created by J. Michael Owen, Wed Nov 20 14:44:44 PST 2024
+//----------------------------------------------------------------------------//
+#ifndef _Spheral_NeighborSpace_PairwiseFieldView_
+#define _Spheral_NeighborSpace_PairwiseFieldView_
+
+#include "Neighbor/PairwiseFieldElementAccessor.hh"
+#include "Utilities/DataTypeTraits.hh"
+#include "Utilities/StrideIterator.hh"
+#include "Utilities/DBC.hh"
+
+#include "chai/ManagedArray.hpp"
+#include "chai/ExecutionSpaces.hpp"
+
+#ifdef SPHERAL_UNIFIED_MEMORY
+#include "Utilities/span.hh"
+#endif
+
+namespace Spheral {
+
+// Forward declarations
+struct NodePairIdxType;
+
+template<typename Dimension, typename Value, size_t numElements=1>
+class PairwiseFieldView {
+public:
+  //--------------------------- Public Interface ---------------------------//
+#ifdef SPHERAL_UNIFIED_MEMORY
+  using ContainerType = SPHERAL_SPAN_TYPE<Value>;
+  using value_type = typename ContainerType::value_type;
+#else
+  using ContainerType = typename chai::ManagedArray<Value>;
+  using value_type = Value;
+#endif
+  
+  using SelfType = PairwiseFieldView<Dimension, Value, numElements>;
+  using Accessor = PairwiseFieldDetail::ElementAccessor<SelfType, numElements>;
+  using reference = typename Accessor::reference;
+  using const_reference = typename Accessor::const_reference;
+  using iterator = StrideIterator<Value, numElements>;
+  using const_iterator = StrideIterator<const Value, numElements>;
+
+  // Constructors, destructors
+  SPHERAL_HOST_DEVICE PairwiseFieldView()                                           = default;
+  SPHERAL_HOST_DEVICE PairwiseFieldView(const PairwiseFieldView& rhs)               = default;
+  SPHERAL_HOST_DEVICE PairwiseFieldView(PairwiseFieldView&& rhs)                    = default;
+  SPHERAL_HOST_DEVICE virtual ~PairwiseFieldView()                                  = default;
+  SPHERAL_HOST_DEVICE PairwiseFieldView& operator=(const PairwiseFieldView& rhs)    = default;
+
+  // Access the data
+  SPHERAL_HOST_DEVICE const_reference operator[](const size_t k) const              { return Accessor::at(mSpan, k); }
+  SPHERAL_HOST_DEVICE const_reference operator()(const size_t k) const              { return (*this)[k]; }
+
+  SPHERAL_HOST_DEVICE reference       operator[](const size_t k)                    { return Accessor::at(mSpan, k); }
+  SPHERAL_HOST_DEVICE reference       operator()(const size_t k)                    { return (*this)[k]; }
+
+  // Comparators
+  SPHERAL_HOST_DEVICE bool operator==(const PairwiseFieldView& rhs) const           { return mSpan == rhs.mSpan; }
+  SPHERAL_HOST_DEVICE bool operator!=(const PairwiseFieldView& rhs) const           { return mSpan != rhs.mSpan; }
+
+  // Other methods
+  SPHERAL_HOST_DEVICE size_t size() const                                           { return mSpan.size()/numElements; }
+
+  // Zero the Field
+  SPHERAL_HOST_DEVICE void Zero()                                                   { for (auto& x: mSpan) x = DataTypeTraits<Value>::zero(); }
+
+protected:
+  //--------------------------- Protected Interface ---------------------------//
+  ContainerType mSpan;
+};
+
+}
+
+#endif
+

--- a/src/Neighbor/PairwiseFieldView.hh
+++ b/src/Neighbor/PairwiseFieldView.hh
@@ -27,7 +27,7 @@ namespace Spheral {
 // Forward declarations
 struct NodePairIdxType;
 
-template<typename Dimension, typename Value, size_t numElements=1>
+template<typename Value, size_t numElements=1>
 class PairwiseFieldView {
 public:
   //--------------------------- Public Interface ---------------------------//
@@ -39,7 +39,7 @@ public:
   using value_type = Value;
 #endif
   
-  using SelfType = PairwiseFieldView<Dimension, Value, numElements>;
+  using SelfType = PairwiseFieldView<Value, numElements>;
   using Accessor = PairwiseFieldDetail::ElementAccessor<SelfType, numElements>;
   using reference = typename Accessor::reference;
   using const_reference = typename Accessor::const_reference;

--- a/src/Neighbor/PairwiseFieldView.hh
+++ b/src/Neighbor/PairwiseFieldView.hh
@@ -54,11 +54,11 @@ public:
   SPHERAL_HOST_DEVICE PairwiseFieldView& operator=(const PairwiseFieldView& rhs)    = default;
 
   // Access the data
-  SPHERAL_HOST_DEVICE const_reference operator[](const size_t k) const              { return Accessor::at(mSpan, k); }
-  SPHERAL_HOST_DEVICE const_reference operator()(const size_t k) const              { return (*this)[k]; }
+  SPHERAL_HOST_DEVICE reference operator[](const size_t k) const                    { return Accessor::at(mSpan, k); }
+  SPHERAL_HOST_DEVICE reference operator()(const size_t k) const                    { return (*this)[k]; }
 
-  SPHERAL_HOST_DEVICE reference       operator[](const size_t k)                    { return Accessor::at(mSpan, k); }
-  SPHERAL_HOST_DEVICE reference       operator()(const size_t k)                    { return (*this)[k]; }
+  SPHERAL_HOST_DEVICE reference operator[](const size_t k)                          { return Accessor::at(mSpan, k); }
+  SPHERAL_HOST_DEVICE reference operator()(const size_t k)                          { return (*this)[k]; }
 
   // Comparators
   SPHERAL_HOST_DEVICE bool operator==(const PairwiseFieldView& rhs) const           { return mSpan == rhs.mSpan; }

--- a/src/Utilities/StrideIterator.hh
+++ b/src/Utilities/StrideIterator.hh
@@ -15,16 +15,16 @@ namespace Spheral {
 template<typename T, size_t stride>
 class StrideIterator: public std::iterator<std::random_access_iterator_tag, T> {
 public:
-  StrideIterator(T* ptr): mptr(ptr)                  {}
+  SPHERAL_HOST_DEVICE StrideIterator(T* ptr): mptr(ptr)                  {}
 
-  T& operator*()                               const { return *mptr; }
-  StrideIterator& operator++()                       { mptr += stride; return *this; }
-  StrideIterator operator++(int)                     { StrideIterator tmp = *this; ++(*this); return tmp; }
-  StrideIterator& operator--()                       { mptr -= stride; return *this; }
-  StrideIterator operator--(int)                     { StrideIterator tmp = *this; --(*this); return tmp; }
+  SPHERAL_HOST_DEVICE T& operator*()                               const { return *mptr; }
+  SPHERAL_HOST_DEVICE StrideIterator& operator++()                       { mptr += stride; return *this; }
+  SPHERAL_HOST_DEVICE StrideIterator operator++(int)                     { StrideIterator tmp = *this; ++(*this); return tmp; }
+  SPHERAL_HOST_DEVICE StrideIterator& operator--()                       { mptr -= stride; return *this; }
+  SPHERAL_HOST_DEVICE StrideIterator operator--(int)                     { StrideIterator tmp = *this; --(*this); return tmp; }
 
-  bool operator==(const StrideIterator& other) const { return mptr == other.mptr; }
-  bool operator!=(const StrideIterator& other) const { return !(*this == other); }
+  SPHERAL_HOST_DEVICE bool operator==(const StrideIterator& other) const { return mptr == other.mptr; }
+  SPHERAL_HOST_DEVICE bool operator!=(const StrideIterator& other) const { return !(*this == other); }
 
 private:
   T* mptr;

--- a/tests/cpp/Neighbor/CMakeLists.txt
+++ b/tests/cpp/Neighbor/CMakeLists.txt
@@ -4,3 +4,10 @@ spheral_add_test(
   DEPENDS_ON Spheral_Utilities Spheral_Neighbor chai
   #DEBUG_LINKER #In case it has unresolved symbols
 )
+
+spheral_add_test(
+  NAME pairwisefieldview_test
+  SOURCES pairwisefieldview_tests.cc
+  DEPENDS_ON Spheral_Utilities Spheral_Neighbor chai
+  #DEBUG_LINKER #In case it has unresolved symbols
+)

--- a/tests/cpp/Neighbor/pairwisefieldview_tests.cc
+++ b/tests/cpp/Neighbor/pairwisefieldview_tests.cc
@@ -29,7 +29,7 @@ using PairwiseFieldDoubleDouble = Spheral::PairwiseField<DIM3, double, 2u>;
 using PairwiseFieldViewDoubleDouble = Spheral::PairwiseFieldView<double, 2u>;
 
 // Default Testing Size.
-static constexpr int N = 1000;
+static constexpr int N = 5;
 
 // PairwiseFieldViewTest is constructed at the start of each unit test.
 class PairwiseFieldViewTest : public ::testing::Test {
@@ -111,160 +111,95 @@ GPU_TYPED_TEST_P(PairwiseFieldViewTypedTest, ExecutionSpaceCapture) {
   } // field and any GPU allocation should be released here.
 }
 
-// //------------------------------------------------------------------------------
-// // This test ensures the FieldView Data is migrated back and forth between
-// // RAJA execution spaces through implicit capture.
-// //------------------------------------------------------------------------------
-// GPU_TYPED_TEST_P(FieldViewTypedTest, MultiSpaceCapture) {
-//   using WORK_EXEC_POLICY = TypeParam;
-//   {
-//     FieldDouble field("MultiSpaceCapture", gpu_this->nl, 4.0);
-//     field.setCallback(gpu_this->callback());
+//------------------------------------------------------------------------------
+// This test ensures the PairwiseFieldView Data is migrated back and forth between
+// RAJA execution spaces through implicit capture.
+//------------------------------------------------------------------------------
+GPU_TYPED_TEST_P(PairwiseFieldViewTypedTest, MultiSpaceCapture) {
+  using WORK_EXEC_POLICY = TypeParam;
+  {
+    auto pairs = gpu_this->createNPL();
+    SPHERAL_ASSERT_EQ(pairs->size(), N);
 
-//     // Setup Field Data w/ iota values.
-//     std::vector<double> data(N);
-//     std::iota(data.begin(), data.end(), 0.0);
-//     field = data;
+    PairwiseFieldDouble dfield(pairs);
+    SPHERAL_ASSERT_EQ(dfield.size(), N);
 
-//     auto field_v = field.view();
+    // Fill in known values for the pairwise fields
+    for (auto i = 0u; i < N; ++i) {
+      dfield[i] = 10.0 * i;
+    }
 
-//     // Execute in working execution space.
-//     RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
-//        [=] SPHERAL_HOST_DEVICE (int i) {
-//          field_v[i] *= 2;
-//        });
+    auto dfield_v = dfield.view();
+    SPHERAL_ASSERT_EQ(dfield_v.size(), N);
 
-//     // Execute in a CPU execution space.
-//     RAJA::forall<LOOP_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
-//        [=, &field](int i) {
-//          SPHERAL_ASSERT_EQ(field_v[i], i * 2);
-//          SPHERAL_ASSERT_EQ(field[i], i * 2);
-//        });
+    // Execute in working execution space.
+    RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, dfield.size()),
+       [=] SPHERAL_HOST_DEVICE (int i) {
+         dfield_v[i] *= 2;
+       });
 
-//   } // field and any GPU allocation should be released here.
+    // Execute in a CPU execution space.
+    RAJA::forall<LOOP_EXEC_POLICY>(TRS_UINT(0, dfield.size()),
+       [=, &dfield](int i) {
+         SPHERAL_ASSERT_EQ(dfield_v[i], i * 20.0);
+         SPHERAL_ASSERT_EQ(dfield[i], i * 20.0);
+       });
 
-//   GPUCounters ref_count;
-//   if (typeid(WORK_EXEC_POLICY) != typeid(SEQ_EXEC_POLICY)) {
-//     ref_count.HToDCopies = 1;
-//     ref_count.DToHCopies = 1;
-//     ref_count.DNumAlloc = 1;
-//     ref_count.DNumFree = 1;
-//   }
+  } // field and any GPU allocation should be released here.
+}
 
-//   COMP_COUNTERS(gpu_this->gcounts, ref_count);
-// }
+//------------------------------------------------------------------------------
+// Test the multi-view semantics for a copy. If multiple views are made from a
+// single PairwiseField then only one copy should be performed as both views will reference
+// the same data.
+//------------------------------------------------------------------------------
+GPU_TYPED_TEST_P(PairwiseFieldViewTypedTest, MultiViewSemantics) {
+  using WORK_EXEC_POLICY = TypeParam;
+  {
+    auto pairs = gpu_this->createNPL();
+    SPHERAL_ASSERT_EQ(pairs->size(), N);
 
-// //------------------------------------------------------------------------------
-// // Test the multi-view semantics for a copy. If multiple views are made from a
-// // single Field then only one copy should be performed as both views will reference
-// // the same data.
-// //------------------------------------------------------------------------------
-// GPU_TYPED_TEST_P(FieldViewTypedTest, MultiViewSemantics) {
-//   const double val = 4.;
-//   using WORK_EXEC_POLICY = TypeParam;
-//   {
-//     FieldDouble field("MultiViewSemantics", gpu_this->nl, val);
-//     field.setCallback(gpu_this->callback());
-//     SPHERAL_ASSERT_EQ(field.numElements(), N);
+    PairwiseFieldDouble field(pairs);
+    SPHERAL_ASSERT_EQ(field.size(), N);
 
-//     // Retreive multiple FieldViews from a Single Field.
-//     auto field_v0 = field.view();
-//     auto field_v1 = field.view();
-//     auto field_v2 = field.view();
-//     auto field_v3 = field.view();
-//     auto field_v4 = field.view();
-//     auto field_v5 = field.view();
-//     auto field_v6 = field.view();
-//     auto field_v7 = field.view();
-//     auto field_v8 = field.view();
-//     auto field_v9 = field.view();
+    // Fill in known values for the pairwise fields
+    for (auto i = 0u; i < N; ++i) {
+      field[i] = 10.0 * i;
+    }
 
-//     // Capture and execute on all FieldView objs in the working space.
-//     RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
-//        [=] SPHERAL_HOST_DEVICE (int i) {
-//          SPHERAL_ASSERT_EQ(field_v0[i], val);
-//          SPHERAL_ASSERT_EQ(field_v1[i], val);
-//          SPHERAL_ASSERT_EQ(field_v2[i], val);
-//          SPHERAL_ASSERT_EQ(field_v3[i], val);
-//          SPHERAL_ASSERT_EQ(field_v4[i], val);
-//          SPHERAL_ASSERT_EQ(field_v5[i], val);
-//          SPHERAL_ASSERT_EQ(field_v6[i], val);
-//          SPHERAL_ASSERT_EQ(field_v7[i], val);
-//          SPHERAL_ASSERT_EQ(field_v8[i], val);
-//          SPHERAL_ASSERT_EQ(field_v9[i], val);
-//        });
+    // Retreive multiple FieldViews from a Single Field.
+    auto field_v0 = field.view();
+    auto field_v1 = field.view();
+    auto field_v2 = field.view();
+    auto field_v3 = field.view();
+    auto field_v4 = field.view();
+    auto field_v5 = field.view();
+    auto field_v6 = field.view();
+    auto field_v7 = field.view();
+    auto field_v8 = field.view();
+    auto field_v9 = field.view();
 
-//   } // field and any GPU allocation should be released here.
+    // Capture and execute on all PairwiseFieldView objs in the working space.
+    RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, field.size()),
+       [=] SPHERAL_HOST_DEVICE (int i) {
+         SPHERAL_ASSERT_EQ(field_v0[i], 10.0 * i);
+         SPHERAL_ASSERT_EQ(field_v1[i], 10.0 * i);
+         SPHERAL_ASSERT_EQ(field_v2[i], 10.0 * i);
+         SPHERAL_ASSERT_EQ(field_v3[i], 10.0 * i);
+         SPHERAL_ASSERT_EQ(field_v4[i], 10.0 * i);
+         SPHERAL_ASSERT_EQ(field_v5[i], 10.0 * i);
+         SPHERAL_ASSERT_EQ(field_v6[i], 10.0 * i);
+         SPHERAL_ASSERT_EQ(field_v7[i], 10.0 * i);
+         SPHERAL_ASSERT_EQ(field_v8[i], 10.0 * i);
+         SPHERAL_ASSERT_EQ(field_v9[i], 10.0 * i);
+       });
 
-//   GPUCounters ref_count;
-//   if (typeid(WORK_EXEC_POLICY) != typeid(SEQ_EXEC_POLICY)) {
-//     ref_count.HToDCopies = 1;
-//     ref_count.DNumAlloc = 1;
-//     ref_count.DNumFree = 1;
-//   }
-
-//   COMP_COUNTERS(gpu_this->gcounts, ref_count);
-// }
+  } // field and any GPU allocation should be released here.
+}
 
 
-// //------------------------------------------------------------------------------
-// // Resize the field after a copy to the execution space. The Second view
-// // Call should trigger a free of any GPU memory and reassign the FieldView
-// // CPU pointer to the underlying vectors new address. This test should expect
-// // two allocations, two copies to the device and two deallocations on the
-// // device.
-// //------------------------------------------------------------------------------
-// GPU_TYPED_TEST_P(FieldViewTypedTest, ResizeField) {
-//   using WORK_EXEC_POLICY = TypeParam;
-//   {
-//     const double val = 4.0;
-//     FieldDouble field("ResizeField", gpu_this->nl, val);
-//     field.setCallback(gpu_this->callback());
-//     SPHERAL_ASSERT_EQ(field.numElements(), N);
-
-//     auto field_v = field.view();
-//     SPHERAL_ASSERT_EQ(field_v.numElements(), N);
-
-//     // Capture the FieldView in the working execution space.
-//     RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
-//        [=] SPHERAL_HOST_DEVICE (int i) {
-//          SPHERAL_ASSERT_EQ(field_v[i], val);
-//        });
-
-//     // We shouldn't have any ghost nodes, but we double check here.
-//     SPHERAL_ASSERT_EQ(field.numInternalElements(), field.numElements());
-
-//     // Resize the NodeList to 10x the original size.
-//     gpu_this->nl.numInternalNodes(N * 10);
-
-//     // Assign field_v again. This should trigger a deallocation of the original
-//     // GPU data.
-//     field_v = field.view();
-//     SPHERAL_ASSERT_EQ(field_v.numElements(), N * 10);
-
-//     // Capture field_v in the working execution space again. This should trigger
-//     // a new copy to the Device if executing on the GPU.
-//     RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
-//        [=] SPHERAL_HOST_DEVICE(int i) {
-//          if (i < N) {SPHERAL_ASSERT_EQ(field_v[i], val);}
-//          else { SPHERAL_ASSERT_EQ(field_v[i], 0); }
-//        });
-
-//     SPHERAL_ASSERT_EQ(field.numElements(), N * 10);
-
-//   } // field and any GPU allocation should be released here.
-
-//   GPUCounters ref_count;
-//   if (typeid(WORK_EXEC_POLICY) != typeid(SEQ_EXEC_POLICY)) {
-//     ref_count.HToDCopies = 2;
-//     ref_count.DNumAlloc = 2;
-//     ref_count.DNumFree = 2;
-//   }
-
-//   COMP_COUNTERS(gpu_this->gcounts, ref_count);
-// }
-
-REGISTER_TYPED_TEST_SUITE_P(PairwiseFieldViewTypedTest, ExecutionSpaceCapture);
+REGISTER_TYPED_TEST_SUITE_P(PairwiseFieldViewTypedTest,
+                            ExecutionSpaceCapture, MultiSpaceCapture, MultiViewSemantics);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Field, PairwiseFieldViewTypedTest,
                                typename Spheral::Test<EXEC_TYPES>::Types, );

--- a/tests/cpp/Neighbor/pairwisefieldview_tests.cc
+++ b/tests/cpp/Neighbor/pairwisefieldview_tests.cc
@@ -1,0 +1,271 @@
+// Debug log printing can be quickly enabled for this unit test by uncommenting the
+// definition below even if Spheral was not configured w/ SPHERAL_ENABLE_LOGGER=On.
+// #define SPHERAL_ENABLE_LOGGER
+
+#include "chai/ExecutionSpaces.hpp"
+#include "test-basic-exec-policies.hh"
+#include "test-utilities.hh"
+
+#include "Field/Field.hh"
+#include "Neighbor/NodePairList.hh"
+#include "Neighbor/PairwiseField.hh"
+
+#include <random>
+#include <memory>
+
+//------------------------------------------------------------------------------
+// These are unit tests for Spheral::PairwiseFieldView with a basic double datatype.
+// Spheral::PairwiseFieldView is a host/device capable. It is tested using typed
+// tests to check for correct execution on both host and device.
+//------------------------------------------------------------------------------
+using DIM3 = Spheral::Dim<3>;
+using NPIT = Spheral::NodePairIdxType;
+using NPLV = Spheral::NodePairListView;
+using NPL = Spheral::NodePairList;
+using NPLVec = std::vector<Spheral::NodePairIdxType>;
+using PairwiseFieldDouble = Spheral::PairwiseField<DIM3, double, 1u>;
+using PairwiseFieldViewDouble = Spheral::PairwiseFieldView<double, 1u>;
+using PairwiseFieldDoubleDouble = Spheral::PairwiseField<DIM3, double, 2u>;
+using PairwiseFieldViewDoubleDouble = Spheral::PairwiseFieldView<double, 2u>;
+
+// Default Testing Size.
+static constexpr int N = 1000;
+
+// PairwiseFieldViewTest is constructed at the start of each unit test.
+class PairwiseFieldViewTest : public ::testing::Test {
+public:
+  GPUCounters gcounts;
+
+  // Build a NodePairList
+  std::shared_ptr<NPL> createNPL(const size_t count = N) {
+    std::random_device rd;
+    std::mt19937 gen(rd()); 
+    std::uniform_int_distribution<size_t> dist(0u, count);
+    NPLVec vals(count);
+    {
+      size_t i = 0u;
+      while (i < count) {
+        vals[i] = NPIT(dist(gen), dist(gen), dist(gen), dist(gen));
+        if ((vals[i].i_list != vals[i].j_list) or
+            (vals[i].i_node != vals[i].j_node)) ++i;
+      }
+    }
+    return std::make_shared<NPL>(vals);
+  }
+  
+  // Increment variables for each action and space
+  auto callback() {
+    return [&](const chai::PointerRecord *, chai::Action action,
+               chai::ExecutionSpace space) {
+    if (action == chai::ACTION_MOVE)
+      (space == chai::CPU) ? gcounts.DToHCopies++ : gcounts.HToDCopies++;
+    if (action == chai::ACTION_ALLOC)
+      (space == chai::CPU) ? gcounts.HNumAlloc++ : gcounts.DNumAlloc++;
+    if (action == chai::ACTION_FREE)
+      (space == chai::CPU) ? gcounts.HNumFree++ : gcounts.DNumFree++;
+    };
+  }
+};
+
+// Setting up Templated Test for PairwiseFieldView
+TYPED_TEST_SUITE_P(PairwiseFieldViewTypedTest);
+template <typename T> class PairwiseFieldViewTypedTest : public PairwiseFieldViewTest {};
+
+
+//------------------------------------------------------------------------------
+// Host/Device test for the PairwiseFieldView being captured in a RAJA execution space.
+// GPU execution spaces should trigger an allocation on the device, a copy from
+// the host to the device, and a deallocation when the Field Dtor is triggered.
+//------------------------------------------------------------------------------
+GPU_TYPED_TEST_P(PairwiseFieldViewTypedTest, ExecutionSpaceCapture) {
+  using WORK_EXEC_POLICY = TypeParam;
+  {
+    auto pairs = gpu_this->createNPL();
+    SPHERAL_ASSERT_EQ(pairs->size(), N);
+
+    PairwiseFieldDouble dfield(pairs);
+    PairwiseFieldDoubleDouble ddfield(pairs);
+    SPHERAL_ASSERT_EQ(dfield.size(), N);
+    SPHERAL_ASSERT_EQ(ddfield.size(), N);
+
+    auto dfield_v = dfield.view();
+    auto ddfield_v = ddfield.view();
+    SPHERAL_ASSERT_EQ(dfield_v.size(), N);
+    SPHERAL_ASSERT_EQ(ddfield_v.size(), N);
+
+    // Fill in known values for the pairwise fields
+    for (auto i = 0u; i < N; ++i) {
+      dfield_v[i] = 0.0;
+      ddfield_v[i][0] = 0.0;
+      ddfield_v[i][1] = 1.0;
+    }
+
+    // Check the values in a RAJA loop
+    RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, N),
+       [=] SPHERAL_HOST_DEVICE (size_t i) {
+         SPHERAL_ASSERT_EQ(dfield_v[i], 0.0);
+         SPHERAL_ASSERT_EQ(ddfield_v[i][0], 0.0);
+         SPHERAL_ASSERT_EQ(ddfield_v[i][1], 1.0);
+       });
+
+  } // field and any GPU allocation should be released here.
+}
+
+// //------------------------------------------------------------------------------
+// // This test ensures the FieldView Data is migrated back and forth between
+// // RAJA execution spaces through implicit capture.
+// //------------------------------------------------------------------------------
+// GPU_TYPED_TEST_P(FieldViewTypedTest, MultiSpaceCapture) {
+//   using WORK_EXEC_POLICY = TypeParam;
+//   {
+//     FieldDouble field("MultiSpaceCapture", gpu_this->nl, 4.0);
+//     field.setCallback(gpu_this->callback());
+
+//     // Setup Field Data w/ iota values.
+//     std::vector<double> data(N);
+//     std::iota(data.begin(), data.end(), 0.0);
+//     field = data;
+
+//     auto field_v = field.view();
+
+//     // Execute in working execution space.
+//     RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
+//        [=] SPHERAL_HOST_DEVICE (int i) {
+//          field_v[i] *= 2;
+//        });
+
+//     // Execute in a CPU execution space.
+//     RAJA::forall<LOOP_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
+//        [=, &field](int i) {
+//          SPHERAL_ASSERT_EQ(field_v[i], i * 2);
+//          SPHERAL_ASSERT_EQ(field[i], i * 2);
+//        });
+
+//   } // field and any GPU allocation should be released here.
+
+//   GPUCounters ref_count;
+//   if (typeid(WORK_EXEC_POLICY) != typeid(SEQ_EXEC_POLICY)) {
+//     ref_count.HToDCopies = 1;
+//     ref_count.DToHCopies = 1;
+//     ref_count.DNumAlloc = 1;
+//     ref_count.DNumFree = 1;
+//   }
+
+//   COMP_COUNTERS(gpu_this->gcounts, ref_count);
+// }
+
+// //------------------------------------------------------------------------------
+// // Test the multi-view semantics for a copy. If multiple views are made from a
+// // single Field then only one copy should be performed as both views will reference
+// // the same data.
+// //------------------------------------------------------------------------------
+// GPU_TYPED_TEST_P(FieldViewTypedTest, MultiViewSemantics) {
+//   const double val = 4.;
+//   using WORK_EXEC_POLICY = TypeParam;
+//   {
+//     FieldDouble field("MultiViewSemantics", gpu_this->nl, val);
+//     field.setCallback(gpu_this->callback());
+//     SPHERAL_ASSERT_EQ(field.numElements(), N);
+
+//     // Retreive multiple FieldViews from a Single Field.
+//     auto field_v0 = field.view();
+//     auto field_v1 = field.view();
+//     auto field_v2 = field.view();
+//     auto field_v3 = field.view();
+//     auto field_v4 = field.view();
+//     auto field_v5 = field.view();
+//     auto field_v6 = field.view();
+//     auto field_v7 = field.view();
+//     auto field_v8 = field.view();
+//     auto field_v9 = field.view();
+
+//     // Capture and execute on all FieldView objs in the working space.
+//     RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
+//        [=] SPHERAL_HOST_DEVICE (int i) {
+//          SPHERAL_ASSERT_EQ(field_v0[i], val);
+//          SPHERAL_ASSERT_EQ(field_v1[i], val);
+//          SPHERAL_ASSERT_EQ(field_v2[i], val);
+//          SPHERAL_ASSERT_EQ(field_v3[i], val);
+//          SPHERAL_ASSERT_EQ(field_v4[i], val);
+//          SPHERAL_ASSERT_EQ(field_v5[i], val);
+//          SPHERAL_ASSERT_EQ(field_v6[i], val);
+//          SPHERAL_ASSERT_EQ(field_v7[i], val);
+//          SPHERAL_ASSERT_EQ(field_v8[i], val);
+//          SPHERAL_ASSERT_EQ(field_v9[i], val);
+//        });
+
+//   } // field and any GPU allocation should be released here.
+
+//   GPUCounters ref_count;
+//   if (typeid(WORK_EXEC_POLICY) != typeid(SEQ_EXEC_POLICY)) {
+//     ref_count.HToDCopies = 1;
+//     ref_count.DNumAlloc = 1;
+//     ref_count.DNumFree = 1;
+//   }
+
+//   COMP_COUNTERS(gpu_this->gcounts, ref_count);
+// }
+
+
+// //------------------------------------------------------------------------------
+// // Resize the field after a copy to the execution space. The Second view
+// // Call should trigger a free of any GPU memory and reassign the FieldView
+// // CPU pointer to the underlying vectors new address. This test should expect
+// // two allocations, two copies to the device and two deallocations on the
+// // device.
+// //------------------------------------------------------------------------------
+// GPU_TYPED_TEST_P(FieldViewTypedTest, ResizeField) {
+//   using WORK_EXEC_POLICY = TypeParam;
+//   {
+//     const double val = 4.0;
+//     FieldDouble field("ResizeField", gpu_this->nl, val);
+//     field.setCallback(gpu_this->callback());
+//     SPHERAL_ASSERT_EQ(field.numElements(), N);
+
+//     auto field_v = field.view();
+//     SPHERAL_ASSERT_EQ(field_v.numElements(), N);
+
+//     // Capture the FieldView in the working execution space.
+//     RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
+//        [=] SPHERAL_HOST_DEVICE (int i) {
+//          SPHERAL_ASSERT_EQ(field_v[i], val);
+//        });
+
+//     // We shouldn't have any ghost nodes, but we double check here.
+//     SPHERAL_ASSERT_EQ(field.numInternalElements(), field.numElements());
+
+//     // Resize the NodeList to 10x the original size.
+//     gpu_this->nl.numInternalNodes(N * 10);
+
+//     // Assign field_v again. This should trigger a deallocation of the original
+//     // GPU data.
+//     field_v = field.view();
+//     SPHERAL_ASSERT_EQ(field_v.numElements(), N * 10);
+
+//     // Capture field_v in the working execution space again. This should trigger
+//     // a new copy to the Device if executing on the GPU.
+//     RAJA::forall<WORK_EXEC_POLICY>(TRS_UINT(0, field.numElements()),
+//        [=] SPHERAL_HOST_DEVICE(int i) {
+//          if (i < N) {SPHERAL_ASSERT_EQ(field_v[i], val);}
+//          else { SPHERAL_ASSERT_EQ(field_v[i], 0); }
+//        });
+
+//     SPHERAL_ASSERT_EQ(field.numElements(), N * 10);
+
+//   } // field and any GPU allocation should be released here.
+
+//   GPUCounters ref_count;
+//   if (typeid(WORK_EXEC_POLICY) != typeid(SEQ_EXEC_POLICY)) {
+//     ref_count.HToDCopies = 2;
+//     ref_count.DNumAlloc = 2;
+//     ref_count.DNumFree = 2;
+//   }
+
+//   COMP_COUNTERS(gpu_this->gcounts, ref_count);
+// }
+
+REGISTER_TYPED_TEST_SUITE_P(PairwiseFieldViewTypedTest, ExecutionSpaceCapture);
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Field, PairwiseFieldViewTypedTest,
+                               typename Spheral::Test<EXEC_TYPES>::Types, );
+

--- a/tests/cpp/Neighbor/pairwisefieldview_tests.cc
+++ b/tests/cpp/Neighbor/pairwisefieldview_tests.cc
@@ -29,7 +29,7 @@ using PairwiseFieldDoubleDouble = Spheral::PairwiseField<DIM3, double, 2u>;
 using PairwiseFieldViewDoubleDouble = Spheral::PairwiseFieldView<double, 2u>;
 
 // Default Testing Size.
-static constexpr int N = 5;
+static constexpr int N = 10000;
 
 // PairwiseFieldViewTest is constructed at the start of each unit test.
 class PairwiseFieldViewTest : public ::testing::Test {


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Breaks up the PairwiseField using View/Value pattern into PairwiseFieldView and PairwiseField, such that PairwiseFieldView is appropriate for use on GPU devices.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#196)
- [x] LLNLSpheral PR has passed all tests.

