### PR TITLE
Refactoring use of pair-wise fields in hydrodynamics packages to avoid pointers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Notable changes include:
 
   * New features / API changes:
     * Added view class for PairwiseField (PairwiseFieldView)
+    * Refactored use of pair-wise fields in hydro packages to avoid using pointers and allow empty PairwiseFields
 
   * Bug fixes
 

--- a/src/CRKSPH/CRKSPH.cc
+++ b/src/CRKSPH/CRKSPH.cc
@@ -80,7 +80,7 @@ CRKSPH(DataBase<Dimension>& dataBase,
                         densityUpdate,
                         epsTensile,
                         nTensile),
-  mPairAccelerationsPtr() {
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()) {
 }
 
 //------------------------------------------------------------------------------
@@ -134,8 +134,8 @@ registerDerivatives(DataBase<Dimension>& dataBase,
   if (compatibleEnergy) {
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
   TIME_END("CRKregisterDerivatives");
 }
 
@@ -240,7 +240,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
   auto  maxViscousPressure = derivs.fields(HydroFieldNames::maxViscousPressure, 0.0);
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   CHECK(DxDt.size() == numNodeLists);
   CHECK(DrhoDt.size() == numNodeLists);
   CHECK(DvDt.size() == numNodeLists);
@@ -250,7 +250,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
   CHECK(maxViscousPressure.size() == numNodeLists);
   CHECK(effViscousPressure.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy and pairAccelerations.size() == npairs) or not compatibleEnergy);
 
   // Walk all the interacting pairs.
 #pragma omp parallel
@@ -378,7 +378,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
                  mj*weighti*((Pj - Pi)/rhoj*gradWi - rhoj*QPiji*gradWi));            // RK
       DvDti -= forceij/mi;
       DvDtj += forceji/mj; 
