### PR TITLE
Insert axis boundary in controller, not hydro

### DIFF
--- a/src/CRKSPH/CRKSPHHydros.py
+++ b/src/CRKSPH/CRKSPHHydros.py
@@ -104,8 +104,7 @@ def CRKSPH(dataBase,
 
     # If we're using area-weighted RZ, we need to reflect from the axis
     if GeometryRegistrar.coords() == CoordinateType.RZ:
-        result.zaxisBC = AxisBoundaryRZ(etaMinAxis)
-        result.appendBoundary(result.zaxisBC)
+        result.etaMinAxis = etaMinAxis
 
     return result
 

--- a/src/SPH/SPHHydros.py
+++ b/src/SPH/SPHHydros.py
@@ -140,18 +140,14 @@ def SPH(W,
     result.appendSubPackage(smoothingScaleMethod)
 
     # In spherical coordatinates, preserve our locally constructed spherical kernels
-    # and add the origin enforcement boundary
     if GeometryRegistrar.coords() == CoordinateType.Spherical:
-        result.originBC = SphericalOriginBoundary()
-        result.appendBoundary(result.originBC)
         result._W3S1 = W
         result._WPi3S1 = WPi
         result._WGrad3S1 = WGrad
 
-    # If we're using area-weighted RZ, we need to reflect from the axis
+    # If we're using area-weighted RZ, store etaMinAxis
     if GeometryRegistrar.coords() == CoordinateType.RZ:
-        result.zaxisBC = AxisBoundaryRZ(etaMinAxis)
-        result.appendBoundary(result.zaxisBC)
+        result.etaMinAxis = etaMinAxis
 
     return result
 

--- a/src/SimulationControl/SpheralController.py
+++ b/src/SimulationControl/SpheralController.py
@@ -95,6 +95,9 @@ class SpheralController:
         self.vizGhosts = vizGhosts
         self.vizDerivs = vizDerivs
 
+        # If this is in spherical or cylindrical coordinates, add axis boundary
+        self.insertAxisBoundary(integrator.physicsPackages())
+        
         # Organize the physics packages as appropriate
         self.organizePhysicsPackages(self.kernel, volumeType, facetedBoundaries)
 
@@ -755,6 +758,24 @@ class SpheralController:
         
         return
 
+    #--------------------------------------------------------------------------
+    # Create an axis boundary if needed
+    #--------------------------------------------------------------------------
+    def insertAxisBoundary(self, physicsPackages):
+        if GeometryRegistrar.coords() == CoordinateType.Spherical:
+            self.axisBC = SphericalOriginBoundary()
+        elif GeometryRegistrar.coords() == CoordinateType.RZ:
+            etaMinAxis = 0.1
+            for package in physicsPackages:
+                etaMinAxis = getattr(package, "etaMinAxis", etaMinAxis)
+            self.axisBC = AxisBoundaryRZ(etaMinAxis)
+        else:
+            self.axisBC = None
+        if self.axisBC is not None:
+            for package in physicsPackages:
+                package.prependBoundary(self.axisBC)
+        return
+        
     #--------------------------------------------------------------------------
     # If necessary create and add a distributed boundary condition to each
     # physics package


### PR DESCRIPTION
# Summary

Moves the axis boundary logic out of individual SPH and CRKSPH hydro constructors and into the SpheralController, where it is applied once during initialization. This makes the axis BC work without hydro, if needed.

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