-      if (compatibleEnergy) (*pairAccelerationsPtr)[kk] = -forceij/mi;               // Acceleration for i (j anti-symmetric)
+      if (compatibleEnergy) pairAccelerations[kk] = -forceij/mi;                     // Acceleration for i (j anti-symmetric)
 
       // Energy
       DepsDti += (true ? // surfacePoint(nodeListi, i) <= 1 ? 

--- a/src/CRKSPH/CRKSPHRZ.cc
+++ b/src/CRKSPH/CRKSPHRZ.cc
@@ -78,7 +78,7 @@ CRKSPHRZ(DataBase<Dimension>& dataBase,
                      densityUpdate,
                      epsTensile,
                      nTensile),
-  mPairAccelerationsPtr() {
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()) {
 }
 
 //------------------------------------------------------------------------------
@@ -166,8 +166,8 @@ registerDerivatives(DataBase<Dim<2>>& dataBase,
   if (compatibleEnergy) {
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
 }
 
 //------------------------------------------------------------------------------
@@ -299,7 +299,7 @@ evaluateDerivativesImpl(const Dim<2>::Scalar /*time*/,
   auto  maxViscousPressure = derivs.fields(HydroFieldNames::maxViscousPressure, 0.0);
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   CHECK(DxDt.size() == numNodeLists);
   CHECK(DrhoDt.size() == numNodeLists);
   CHECK(DvDt.size() == numNodeLists);
@@ -309,7 +309,7 @@ evaluateDerivativesImpl(const Dim<2>::Scalar /*time*/,
   CHECK(maxViscousPressure.size() == numNodeLists);
   CHECK(effViscousPressure.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy and pairAccelerations.size() == npairs) or not compatibleEnergy);
 
   // Walk all the interacting pairs.
 #pragma omp parallel
@@ -434,8 +434,8 @@ evaluateDerivativesImpl(const Dim<2>::Scalar /*time*/,
       DvDti -= forceij/mRZi; //CRK Acceleration
       DvDtj += forceij/mRZj; //CRK Acceleration
       if (compatibleEnergy) {
-        (*pairAccelerationsPtr)[kk][0] = -forceij/mRZi;
-        (*pairAccelerationsPtr)[kk][1] =  forceij/mRZj;
+        pairAccelerations[kk][0] = -forceij/mRZi;
+        pairAccelerations[kk][1] =  forceij/mRZj;
       }
 
       DepsDti += 0.5*weighti*weightj*(Pj*vij.dot(deltagrad) + workQi)/mRZi;    // CRK Q

--- a/src/CRKSPH/SolidCRKSPH.cc
+++ b/src/CRKSPH/SolidCRKSPH.cc
@@ -341,7 +341,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
   auto  DSDt = derivs.fields(IncrementState<Dimension, SymTensor>::prefix() + SolidFieldNames::deviatoricStress, SymTensor::zero());
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   CHECK(DxDt.size() == numNodeLists);
   CHECK(DrhoDt.size() == numNodeLists);
   CHECK(DvDt.size() == numNodeLists);
@@ -352,7 +352,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
   CHECK(effViscousPressure.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
   CHECK(DSDt.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy and pairAccelerations.size() == npairs) or not compatibleEnergy);
 
   // Walk all the interacting pairs.
 #pragma omp parallel
@@ -503,7 +503,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
         DvDti -= forceij/mi;
         DvDtj += forceji/mj;
       }
-      if (compatibleEnergy) (*pairAccelerationsPtr)[kk] = -forceij/mi;                                            // Acceleration for i (j anti-symmetric)
+      if (compatibleEnergy) pairAccelerations[kk] = -forceij/mi;                                                  // Acceleration for i (j anti-symmetric)
 
       // Energy
       DepsDti += (true ? // surfacePoint(nodeListi, i) <= 1 ?

--- a/src/CRKSPH/SolidCRKSPHRZ.cc
+++ b/src/CRKSPH/SolidCRKSPHRZ.cc
@@ -119,7 +119,7 @@ SolidCRKSPHRZ(DataBase<Dimension>& dataBase,
                          epsTensile,
                          nTensile,
                          damageRelieveRubble),
-  mPairAccelerationsPtr(),
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()),
   mSelfAccelerations(FieldStorageType::CopyFields) {
 }
 
@@ -215,9 +215,9 @@ registerDerivatives(DataBase<Dimension>& dataBase,
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
     dataBase.resizeFluidFieldList(mSelfAccelerations, Vector::zero(), HydroFieldNames::selfAccelerations, false);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
-    derivs.enroll(HydroFieldNames::selfAccelerations, mSelfAccelerations);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
+  derivs.enroll(HydroFieldNames::selfAccelerations, mSelfAccelerations);
 }
 
 //------------------------------------------------------------------------------
@@ -368,7 +368,7 @@ evaluateDerivativesImpl(const Dimension::Scalar /*time*/,
   auto  localDvDx = derivs.fields(HydroFieldNames::internalVelocityGradient, Tensor::zero());
   auto  maxViscousPressure = derivs.fields(HydroFieldNames::maxViscousPressure, 0.0);
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   auto  selfAccelerations = derivs.fields(HydroFieldNames::selfAccelerations, Vector::zero(), true);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
   auto  DSDt = derivs.fields(IncrementState<Dimension, SymTensor>::prefix() + SolidFieldNames::deviatoricStress, SymTensor::zero());
@@ -382,7 +382,7 @@ evaluateDerivativesImpl(const Dimension::Scalar /*time*/,
   CHECK(effViscousPressure.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
   CHECK(DSDt.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy     and pairAccelerations.size() == npairs) or not compatibleEnergy);
   CHECK((compatibleEnergy     and selfAccelerations.size() == 0u) or
         (not compatibleEnergy and selfAccelerations.size() == numNodeLists));
 
@@ -539,8 +539,8 @@ evaluateDerivativesImpl(const Dimension::Scalar /*time*/,
         DvDtj += forceji/mRZj;
       }
       if (compatibleEnergy) {
-        (*pairAccelerationsPtr)[kk][0] = -forceij/mRZi;
-        (*pairAccelerationsPtr)[kk][1] =  forceji/mRZj;
+        pairAccelerations[kk][0] = -forceij/mRZi;
+        pairAccelerations[kk][1] =  forceji/mRZj;
       }
 
       // Energy

--- a/src/CRKSPH/SolidCRKSPHRZ.cc
+++ b/src/CRKSPH/SolidCRKSPHRZ.cc
@@ -215,9 +215,9 @@ registerDerivatives(DataBase<Dimension>& dataBase,
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
     dataBase.resizeFluidFieldList(mSelfAccelerations, Vector::zero(), HydroFieldNames::selfAccelerations, false);
+    derivs.enroll(HydroFieldNames::selfAccelerations, mSelfAccelerations);
   }
   derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
-  derivs.enroll(HydroFieldNames::selfAccelerations, mSelfAccelerations);
 }
 
 //------------------------------------------------------------------------------
@@ -382,9 +382,9 @@ evaluateDerivativesImpl(const Dimension::Scalar /*time*/,
   CHECK(effViscousPressure.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
   CHECK(DSDt.size() == numNodeLists);
-  CHECK((compatibleEnergy     and pairAccelerations.size() == npairs) or not compatibleEnergy);
-  CHECK((compatibleEnergy     and selfAccelerations.size() == 0u) or
-        (not compatibleEnergy and selfAccelerations.size() == numNodeLists));
+  CHECK((compatibleEnergy and pairAccelerations.size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy and selfAccelerations.size() == numNodeLists) or
+        (selfAccelerations.size() == 0u));
 
   // Build the functor we use to compute the effective coupling between nodes.
   const NodeCoupling coupling;

--- a/src/FSISPH/SolidFSISPH.cc
+++ b/src/FSISPH/SolidFSISPH.cc
@@ -157,8 +157,8 @@ SolidFSISPH(DataBase<Dimension>& dataBase,
   mnTensile(nTensile),
   mxmin(xmin),
   mxmax(xmax),
-  mPairAccelerationsPtr(),
-  mPairDepsDtPtr(),
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()),
+  mPairDepsDtPtr(std::make_unique<PairWorkType>()),
   mTimeStepMask(FieldStorageType::CopyFields),
   mPressure(FieldStorageType::CopyFields),
   mDamagedPressure(FieldStorageType::CopyFields),
@@ -410,9 +410,9 @@ registerDerivatives(DataBase<Dimension>&  dataBase,
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
     mPairDepsDtPtr = std::make_unique<PairWorkType>(connectivityMap);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
-    derivs.enroll(HydroFieldNames::pairWork, *mPairDepsDtPtr);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
+  derivs.enroll(HydroFieldNames::pairWork, *mPairDepsDtPtr);
 
   derivs.enroll(plasticStrainRate);
   derivs.enroll(mXSPHDeltaV);

--- a/src/FSISPH/SolidFSISPHEvaluateDerivatives.cc
+++ b/src/FSISPH/SolidFSISPHEvaluateDerivatives.cc
@@ -173,12 +173,8 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
   auto  XSPHWeightSum = derivs.fields(HydroFieldNames::XSPHWeightSum, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
   auto  DSDt = derivs.fields(IncrementState<Dimension, SymTensor>::prefix() + SolidFieldNames::deviatoricStress, SymTensor::zero());
-  auto* pairAccelerationsPtr = (compatibleEnergy ?
-                                &derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations) :
-                                nullptr);
-  auto* pairDepsDtPtr = (compatibleEnergy ?
-                         &derivs.template get<PairWorkType>(HydroFieldNames::pairWork) :
-                         nullptr);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairDepsDt = derivs.template get<PairWorkType>(HydroFieldNames::pairWork);
   CHECK(M.size() == numNodeLists);
   CHECK(localM.size() == numNodeLists);
   CHECK(DepsDx.size() == numNodeLists);
@@ -204,8 +200,8 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
   CHECK(XSPHWeightSum.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
   CHECK(DSDt.size() == numNodeLists);
-  CHECK(not compatibleEnergy or pairAccelerationsPtr->size() == numPairs);
-  CHECK(not compatibleEnergy or pairDepsDtPtr->size() == numPairs);
+  CHECK(not compatibleEnergy or pairAccelerations.size() == numPairs);
+  CHECK(not compatibleEnergy or pairDepsDt.size() == numPairs);
 
   //this->computeMCorrection(time,dt,dataBase,state,derivs);
 
@@ -626,9 +622,9 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
         DepsDtj -= mi*deltaDepsDtj;
 
         if(compatibleEnergy){
-          (*pairAccelerationsPtr)[kk] = - deltaDvDt;
-          (*pairDepsDtPtr)[kk][0] = - deltaDepsDti; 
-          (*pairDepsDtPtr)[kk][1] = - deltaDepsDtj;
+          pairAccelerations[kk] = - deltaDvDt;
+          pairDepsDt[kk][0] = - deltaDepsDti; 
+          pairDepsDt[kk][1] = - deltaDepsDtj;
         }
         
         // thermal diffusion
@@ -638,8 +634,8 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
           const auto cijEff = max(min(cij + (vi-vj).dot(rhatij), cij),0.0);
           const auto diffusion =  epsDiffusionCoeff*cijEff*(epsLineari-epsLinearj)*etaij.dot(gradWij)/(rhoij*etaMagij*etaMagij+tiny);
           if (compatibleEnergy) {
-            (*pairDepsDtPtr)[kk][0] += diffusion; 
-            (*pairDepsDtPtr)[kk][1] -= diffusion;
+            pairDepsDt[kk][0] += diffusion; 
+            pairDepsDt[kk][1] -= diffusion;
           }
         }
 

--- a/src/GSPH/GenericRiemannHydro.cc
+++ b/src/GSPH/GenericRiemannHydro.cc
@@ -123,8 +123,8 @@ GenericRiemannHydro(DataBase<Dimension>& dataBase,
   mRiemannDvDx(FieldStorageType::CopyFields),
   mNewRiemannDpDx(FieldStorageType::CopyFields),
   mNewRiemannDvDx(FieldStorageType::CopyFields),
-  mPairAccelerationsPtr(),
-  mPairDepsDtPtr() {
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()),
+  mPairDepsDtPtr(std::make_unique<PairWorkType>()) {
 
   // Create storage for our internal state.
   mTimeStepMask = dataBase.newFluidFieldList(int(0), HydroFieldNames::timeStepMask);
@@ -297,9 +297,9 @@ registerDerivatives(DataBase<Dimension>& dataBase,
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
     mPairDepsDtPtr = std::make_unique<PairWorkType>(connectivityMap);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
-    derivs.enroll(HydroFieldNames::pairWork, *mPairDepsDtPtr);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
+  derivs.enroll(HydroFieldNames::pairWork, *mPairDepsDtPtr);
 }
 
 //------------------------------------------------------------------------------

--- a/src/GSPH/MFMEvaluateDerivatives.cc
+++ b/src/GSPH/MFMEvaluateDerivatives.cc
@@ -71,12 +71,8 @@ evaluateDerivatives(const typename Dimension::Scalar time,
   auto  DvDt = derivs.fields(HydroFieldNames::hydroAcceleration, Vector::zero());
   auto  DepsDt = derivs.fields(IncrementState<Dimension, Scalar>::prefix() + HydroFieldNames::specificThermalEnergy, 0.0);
   auto  DvDx = derivs.fields(HydroFieldNames::velocityGradient, Tensor::zero());
-  auto* pairAccelerationsPtr = (compatibleEnergy ?
-                                &derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations) :
-                                nullptr);
-  auto* pairDepsDtPtr = (compatibleEnergy ?
-                         &derivs.template get<PairWorkType>(HydroFieldNames::pairWork) :
-                         nullptr);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairDepsDt = derivs.template get<PairWorkType>(HydroFieldNames::pairWork);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
   auto  newRiemannDpDx = derivs.fields(ReplaceState<Dimension, Scalar>::prefix() + GSPHFieldNames::RiemannPressureGradient,Vector::zero());
   auto  newRiemannDvDx = derivs.fields(ReplaceState<Dimension, Scalar>::prefix() + GSPHFieldNames::RiemannVelocityGradient,Tensor::zero());
@@ -92,8 +88,8 @@ evaluateDerivatives(const typename Dimension::Scalar time,
   CHECK(XSPHDeltaV.size() == numNodeLists);
   CHECK(newRiemannDpDx.size() == numNodeLists);
   CHECK(newRiemannDvDx.size() == numNodeLists);
-  CHECK(not compatibleEnergy or pairAccelerationsPtr->size() == npairs);
-  CHECK(not compatibleEnergy or pairDepsDtPtr->size() == npairs);
+  CHECK(not compatibleEnergy or pairAccelerations.size() == npairs);
+  CHECK(not compatibleEnergy or pairDepsDt.size() == npairs);
 
   this->computeMCorrection(time,dt,dataBase,state,derivs);
 
@@ -255,9 +251,9 @@ evaluateDerivatives(const typename Dimension::Scalar time,
      
       if(compatibleEnergy){
         const auto invmij = 1.0/(mi*mj);
-        (*pairAccelerationsPtr)[kk] = deltaDvDt*invmij; 
-        (*pairDepsDtPtr)[kk][0]  = deltaDepsDti*invmij; 
-        (*pairDepsDtPtr)[kk][1]  = deltaDepsDtj*invmij; 
+        pairAccelerations[kk] = deltaDvDt*invmij; 
+        pairDepsDt[kk][0]  = deltaDepsDti*invmij; 
+        pairDepsDt[kk][1]  = deltaDepsDtj*invmij; 
       }
 
       // gradients

--- a/src/GSPH/MFV.cc
+++ b/src/GSPH/MFV.cc
@@ -115,7 +115,7 @@ MFV(DataBase<Dimension>& dataBase,
   mDmomentumDt(FieldStorageType::CopyFields),
   mDvolumeDt(FieldStorageType::CopyFields),
   //mHStretchTensor(FieldStorageType::CopyFields),
-  mPairMassFluxPtr() {
+  mPairMassFluxPtr(std::make_unique<PairMassFluxType>()) {
     // mNodalVelocity = dataBase.newFluidFieldList(Vector::zero(), GSPHFieldNames::nodalVelocity);
     mDmassDt = dataBase.newFluidFieldList(0.0, IncrementState<Dimension, Scalar>::prefix() + HydroFieldNames::mass);
     mDthermalEnergyDt = dataBase.newFluidFieldList(0.0, IncrementState<Dimension, Scalar>::prefix() + GSPHFieldNames::thermalEnergy);

--- a/src/GSPH/MFVEvaluateDerivatives.cc
+++ b/src/GSPH/MFVEvaluateDerivatives.cc
@@ -89,15 +89,9 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
   //auto  HStretchTensor = derivs.fields("HStretchTensor", SymTensor::zero());
   auto  newRiemannDpDx = derivs.fields(ReplaceState<Dimension, Scalar>::prefix() + GSPHFieldNames::RiemannPressureGradient,Vector::zero());
   auto  newRiemannDvDx = derivs.fields(ReplaceState<Dimension, Scalar>::prefix() + GSPHFieldNames::RiemannVelocityGradient,Tensor::zero());
-  auto* pairAccelerationsPtr = (compatibleEnergy ?
-                                &derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations) :
-                                nullptr);
-  auto* pairDepsDtPtr = (compatibleEnergy ?
-                         &derivs.template get<PairWorkType>(HydroFieldNames::pairWork) :
-                         nullptr);
-  auto* pairMassFluxPtr = (compatibleEnergy ?
-                           &derivs.template get<PairMassFluxType>(GSPHFieldNames::pairMassFlux) :
-                           nullptr);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairDepsDt = derivs.template get<PairWorkType>(HydroFieldNames::pairWork);
+  auto& pairMassFlux = derivs.template get<PairMassFluxType>(GSPHFieldNames::pairMassFlux);
   CHECK(DrhoDx.size() == numNodeLists);
   CHECK(M.size() == numNodeLists);
   CHECK(normalization.size() == numNodeLists);
@@ -110,9 +104,9 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
   //CHECK(HStretchTensor.size() == numNodeLists);
   CHECK(newRiemannDpDx.size() == numNodeLists);
   CHECK(newRiemannDvDx.size() == numNodeLists);
-  CHECK(not compatibleEnergy or pairAccelerationsPtr->size() == npairs);
-  CHECK(not compatibleEnergy or pairDepsDtPtr->size() == npairs);
-  CHECK(not compatibleEnergy or pairMassFluxPtr->size() == npairs);
+  CHECK(not compatibleEnergy or pairAccelerations.size() == npairs);
+  CHECK(not compatibleEnergy or pairDepsDt.size() == npairs);
+  CHECK(not compatibleEnergy or pairMassFlux.size() == npairs);
 
   // Walk all the interacting pairs.
 #pragma omp parallel
@@ -308,10 +302,10 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
       DEDtj += deltaDepsDtj;
      
       if(compatibleEnergy){
-        (*pairMassFluxPtr)[kk] = massFlux;
-        (*pairAccelerationsPtr)[kk] = deltaDvDt;
-        (*pairDepsDtPtr)[kk][0] = deltaDepsDti;
-        (*pairDepsDtPtr)[kk][1] = deltaDepsDtj;
+        pairMassFlux[kk] = massFlux;
+        pairAccelerations[kk] = deltaDvDt;
+        pairDepsDt[kk][0] = deltaDepsDti;
+        pairDepsDt[kk][1] = deltaDepsDtj;
       }
 
       // volume change based on nodal velocity

--- a/src/Neighbor/PairwiseField.hh
+++ b/src/Neighbor/PairwiseField.hh
@@ -41,6 +41,7 @@ public:
   using ViewType::operator[];
 
   // Constructors, destructors
+  PairwiseField()                                               = default;
   PairwiseField(const ConnectivityMap<Dimension>& connectivity);
   PairwiseField(std::shared_ptr<NodePairList> pairsPtr);
   PairwiseField(const PairwiseField& rhs);
@@ -63,9 +64,6 @@ public:
   
   // Get the view (for trivially copyable types)
   ViewType view()                                               { return static_cast<ViewType>(*this); }
-
-  // Forbidden methods
-  PairwiseField()                                               = delete;
 
 private:
   //--------------------------- Private Interface ---------------------------//

--- a/src/Neighbor/PairwiseFieldInline.hh
+++ b/src/Neighbor/PairwiseFieldInline.hh
@@ -72,6 +72,7 @@ inline
 PairwiseField<Dimension, Value, numElements>&
 PairwiseField<Dimension, Value, numElements>::operator=(const PairwiseField& rhs) {
   if (this != &rhs) {
+    mPairsPtr = rhs.mPairsPtr;
     mArray = rhs.mArray;
     assignDataSpan();
   }

--- a/src/Neighbor/PairwiseFieldView.hh
+++ b/src/Neighbor/PairwiseFieldView.hh
@@ -66,6 +66,11 @@ public:
 
   // Other methods
   SPHERAL_HOST_DEVICE size_t size() const                                           { return mSpan.size()/numElements; }
+#ifdef SPHERAL_UNIFIED_MEMORY
+  SPHERAL_HOST_DEVICE bool empty() const                                            { return mSpan.empty(); }
+#else
+  SPHERAL_HOST        bool empty() const                                            { return mSpan.size() == 0u; }
+#endif
 
   // Zero the Field
   SPHERAL_HOST_DEVICE void Zero()                                                   { for (auto& x: mSpan) x = DataTypeTraits<Value>::zero(); }

--- a/src/PYB11/Neighbor/PairwiseField.py
+++ b/src/PYB11/Neighbor/PairwiseField.py
@@ -60,6 +60,11 @@ class PairwiseField:
         "NodePairList this PairwiseField is defined on"
         return "const NodePairList&"
 
+    @PYB11const
+    def empty(self):
+        "Check if PairwiseField is empty"
+        return "bool"
+
     #...........................................................................
     # Properties
     size = PYB11property("size_t", doc="size of the PairwiseField")

--- a/src/SPH/PSPH.cc
+++ b/src/SPH/PSPH.cc
@@ -314,7 +314,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
   auto  localM = derivs.fields("local " + HydroFieldNames::M_SPHCorrection, Tensor::zero());
   auto  maxViscousPressure = derivs.fields(HydroFieldNames::maxViscousPressure, 0.0);
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   auto  XSPHWeightSum = derivs.fields(HydroFieldNames::XSPHWeightSum, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
   CHECK(rhoSum.size() == numNodeLists);
@@ -331,7 +331,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
   CHECK(effViscousPressure.size() == numNodeLists);
   CHECK(XSPHWeightSum.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy and pairAccelerations.size() == npairs) or not compatibleEnergy);
 
   // Walk all the interacting pairs.
 #pragma omp parallel
@@ -480,7 +480,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
       const auto  deltaDvDt = engCoef*(gradWi*Fij*safeInv(Pi, tiny) + gradWj*Fji*safeInv(Pj, tiny)) + Qacci + Qaccj;
       DvDti -= mj*deltaDvDt;
       DvDtj += mi*deltaDvDt;
-      if (compatibleEnergy) (*pairAccelerationsPtr)[kk] = -mj*deltaDvDt;  // Acceleration for i (j anti-symmetric)
+      if (compatibleEnergy) pairAccelerations[kk] = -mj*deltaDvDt;  // Acceleration for i (j anti-symmetric)
 
       // Specific thermal energy evolution.
       DepsDti += mj*(engCoef*Fij*safeInv(Pi, tiny)*vij.dot(gradWi) + workQi);

--- a/src/SPH/SPH.cc
+++ b/src/SPH/SPH.cc
@@ -76,7 +76,7 @@ SPH(DataBase<Dimension>& dataBase,
                      nTensile,
                      xmin,
                      xmax),
-  mPairAccelerationsPtr() {
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()) {
 }
 
 //------------------------------------------------------------------------------
@@ -129,8 +129,8 @@ registerDerivatives(DataBase<Dimension>& dataBase,
   if (compatibleEnergy) {
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
   TIME_END("SPHregisterDerivs");
 }
 
@@ -240,7 +240,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar time,
   auto  localM = derivs.fields("local " + HydroFieldNames::M_SPHCorrection, Tensor::zero());
   auto  maxViscousPressure = derivs.fields(HydroFieldNames::maxViscousPressure, 0.0);
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   auto  XSPHWeightSum = derivs.fields(HydroFieldNames::XSPHWeightSum, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
   CHECK(rhoSum.size() == numNodeLists);
@@ -258,7 +258,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar time,
   CHECK(effViscousPressure.size() == numNodeLists);
   CHECK(XSPHWeightSum.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy and pairAccelerations.size() == npairs) or not compatibleEnergy);
 
   // The scale for the tensile correction.
   const auto& nodeList = mass[0]->nodeList();
@@ -427,7 +427,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar time,
       const auto deltaDvDt = Prhoi*gradWi + Prhoj*gradWj + Qacci + Qaccj;
       DvDti -= mj*deltaDvDt;
       DvDtj += mi*deltaDvDt;
-      if (compatibleEnergy) (*pairAccelerationsPtr)[kk] = -mj*deltaDvDt;  // Acceleration for i (j anti-symmetric)
+      if (compatibleEnergy) pairAccelerations[kk] = -mj*deltaDvDt;  // Acceleration for i (j anti-symmetric)
 
       // Specific thermal energy evolution.
       // const Scalar workQij = 0.5*(mj*workQi + mi*workQj);

--- a/src/SPH/SPHRZ.cc
+++ b/src/SPH/SPHRZ.cc
@@ -89,7 +89,7 @@ SPHRZ(DataBase<Dimension>& dataBase,
                   nTensile,
                   xmin,
                   xmax),
-  mPairAccelerationsPtr() {
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()) {
 }
 
 //------------------------------------------------------------------------------
@@ -139,8 +139,8 @@ registerDerivatives(DataBase<Dimension>& dataBase,
   if (compatibleEnergy) {
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
 }
 
 //------------------------------------------------------------------------------
@@ -290,7 +290,7 @@ evaluateDerivativesImpl(const Dim<2>::Scalar time,
   auto  localM = derivs.fields("local " + HydroFieldNames::M_SPHCorrection, Tensor::zero());
   auto  maxViscousPressure = derivs.fields(HydroFieldNames::maxViscousPressure, 0.0);
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   auto  XSPHWeightSum = derivs.fields(HydroFieldNames::XSPHWeightSum, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
   CHECK(rhoSum.size() == numNodeLists);
@@ -307,7 +307,7 @@ evaluateDerivativesImpl(const Dim<2>::Scalar time,
   CHECK(effViscousPressure.size() == numNodeLists);
   CHECK(XSPHWeightSum.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy and pairAccelerations.size() == npairs) or not compatibleEnergy);
 
   // Walk all the interacting pairs.
 #pragma omp parallel
@@ -468,8 +468,8 @@ evaluateDerivativesImpl(const Dim<2>::Scalar time,
       DvDti -= mRZj*deltaDvDt;
       DvDtj += mRZi*deltaDvDt;
       if (compatibleEnergy) {
-        (*pairAccelerationsPtr)[kk][0] = -mRZj*deltaDvDt;
-        (*pairAccelerationsPtr)[kk][1] =  mRZi*deltaDvDt;
+        pairAccelerations[kk][0] = -mRZj*deltaDvDt;
+        pairAccelerations[kk][1] =  mRZi*deltaDvDt;
       }
 
       // Specific thermal energy evolution.

--- a/src/SPH/SolidSPH.cc
+++ b/src/SPH/SolidSPH.cc
@@ -393,7 +393,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
   auto  XSPHWeightSum = derivs.fields(HydroFieldNames::XSPHWeightSum, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
   auto  DSDt = derivs.fields(IncrementState<Dimension, SymTensor>::prefix() + SolidFieldNames::deviatoricStress, SymTensor::zero());
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   CHECK(rhoSum.size() == numNodeLists);
   CHECK(DxDt.size() == numNodeLists);
   CHECK(DrhoDt.size() == numNodeLists);
@@ -409,7 +409,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
   CHECK(XSPHWeightSum.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
   CHECK(DSDt.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy and pairAccelerations.size() == npairs) or not compatibleEnergy);
 
   // The scale for the tensile correction.
   const auto& nodeList = mass[0]->nodeList();
@@ -624,7 +624,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
         DvDti += mj*deltaDvDt;
         DvDtj -= mi*deltaDvDt;
       }
-      if (compatibleEnergy) (*pairAccelerationsPtr)[kk] = mj*deltaDvDt;  // Acceleration for i (j anti-symmetric)
+      if (compatibleEnergy) pairAccelerations[kk] = mj*deltaDvDt;  // Acceleration for i (j anti-symmetric)
 
       // Pair-wise portion of grad velocity.
       const auto deltaDvDxi = fDij * vij.dyad(gradWGi);

--- a/src/SPH/SolidSPHRZ.cc
+++ b/src/SPH/SolidSPHRZ.cc
@@ -108,7 +108,7 @@ SolidSPHRZ(DataBase<Dimension>& dataBase,
                       strengthInDamage,
                       xmin,
                       xmax),
-  mPairAccelerationsPtr(),
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()),
   mSelfAccelerations(FieldStorageType::CopyFields) {
 }
 
@@ -167,9 +167,9 @@ registerDerivatives(DataBase<Dimension>& dataBase,
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
     dataBase.resizeFluidFieldList(mSelfAccelerations, Vector::zero(), HydroFieldNames::selfAccelerations, false);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
-    derivs.enroll(mSelfAccelerations);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
+  derivs.enroll(mSelfAccelerations);
 }
 
 //------------------------------------------------------------------------------
@@ -338,7 +338,7 @@ evaluateDerivativesImpl(const Dimension::Scalar time,
   auto  maxViscousPressure = derivs.fields(HydroFieldNames::maxViscousPressure, 0.0);
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
   auto  rhoSumCorrection = derivs.fields(HydroFieldNames::massDensityCorrection, 0.0);
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   auto  selfAccelerations = derivs.fields(HydroFieldNames::selfAccelerations, Vector::zero(), true);
   auto  XSPHWeightSum = derivs.fields(HydroFieldNames::XSPHWeightSum, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
@@ -358,7 +358,7 @@ evaluateDerivativesImpl(const Dimension::Scalar time,
   CHECK(XSPHWeightSum.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
   CHECK(DSDt.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy     and pairAccelerations.size() == npairs) or not compatibleEnergy);
   CHECK((compatibleEnergy     and selfAccelerations.size() == numNodeLists) or
         (not compatibleEnergy and selfAccelerations.size() == 0u));
 
@@ -572,8 +572,8 @@ evaluateDerivativesImpl(const Dimension::Scalar time,
         DvDti += mRZj*deltaDvDt;
         DvDtj -= mRZi*deltaDvDt;
         if (compatibleEnergy) {
-          (*pairAccelerationsPtr)[kk][0] =  mRZj*deltaDvDt;
-          (*pairAccelerationsPtr)[kk][1] = -mRZi*deltaDvDt;
+          pairAccelerations[kk][0] =  mRZj*deltaDvDt;
+          pairAccelerations[kk][1] = -mRZi*deltaDvDt;
         }
       }
 

--- a/src/SPH/SolidSphericalSPH.cc
+++ b/src/SPH/SolidSphericalSPH.cc
@@ -129,7 +129,7 @@ SolidSphericalSPH(DataBase<Dimension>& dataBase,
   mKernel(W),
   mPiKernel(WPi),
   mGradKernel(WGrad),
-  mPairAccelerationsPtr(),
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()),
   mSelfAccelerations(FieldStorageType::CopyFields) {
 }
 
@@ -183,9 +183,9 @@ registerDerivatives(DataBase<Dimension>& dataBase,
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
     dataBase.resizeFluidFieldList(mSelfAccelerations, Vector::zero(), HydroFieldNames::selfAccelerations, false);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
-    derivs.enroll(mSelfAccelerations);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
+  derivs.enroll(mSelfAccelerations);
 }
 
 //------------------------------------------------------------------------------
@@ -354,7 +354,7 @@ evaluateDerivativesImpl(const Dim<1>::Scalar /*time*/,
   auto  maxViscousPressure = derivs.fields(HydroFieldNames::maxViscousPressure, 0.0);
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
   auto  rhoSumCorrection = derivs.fields(HydroFieldNames::massDensityCorrection, 0.0);
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   auto  selfAccelerations = derivs.fields(HydroFieldNames::selfAccelerations, Vector::zero(), true);
   auto  XSPHWeightSum = derivs.fields(HydroFieldNames::XSPHWeightSum, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
@@ -374,7 +374,7 @@ evaluateDerivativesImpl(const Dim<1>::Scalar /*time*/,
   CHECK(XSPHWeightSum.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
   CHECK(DSDt.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy     and pairAccelerations.size() == npairs) or not compatibleEnergy);
   CHECK((compatibleEnergy     and selfAccelerations.size() == numNodeLists) or
         (not compatibleEnergy and selfAccelerations.size() == 0u));
 
@@ -569,8 +569,8 @@ evaluateDerivativesImpl(const Dim<1>::Scalar /*time*/,
       DvDti += deltaDvDti;
       DvDtj += deltaDvDtj;
       if (compatibleEnergy) {
-        (*pairAccelerationsPtr)[kk][0] = deltaDvDti;
-        (*pairAccelerationsPtr)[kk][1] = deltaDvDtj;
+        pairAccelerations[kk][0] = deltaDvDti;
+        pairAccelerations[kk][1] = deltaDvDtj;
       }
 
       // Specific thermal energy evolution.

--- a/src/SPH/SphericalSPH.cc
+++ b/src/SPH/SphericalSPH.cc
@@ -98,7 +98,7 @@ SphericalSPH(DataBase<Dimension>& dataBase,
   mQself(2.0),
   mKernel(W),
   mPiKernel(WPi),
-  mPairAccelerationsPtr(),
+  mPairAccelerationsPtr(std::make_unique<PairAccelerationsType>()),
   mSelfAccelerations(FieldStorageType::CopyFields) {
 }
 
@@ -152,9 +152,9 @@ registerDerivatives(DataBase<Dimension>& dataBase,
     const auto& connectivityMap = dataBase.connectivityMap();
     mPairAccelerationsPtr = std::make_unique<PairAccelerationsType>(connectivityMap);
     dataBase.resizeFluidFieldList(mSelfAccelerations, Vector::zero(), HydroFieldNames::selfAccelerations, false);
-    derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
-    derivs.enroll(mSelfAccelerations);
   }
+  derivs.enroll(HydroFieldNames::pairAccelerations, *mPairAccelerationsPtr);
+  derivs.enroll(mSelfAccelerations);
 }
 
 //------------------------------------------------------------------------------
@@ -311,7 +311,7 @@ evaluateDerivativesImpl(const Dim<1>::Scalar time,
   auto  localM = derivs.fields("local " + HydroFieldNames::M_SPHCorrection, Tensor::zero());
   auto  maxViscousPressure = derivs.fields(HydroFieldNames::maxViscousPressure, 0.0);
   auto  effViscousPressure = derivs.fields(HydroFieldNames::effectiveViscousPressure, 0.0);
-  auto* pairAccelerationsPtr = derivs.template getPtr<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
+  auto& pairAccelerations = derivs.template get<PairAccelerationsType>(HydroFieldNames::pairAccelerations);
   auto  selfAccelerations = derivs.fields(HydroFieldNames::selfAccelerations, Vector::zero(), true);
   auto  XSPHWeightSum = derivs.fields(HydroFieldNames::XSPHWeightSum, 0.0);
   auto  XSPHDeltaV = derivs.fields(HydroFieldNames::XSPHDeltaV, Vector::zero());
@@ -329,7 +329,7 @@ evaluateDerivativesImpl(const Dim<1>::Scalar time,
   CHECK(effViscousPressure.size() == numNodeLists);
   CHECK(XSPHWeightSum.size() == numNodeLists);
   CHECK(XSPHDeltaV.size() == numNodeLists);
-  CHECK((compatibleEnergy and pairAccelerationsPtr->size() == npairs) or not compatibleEnergy);
+  CHECK((compatibleEnergy     and pairAccelerations.size() == npairs) or not compatibleEnergy);
   CHECK((compatibleEnergy     and selfAccelerations.size() == numNodeLists) or
         (not compatibleEnergy and selfAccelerations.size() == 0u));
   TIME_END("SphericalSPHevalDerivs_initial");
@@ -486,8 +486,8 @@ evaluateDerivativesImpl(const Dim<1>::Scalar time,
       DvDti += deltaDvDti;
       DvDtj += deltaDvDtj;
       if (mCompatibleEnergyEvolution) {
-        (*pairAccelerationsPtr)[kk][0] = deltaDvDti;
-        (*pairAccelerationsPtr)[kk][1] = deltaDvDtj;
+        pairAccelerations[kk][0] = deltaDvDti;
+        pairAccelerations[kk][1] = deltaDvDtj;
       }
 
       // Specific thermal energy evolution


### PR DESCRIPTION
# Summary

- This PR is a feature/refactoring
- It does the following:
  - Modifies the hydrodyanmics packages to use empty pair-wise fields when not using compatible energy (ratther than null pointers).  This avoids grabbing pointers from the state and should simplify porting to the GPU.
 
------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#197)
- [x] LLNLSpheral PR has passed all tests.

