### PR TITLE
Linear solver wrappers

### DIFF
--- a/cmake/CMakeDefinitions.cmake
+++ b/cmake/CMakeDefinitions.cmake
@@ -88,4 +88,8 @@ else()
   message("-- Assuming non-unified memory for GPU architectures")
 endif()
 
+if (SPHERAL_ENABLE_SOLVERS)
+  list(APPEND SPHERAL_COMPILE_DEFS SPHERAL_ENABLE_SOLVERS)
+endif()
+
 set_property(GLOBAL PROPERTY SPHERAL_COMPILE_DEFS "${SPHERAL_COMPILE_DEFS}")

--- a/cmake/InstallTPLs.cmake
+++ b/cmake/InstallTPLs.cmake
@@ -202,7 +202,7 @@ list(APPEND SPHERAL_FP_DIRS ${chai_DIR} ${raja_DIR} ${umpire_DIR})
 
 message("-----------------------------------------------------------------------------")
 # Use find_package to get Sundials
-if (SPHERAL_ENABLE_SUNDIALS)
+if (SPHERAL_ENABLE_SOLVERS)
   set(SUNDIALS_DIR "${sundials_DIR}")
   find_package(SUNDIALS REQUIRED NO_DEFAULT_PATH
     COMPONENTS kinsol nvecparallel nvecmpiplusx nvecserial
@@ -216,6 +216,7 @@ if (SPHERAL_ENABLE_SUNDIALS)
     list(APPEND SPHERAL_FP_DIRS ${sundials_DIR})
     message("Found SUNDIALS External Package.")
   endif()
+  list(APPEND SPHERAL_EXTERN_LIBS hypre)
 endif()
 
 set_property(GLOBAL PROPERTY SPHERAL_FP_TPLS ${SPHERAL_FP_TPLS})

--- a/cmake/SpheralOptions.cmake
+++ b/cmake/SpheralOptions.cmake
@@ -24,7 +24,7 @@ option(SPHERAL_ENABLE_GSPH "Enable the GSPH package" ON)
 option(SPHERAL_ENABLE_SVPH "Enable the SVPH package" ON)
 option(SPHERAL_ENABLE_GLOBALDT_REDUCTION "Enable global allreduce for the time step" ON)
 option(SPHERAL_ENABLE_LONGCSDT "Enable longitudinal sound speed time step constraint" ON)
-cmake_dependent_option(SPHERAL_ENABLE_SUNDIALS "Enable use of SUNDIALS" ON ENABLE_MPI OFF)
+cmake_dependent_option(SPHERAL_ENABLE_SOLVERS "Enable use of solvers" ON ENABLE_MPI OFF)
 option(SPHERAL_ENABLE_LEOS "Enable use of LEOS" OFF)
 
 option(SPHERAL_NETWORK_CONNECTED "Enable use of network. Disable if using a build cache" ON)

--- a/cmake/tpl/hypre.cmake
+++ b/cmake/tpl/hypre.cmake
@@ -1,0 +1,1 @@
+set(hypre_libs libHYPRE.a)

--- a/scripts/spack/spack_repo/spheral/packages/spheral/package.py
+++ b/scripts/spack/spack_repo/spheral/packages/spheral/package.py
@@ -44,7 +44,7 @@ class Spheral(CachedCMakePackage, CudaPackage, ROCmPackage):
     variant('caliper', default=True, description='Enable Caliper timers.')
     variant('opensubdiv', default=True, description='Enable use of opensubdiv to do refinement.')
     variant('network', default=True, description='Disable to build Spheral from a local buildcache.')
-    variant('sundials', default=True, when="+mpi", description='Enable use of SUNDIALS solvers.')
+    variant('solvers', default=True, when="+mpi", description='Enable Sundials and Hypre solvers.')
     variant('leos', default=LEOSpresent, when="+mpi", description='Build LEOS package.')
 
     # -------------------------------------------------------------------------
@@ -96,8 +96,12 @@ class Spheral(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on('polytope@v0.7.5 +python', type='build', when="+python")
     depends_on('polytope@v0.7.5 ~python', type='build', when="~python")
 
-    depends_on('sundials@7.0.0 ~shared cxxstd=17 cppflags="-fPIC"', type='build', when='+sundials')
-    depends_on('sundials build_type=Debug', when='+sundials build_type=Debug')
+    with when("+solvers"):
+        depends_on('sundials@7.0.0 ~shared cxxstd=17 cppflags="-fPIC"', type='build')
+        depends_on('sundials build_type=Debug', when='build_type=Debug')
+        depends_on('hypre@3.0.0 ~shared cppflags="-fPIC" cflags="-fPIC"', type='build')
+        depends_on('blas', type='build')
+        depends_on('lapack', type='build')
 
     # Forward MPI Variants
     mpi_tpl_list = ["hdf5", "conduit", "axom", "adiak~shared", "chai", "umpire"]
@@ -292,10 +296,15 @@ class Spheral(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option('SPHERAL_ENABLE_DOCS', '+docs' in spec))
             entries.append(cmake_cache_path('python_DIR', spec['python'].prefix))
 
-        # SUNDIALS
-        entries.append(cmake_cache_option('SPHERAL_ENABLE_SUNDIALS', '+sundials' in spec))
-        if spec.satisfies("+sundials"):
+        # SOLVERS
+        entries.append(cmake_cache_option('SPHERAL_ENABLE_SOLVERS', '+solvers' in spec))
+        if spec.satisfies("+solvers"):
             entries.append(cmake_cache_path('sundials_DIR', spec['sundials'].prefix))
+            entries.append(cmake_cache_path('hypre_DIR', spec['hypre'].prefix))
+            entries.append(cmake_cache_path('hypre_INCLUDES', spec['hypre'].prefix.include))
+            hypre_libs = spec["blas"].libs + spec["lapack"].libs
+            entries.append(cmake_cache_path('hypre_EXT_LIBRARIES', hypre_libs.joined(";")))
+            entries.append(cmake_cache_option('ENABLE_SOLVERS', True))
 
         if spec.satisfies("+leos"):
             entries.append(cmake_cache_path('leos_DIR', spec['leos'].prefix))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,7 @@ if (SPHERAL_ENABLE_SVPH)
   list(APPEND _packages SVPH)
 endif()
 
-if (SPHERAL_ENABLE_SUNDIALS)
+if (SPHERAL_ENABLE_SOLVERS)
   list(APPEND _packages Solvers)
 endif()
 

--- a/src/Integrator/CMakeLists.txt
+++ b/src/Integrator/CMakeLists.txt
@@ -12,7 +12,7 @@ set(Integrator_inst
 
 set(Integrator_sources )
 
-if (SPHERAL_ENABLE_SUNDIALS)
+if (SPHERAL_ENABLE_SOLVERS)
   list(APPEND Integrator_inst
     BackwardEuler
     ImplicitIntegrationVectorOperator)

--- a/src/PYB11/CMakeLists.txt
+++ b/src/PYB11/CMakeLists.txt
@@ -74,7 +74,7 @@ if (SPHERAL_ENABLE_SVPH)
   list(APPEND _python_packages SVPH)
 endif()
 
-if (SPHERAL_ENABLE_SUNDIALS)
+if (SPHERAL_ENABLE_SOLVERS)
   list(PREPEND _python_packages Solvers)
 endif()
 

--- a/src/PYB11/Integrator/CMakeLists.txt
+++ b/src/PYB11/Integrator/CMakeLists.txt
@@ -1,6 +1,6 @@
-set(SUNDIALS_PYTHON_FLAG "False")
-if (SPHERAL_ENABLE_SUNDIALS)
-  set(SUNDIALS_PYTHON_FLAG "True")
+set(SOLVERS_PYTHON_FLAG "False")
+if (SPHERAL_ENABLE_SOLVERS)
+  set(SOLVERS_PYTHON_FLAG "True")
 endif()
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/Integrator_PYB11.py

--- a/src/PYB11/Integrator/Integrator_PYB11.py
+++ b/src/PYB11/Integrator/Integrator_PYB11.py
@@ -9,7 +9,7 @@ from SpheralCommon import *
 from spheralDimensions import *
 dims = spheralDimensions()
 
-HAVE_SOLVERS = @SUNDIALS_PYTHON_FLAG@
+HAVE_SOLVERS = @SOLVERS_PYTHON_FLAG@
 
 #-------------------------------------------------------------------------------
 # Includes

--- a/src/PYB11/Solvers/EigenLinearSolver.py
+++ b/src/PYB11/Solvers/EigenLinearSolver.py
@@ -1,0 +1,10 @@
+from PYB11Generator import *
+from LinearSolver import *
+
+@PYB11holder("std::shared_ptr")
+class EigenLinearSolver(LinearSolver):
+    def pyinit(self,
+               options = "std::shared_ptr<EigenOptions>"):
+        "Eigen solver"
+        
+PYB11inject(LinearSolverAbstractMethods, EigenLinearSolver, virtual = True)

--- a/src/PYB11/Solvers/EigenOptions.py
+++ b/src/PYB11/Solvers/EigenOptions.py
@@ -1,0 +1,8 @@
+from PYB11Generator import *
+
+@PYB11holder("std::shared_ptr")
+class EigenOptions:
+    def pyinit(self):
+        "Holds the options for Eigen solvers"
+
+    qr = PYB11readwrite()

--- a/src/PYB11/Solvers/HypreLinearSolver.py
+++ b/src/PYB11/Solvers/HypreLinearSolver.py
@@ -1,0 +1,10 @@
+from PYB11Generator import *
+from LinearSolver import *
+
+@PYB11holder("std::shared_ptr")
+class HypreLinearSolver(LinearSolver):
+    def pyinit(self,
+               options = "std::shared_ptr<HypreOptions>"):
+        "Hypre solver"
+
+PYB11inject(LinearSolverAbstractMethods, HypreLinearSolver, virtual = True)

--- a/src/PYB11/Solvers/HypreOptions.py
+++ b/src/PYB11/Solvers/HypreOptions.py
@@ -19,55 +19,79 @@ class HypreOptions:
                preset = ("HyprePreset", "HyprePreset::Default")):
         "Holds the options for Hypre preconditioners and solver"
 
-    quitIfDiverged = PYB11readwrite()
-    warnIfDiverged = PYB11readwrite()
-    
-    logLevel = PYB11readwrite()
-    printLevel = PYB11readwrite()
+    # General options
+    quitIfDiverged = PYB11readwrite(doc="Abort execution when the linear solver fails to converge")
+    warnIfDiverged = PYB11readwrite(doc="Emit a warning when the solver fails to converge")
+    addToValues = PYB11readwrite(doc="Sum all row values that share an index")
+    logLevel = PYB11readwrite(doc="Logging verbosity (0 = off)")
+    printLevel = PYB11readwrite(doc="Print verbosity (0 = off)")
 
-    addToValues = PYB11readwrite()
-    
-    saveLinearSystem = PYB11readwrite()
-    printIterations = PYB11readwrite()
-    maxNumberOfIterations = PYB11readwrite()
-    toleranceL2 = PYB11readwrite()
-    useRobustTolerance = PYB11readwrite()
-    absoluteTolerance = PYB11readwrite()
+    # GMRES solve options
+    saveLinearSystem = PYB11readwrite(doc="Save the linear system (A, b, x) to disk for debugging")
+    printIterations = PYB11readwrite(doc="Print information after each iteration")
+    meanIterationsGuess = PYB11readwrite(doc="Initial guess for mean iterations (statistics only)")
+    maxNumberOfIterations = PYB11readwrite(doc="Maximum number of GMRES iterations")
+    toleranceL2 = PYB11readwrite(doc="Relative L2 convergence tolerance")
+    useRobustTolerance = PYB11readwrite(doc="Use Hypre robust convergence criterion for ill-conditioned systems")
+    absoluteTolerance = PYB11readwrite(doc="Absolute tolerance (OR with L2 tolerance)")
 
-    kDim = PYB11readwrite()
-    minIters = PYB11readwrite()
-    
-    preconditionerType = PYB11readwrite()
-    
-    measure_type = PYB11readwrite()
-    pcTol = PYB11readwrite()
-    minItersAMG = PYB11readwrite()
-    maxItersAMG = PYB11readwrite()
-    cycleType = PYB11readwrite()
-    coarsenTypeAMG = PYB11readwrite()
-    strongThresholdAMG = PYB11readwrite()
-    maxRowSumAMG = PYB11readwrite()
-    interpTypeAMG = PYB11readwrite()
-    aggNumLevelsAMG = PYB11readwrite()
-    aggInterpTypeAMG = PYB11readwrite()
-    pMaxElmtsAMG = PYB11readwrite()
-    truncFactorAMG = PYB11readwrite()
-    printLevelAMG = PYB11readwrite()
-    logLevelAMG = PYB11readwrite()
-    relaxWeightAMG = PYB11readwrite()
-    relaxTypeAMG = PYB11readwrite()
-    relaxTypeCoarseAMG = PYB11readwrite()
-    cycleNumSweepsAMG = PYB11readwrite()
-    cycleNumSweepsCoarseAMG = PYB11readwrite()
-    maxLevelsAMG = PYB11readwrite()
+    # GMRES initialization
+    kDim = PYB11readwrite(doc="Krylov subspace dimension")
+    minIters = PYB11readwrite(doc="Minimum GMRES iterations before convergence test")
 
-    numFunctionsAMG = PYB11readwrite()
-    nodalAMG = PYB11readwrite()
+    # Preconditioner selection
+    preconditionerType = PYB11readwrite(doc="Preconditioner type (AMG, ILU, or none)")
 
-    useILUT = PYB11readwrite()
-    factorLevelILU = PYB11readwrite()
-    rowScaleILU = PYB11readwrite()
-    printLevelILU = PYB11readwrite()
-    dropToleranceILU = PYB11readwrite()
-    
-    zeroOutNegativities = PYB11readwrite()
+    #---------------------------------------------------------------------------
+    # AMG nested type — BoomerAMG options
+    #---------------------------------------------------------------------------
+    class AMG:
+        def pyinit(self):
+            "BoomerAMG preconditioner options"
+
+        measureType = PYB11readwrite(doc="Strength-of-connection measure (0 = classical)")
+        tol = PYB11readwrite(doc="AMG convergence tolerance (0 for preconditioning)")
+        minIters = PYB11readwrite(doc="Minimum AMG iterations per application")
+        maxIters = PYB11readwrite(doc="Maximum AMG iterations per application")
+        cycleType = PYB11readwrite(doc="Multigrid cycle type (1 = V-cycle, 2 = W-cycle)")
+        coarsenType = PYB11readwrite(doc="Coarsening algorithm (6 = Falgout, 8 = PMIS, 10 = HMIS)")
+        strongThreshold = PYB11readwrite(doc="Strength-of-connection threshold")
+        maxRowSum = PYB11readwrite(doc="Maximum allowed sum of weak connections relative to strong ones")
+        interpType = PYB11readwrite(doc="Interpolation type (6 = extended classical)")
+        aggNumLevels = PYB11readwrite(doc="Number of aggressive coarsening levels (-1 = disabled)")
+        aggInterpType = PYB11readwrite(doc="Interpolation type during aggressive coarsening (-1 = default)")
+        pMaxElmts = PYB11readwrite(doc="Maximum nonzeros per row in interpolation (-1 = default)")
+        truncFactor = PYB11readwrite(doc="Truncation factor for interpolation coefficients (0.0 = disabled)")
+        printLevel = PYB11readwrite(doc="AMG print verbosity (-1 inherits from global)")
+        logLevel = PYB11readwrite(doc="AMG logging level")
+        relaxWeight = PYB11readwrite(doc="Relaxation weight for smoothers")
+        relaxType = PYB11readwrite(doc="Relaxation type on fine/intermediate levels (8 = L1 GS, 16 = Chebyshev)")
+        relaxTypeCoarse = PYB11readwrite(doc="Relaxation type on coarsest level (-1 = use relaxType, 9 = Gaussian elimination)")
+        cycleNumSweeps = PYB11readwrite(doc="Number of pre- and post-smoothing sweeps")
+        cycleNumSweepsCoarse = PYB11readwrite(doc="Number of coarse-level sweeps (-1 = use cycleNumSweeps)")
+        maxLevels = PYB11readwrite(doc="Maximum number of AMG levels")
+        numFunctions = PYB11readwrite(doc="DOFs per node for systems of PDEs (1 = scalar)")
+        nodal = PYB11readwrite(doc="Nodal coarsening for systems (requires numFunctions > 1)")
+
+    #---------------------------------------------------------------------------
+    # ILU nested type — Euclid ILU options
+    #---------------------------------------------------------------------------
+    class ILU:
+        def pyinit(self):
+            "Euclid ILU preconditioner options"
+
+        useILUT = PYB11readwrite(doc="Use ILUT instead of ILU(k)")
+        factorLevel = PYB11readwrite(doc="Fill level for ILU(k)")
+        rowScale = PYB11readwrite(doc="Enable row scaling prior to ILU factorization")
+        printLevel = PYB11readwrite(doc="Euclid print verbosity (-1 inherits from global)")
+        dropTolerance = PYB11readwrite(doc="Drop tolerance for ILUT or sparse ILU")
+
+    #---------------------------------------------------------------------------
+    # Top-level sub-struct members
+    #---------------------------------------------------------------------------
+    amg = PYB11readwrite(doc="BoomerAMG preconditioner options")
+    ilu = PYB11readwrite(doc="Euclid ILU preconditioner options")
+
+    # Postprocessing
+    zeroOutNegativities = PYB11readwrite(doc="Clamp negative solution values to zero after solve")
+

--- a/src/PYB11/Solvers/HypreOptions.py
+++ b/src/PYB11/Solvers/HypreOptions.py
@@ -1,0 +1,73 @@
+from PYB11Generator import *
+
+HyprePreconditionerType = PYB11enum(("NoPreconditioner",
+                                     "AMGPreconditioner",
+                                     "ILUPreconditioner"),
+                                    export_values = False,
+                                    doc = "Preconditioners available for Hypre")
+
+HyprePreset = PYB11enum(("Default",
+                         "OldDefault",
+                         "Robust",
+                         "Fast"),
+                        export_values = False,
+                        doc = "Hypre presets for speed or robustness")
+
+@PYB11holder("std::shared_ptr")
+class HypreOptions:
+    def pyinit(self,
+               preset = ("HyprePreset", "HyprePreset::Default")):
+        "Holds the options for Hypre preconditioners and solver"
+
+    quitIfDiverged = PYB11readwrite()
+    warnIfDiverged = PYB11readwrite()
+    
+    logLevel = PYB11readwrite()
+    printLevel = PYB11readwrite()
+
+    addToValues = PYB11readwrite()
+    
+    saveLinearSystem = PYB11readwrite()
+    printIterations = PYB11readwrite()
+    maxNumberOfIterations = PYB11readwrite()
+    toleranceL2 = PYB11readwrite()
+    useRobustTolerance = PYB11readwrite()
+    absoluteTolerance = PYB11readwrite()
+
+    kDim = PYB11readwrite()
+    minIters = PYB11readwrite()
+    
+    preconditionerType = PYB11readwrite()
+    
+    measure_type = PYB11readwrite()
+    pcTol = PYB11readwrite()
+    minItersAMG = PYB11readwrite()
+    maxItersAMG = PYB11readwrite()
+    cycleType = PYB11readwrite()
+    coarsenTypeAMG = PYB11readwrite()
+    strongThresholdAMG = PYB11readwrite()
+    maxRowSumAMG = PYB11readwrite()
+    interpTypeAMG = PYB11readwrite()
+    aggNumLevelsAMG = PYB11readwrite()
+    aggInterpTypeAMG = PYB11readwrite()
+    pMaxElmtsAMG = PYB11readwrite()
+    truncFactorAMG = PYB11readwrite()
+    printLevelAMG = PYB11readwrite()
+    logLevelAMG = PYB11readwrite()
+    relaxWeightAMG = PYB11readwrite()
+    relaxTypeAMG = PYB11readwrite()
+    relaxTypeCoarseAMG = PYB11readwrite()
+    cycleNumSweepsAMG = PYB11readwrite()
+    cycleNumSweepsCoarseAMG = PYB11readwrite()
+    maxLevelsAMG = PYB11readwrite()
+
+    numFunctionsAMG = PYB11readwrite()
+    nodalAMG = PYB11readwrite()
+
+    useILUT = PYB11readwrite()
+    factorLevelILU = PYB11readwrite()
+    rowScaleILU = PYB11readwrite()
+    printLevelILU = PYB11readwrite()
+    dropToleranceILU = PYB11readwrite()
+    
+    zeroOutNegativities = PYB11readwrite()

--- a/src/PYB11/Solvers/IncrementalStatistic.py
+++ b/src/PYB11/Solvers/IncrementalStatistic.py
@@ -1,0 +1,46 @@
+from PYB11Generator import *
+
+@PYB11template("DataType")
+@PYB11holder("std::shared_ptr")
+class IncrementalStatistic:
+    def pyinit(self,
+               meanGuess = ("const %(DataType)s", 0),
+               name = ("const std::string", "\"IncrementalStatistic\""),
+               printAdd = ("bool", "false")):
+        "Allows tracking of incrementally added statistics"
+        
+    def add(self,
+            data = "const %(DataType)s"):
+        return "void"
+
+    @PYB11const
+    def mean(self):
+        return "%(DataType)s"
+    @PYB11const
+    def variance(self):
+        return "%(DataType)s"
+    @PYB11const
+    def total(self):
+        return "%(DataType)s"
+    @PYB11const
+    def min(self):
+        return "%(DataType)s"
+    @PYB11const
+    def max(self):
+        return "%(DataType)s"
+    @PYB11const
+    def meanGuess(self):
+        return "%(DataType)s"
+    @PYB11const
+    def numPoints(self):
+        return "%(DataType)s"
+    @PYB11const
+    def shiftedSum(self):
+        return "%(DataType)s"
+    @PYB11const
+    def shiftedSum2(self):
+        return "%(DataType)s"
+    @PYB11cppname("print")
+    @PYB11const
+    def print1(self):
+        return "void"

--- a/src/PYB11/Solvers/LinearSolver.py
+++ b/src/PYB11/Solvers/LinearSolver.py
@@ -1,0 +1,164 @@
+from PYB11Generator import *
+
+@PYB11ignore
+class LinearSolverAbstractMethods:
+    @PYB11cppname("initialize")
+    def initializePtr(self,
+                    numLocVal = "const unsigned",
+                    firstGlobInd = "const unsigned",
+                    numValsPerRow = "const unsigned*"):
+        "Create matrices and vectors"
+        return "void"
+
+    def beginFill(self):
+        "Begin matrix fill"
+        return "void"
+
+    @PYB11cppname("setMatRow")
+    def setMatRowPtr(self,
+                     numVals = "const unsigned",
+                     globRowInd = "const unsigned",
+                     globColInd = "const unsigned*",
+                     colVal = "const double*"):
+        "Set values in matrix"
+        return "void"
+
+    @PYB11cppname("setMatRows")
+    def setMatRowsPtr(self,
+                      numRows = "const unsigned",
+                      numColsPerRow = "const unsigned*",
+                      globRowInd = "const unsigned*",
+                      globColInd = "const unsigned*",
+                      colVal = "const double*"):
+        "Set multiple rows in matrix"
+        return "void"
+
+    def assemble(self):
+        "Assemble matrix after fill"
+        return "void"
+      
+    def finalize(self):
+        "Create solver/preconditioner"
+        return "void"
+
+    @PYB11cppname("set")
+    def setPtr(self,
+               c = "const LinearSolver::Component",
+               numVals = "const unsigned",
+               firstGlobInd = "const unsigned",
+               val = "const double*"):
+        "Set values from external vector"
+        return "void"
+
+    @PYB11cppname("get")
+    def getPtr(self,
+               c = "const LinearSolver::Component",
+               numVals = "const unsigned",
+               firstGlobInd = "const unsigned",
+               val = "double*"):
+        "Get values from internal vector"
+        return "void"
+
+    def solve(self):
+        "Solve the system of equations in place; returns true if converged"
+        return "bool"
+
+    def multiply(self):
+        "Multiply the matrix by a vector"
+        return "void"
+
+@PYB11holder("std::shared_ptr")
+class LinearSolver:
+    Component = PYB11enum(("LHS",
+                           "RHS"),
+                          export_values = True,
+                          doc = "Choose which vector to use when applying a function")
+    
+    def pyinit(self):
+        "Pure virtual linear solver class"
+
+    @PYB11implementation("""[](LinearSolver& self,
+                               const unsigned numLocVal,
+                               const unsigned firstGlobInd,
+                               const std::vector<unsigned>& numValsPerRow) {
+                               self.initialize(numLocVal, firstGlobInd, &numValsPerRow[0]); }""")
+    @PYB11pyname("initialize")
+    def initializeVec(self,
+                      numLocVal = "const unsigned",
+                      firstGlobInd = "const unsigned",
+                      numValsPerRow = "const std::vector<unsigned>&"):
+        "Create matrices and vectors"
+        return "void"
+
+    @PYB11implementation("""[](LinearSolver& self,
+                               const unsigned numVals,
+                               const unsigned globRowInd,
+                               const std::vector<unsigned>& globColInd,
+                               const std::vector<double>& colVal) {
+                               self.setMatRow(numVals, globRowInd, &globColInd[0], &colVal[0]); }""")
+    @PYB11pyname("setMatRow")
+    def setMatRowVec(self,
+                     numVals = "const unsigned",
+                     globRowInd = "const unsigned",
+                     globColInd = "const vector<unsigned>&",
+                     colVal = "const std::vector<double>&"):
+        "Set values in matrix"
+        return "void"
+
+    @PYB11implementation("""[](LinearSolver& self,
+                               const unsigned numRows,
+                               const std::vector<unsigned>& numColsPerRow,
+                               const std::vector<unsigned>& globRowInd,
+                               const std::vector<unsigned>& globColInd,
+                               const std::vector<double>& colVal) {
+                               self.setMatRows(numRows, &numColsPerRow[0], &globRowInd[0], &globColInd[0], &colVal[0]); }""")
+    @PYB11pyname("setMatRows")
+    def setMatRowsVec(self,
+                      numRows = "const unsigned",
+                      numColsPerRow = "const vector<unsigned>&",
+                      globRowInd = "const vector<unsigned>&",
+                      globColInd = "const vector<unsigned>&",
+                      colVal = "const std::vector<double>&"):
+        "Set multiple rows in matrix"
+        return "void"
+
+    @PYB11implementation("""[](LinearSolver& self,
+                               const LinearSolver::Component c,
+                               const unsigned numVals,
+                               const unsigned firstGlobInd,
+                               const std::vector<double>& val) {
+                               self.set(c, numVals, firstGlobInd, &val[0]); }""")
+    @PYB11pyname("set")
+    def setVec(self,
+               c = "const LinearSolver::Component",
+               numVals = "const unsigned",
+               firstGlobInd = "const unsigned",
+               val = "const std::vector<double>&"):
+        "Set values in RHS"
+        return "void"
+    
+    @PYB11implementation("""[](LinearSolver& self,
+                               const LinearSolver::Component c,
+                               const unsigned numVals,
+                               const unsigned firstGlobInd) {
+                               std::vector<double> result(numVals);
+                               self.get(c, numVals, firstGlobInd, &result[0]);
+                               return result; }""")
+    @PYB11pyname("get")
+    def getVec(self,
+               c = "const LinearSolver::Component",
+               numVals = "const unsigned",
+               firstGlobInd = "const unsigned"):
+        "Get values from RHS"
+        return "std::vector<double>"
+    
+    description = PYB11property(returnType = "std::string",
+                                getter = "getDescription",
+                                setter = "setDescription")
+
+    @PYB11virtual
+    @PYB11const
+    def statistics(self):
+        return "std::vector<std::shared_ptr<IncrementalStatistic<double>>>"
+
+PYB11inject(LinearSolverAbstractMethods, LinearSolver, pure_virtual = True)

--- a/src/PYB11/Solvers/Solvers_PYB11.py
+++ b/src/PYB11/Solvers/Solvers_PYB11.py
@@ -5,13 +5,23 @@ Provides interfaces to solver libraries wrapped in Spheral.
 """
 
 from PYB11Generator import *
+from SpheralCommon import *
+from spheralDimensions import *
+dims = spheralDimensions()
 
-PYB11opaque = ["std::vector<double>"]
+# PYB11opaque = ["std::vector<double>"]
 
 #-------------------------------------------------------------------------------
 # Includes
 #-------------------------------------------------------------------------------
-PYB11includes = ['"Solvers/SolverFunction.hh"',
+PYB11includes = ['"Solvers/containsConstantNodes.hh"',
+                 '"Solvers/EigenLinearSolver.hh"',
+                 '"Solvers/EigenOptions.hh"',
+                 '"Solvers/HypreLinearSolver.hh"',
+                 '"Solvers/HypreOptions.hh"',
+                 '"Solvers/IncrementalStatistic.hh"',
+                 '"Solvers/LinearSolver.hh"',
+                 '"Solvers/SolverFunction.hh"',
                  '"Solvers/KINSOL.hh"']
 
 #-------------------------------------------------------------------------------
@@ -19,5 +29,39 @@ PYB11includes = ['"Solvers/SolverFunction.hh"',
 #-------------------------------------------------------------------------------
 PYB11namespaces = ["Spheral"]
 
-from SolverFunction import *
+from EigenLinearSolver import *
+from EigenOptions import *
+from HypreLinearSolver import *
+from HypreOptions import *
+from IncrementalStatistic import *
 from KINSOL import *
+from LinearSolver import *
+from SolverFunction import *
+
+#-------------------------------------------------------------------------------
+# Instantiations
+#-------------------------------------------------------------------------------
+for ndim in dims:
+    # Dimension-dependent
+    exec('''
+@PYB11pycppname("containsConstantNodes")
+def containsConstantNodes1%(ndim)id(boundary = "const Boundary<Dim<%(ndim)i>>*"):
+    "Does this boundary contain constant boundary nodes?"
+    return "bool"
+@PYB11pycppname("containsConstantNodes")
+def containsConstantNodes2%(ndim)id(boundaries = "const std::vector<Boundary<Dim<%(ndim)i>>*>&"):
+    "Do these boundaries contain constant boundary nodes?"
+    return "bool"
+''' % {"ndim" : ndim})
+
+#-------------------------------------------------------------------------------
+# Scalar instantiations
+#-------------------------------------------------------------------------------
+scalar_types = (("int", "Ordinal"),
+                ("double", "Scalar"))
+
+for (value, label) in scalar_types:
+    exec('''
+%(label)sIncrementalStatistic = PYB11TemplateClass(IncrementalStatistic, template_parameters=("%(value)s"))
+''' % {"value" : value,
+       "label" : label})

--- a/src/PYB11/Utilities/Utilities_PYB11.py
+++ b/src/PYB11/Utilities/Utilities_PYB11.py
@@ -60,6 +60,7 @@ PYB11includes += ['"Utilities/setGlobalFlags.hh"',
                   '"Utilities/uniform_random.hh"',
                   '"Utilities/Timer.hh"',
                   '"Utilities/initializeAxom.hh"',
+                  '"Utilities/initializeHypre.hh"',
                   '"Distributed/Communicator.hh"',
                   '"adiak.hpp"',
                   '<algorithm>']
@@ -829,4 +830,12 @@ def initializeAxom():
     return "void"
 
 def finalizeAxom():
+    return "void"
+
+#...............................................................................
+# HYPRE stuff
+def initializeHypre():
+    return "void"
+
+def finalizeHypre():
     return "void"

--- a/src/SimulationControl/Spheral.py
+++ b/src/SimulationControl/Spheral.py
@@ -126,10 +126,12 @@ for shadowedthing in ("TillotsonEquationOfState",
         exec(f"from Shadow{shadowedthing} import {shadowedthing}{dim}d")
 
 #-------------------------------------------------------------------------------
-# Set up Axom
+# Set up Axom and HYPRE
 #-------------------------------------------------------------------------------
 import atexit
 initializeAxom()
+initializeHypre()
+atexit.register(finalizeHypre)
 atexit.register(finalizeAxom)
 
 # ------------------------------------------------------------------------------

--- a/src/Solvers/CMakeLists.txt
+++ b/src/Solvers/CMakeLists.txt
@@ -1,15 +1,32 @@
 include_directories(.)
-set(Solvers_inst )
+set(Solvers_inst
+  )
 
 set(Solvers_sources
+  EigenLinearSolver.cc
+  HypreFunctions.cc
+  HypreLinearSolver.cc
   KINSOL.cc
+  LinearSolver.cc
 )
 
 instantiate(Solvers_inst Solvers_sources)
 
 set(Solvers_headers
-  SolverFunction.hh
+  containsConstantNodes.hh
+  containsConstantNodesInline.hh
+  EigenLinearSolver.hh
+  EigenOptions.hh
+  HypreFunctions.hh
+  HypreLinearSolver.hh
+  HypreLinearSolverInline.hh
+  HypreOptions.hh
+  IncrementalStatistic.hh
+  IncrementalStatisticInline.hh
   KINSOL.hh
+  LinearSolver.hh
+  LinearSolverInline.hh
+  SolverFunction.hh
 )
 
 spheral_add_obj_library(Solvers SPHERAL_OBJ_LIBS)

--- a/src/Solvers/EigenLinearSolver.cc
+++ b/src/Solvers/EigenLinearSolver.cc
@@ -1,0 +1,177 @@
+//---------------------------------Spheral++----------------------------------//
+// EigenLinearSolver
+//
+// Represents a solver for a linear system of equations
+//----------------------------------------------------------------------------//
+
+#include "EigenLinearSolver.hh"
+
+#include <map>
+#include <numeric> // for std::accumulate
+#include "Utilities/DBC.hh"
+#include "Distributed/Process.hh"
+
+namespace Spheral {
+
+//------------------------------------------------------------------------------
+// Constructor
+//------------------------------------------------------------------------------
+EigenLinearSolver::
+EigenLinearSolver(std::shared_ptr<EigenOptions> options) :
+  mGraphChangedSinceFill(true),
+  mMatrixChangedSinceFactorization(true),
+  mOptions(options) {
+  this->setDescription("EigenLinearSolver");
+}
+
+//------------------------------------------------------------------------------
+// Initialize the matrices and vectors
+//------------------------------------------------------------------------------
+void
+EigenLinearSolver::
+initialize(const unsigned numLocVal,
+           const unsigned firstGlobInd,
+           const unsigned* numValsPerRow) {
+  VERIFY(Process::getTotalNumberOfProcesses() == 1);
+
+  mMatrix.setZero();
+  mMatrix.resize(numLocVal, numLocVal);
+  mRhs.resize(numLocVal);
+  mLhs.resize(numLocVal);
+
+  mGraphChangedSinceFill = true;
+}
+
+//------------------------------------------------------------------------------
+// Set matrix values
+//------------------------------------------------------------------------------
+void
+EigenLinearSolver::
+setMatRow(const unsigned numVals,
+          const unsigned globRowInd,
+          const unsigned* globColInd,
+          const double* colVal) {
+  VERIFY(globRowInd < mMatrix.rows());
+  for (auto j = 0u; j < numVals; ++j) {
+    mMatrix.coeffRef(globRowInd, globColInd[j]) = colVal[j];
+  }
+  mMatrixChangedSinceFactorization = true;
+}
+
+void
+EigenLinearSolver::
+setMatRows(const unsigned numRows,
+           const unsigned* numColsPerRow,
+           const unsigned* globRowInd,
+           const unsigned* globColInd,
+           const double* colVal) {
+  VERIFY(numRows > 0);
+  auto index = 0u;
+  for (auto i = 0u; i < numRows; ++i) {
+    setMatRow(numColsPerRow[i], globRowInd[i], globColInd + index, colVal + index);
+    index += numColsPerRow[i];
+  }
+  mMatrixChangedSinceFactorization = true;
+}
+
+//------------------------------------------------------------------------------
+// Assemble matrix after fill
+//------------------------------------------------------------------------------
+void
+EigenLinearSolver::
+assemble() {
+  mMatrix.makeCompressed();
+  
+  mGraphChangedSinceFill = false;
+  mMatrixChangedSinceFactorization = true;
+}
+
+//------------------------------------------------------------------------------
+// Create solver and preconditioner
+//------------------------------------------------------------------------------
+void
+EigenLinearSolver::
+finalize() {
+  VERIFY(!mGraphChangedSinceFill);
+
+  if (mOptions->qr) {
+    mQRSolver.analyzePattern(mMatrix);
+    mQRSolver.factorize(mMatrix);
+  }
+  else {
+    mLUSolver.analyzePattern(mMatrix);
+    mLUSolver.factorize(mMatrix);
+  }
+
+  mMatrixChangedSinceFactorization = false;
+}
+
+//------------------------------------------------------------------------------
+// Set/get values in LHS and RHS
+//------------------------------------------------------------------------------
+void
+EigenLinearSolver::
+set(const Component c,
+    const unsigned numVals,
+    const unsigned firstGlobInd,
+    const double* val) {
+  switch (c) {
+  case RHS:
+    for (auto i = 0u; i < numVals; ++i) {
+      mRhs(firstGlobInd + i) = val[i];
+    }
+    break;
+  case LHS:
+    for (auto i = 0u; i < numVals; ++i) {
+      mLhs(firstGlobInd + i) = val[i];
+    }
+    break;
+  }
+}
+
+void
+EigenLinearSolver::
+get(const Component c,
+    const unsigned numVals,
+    const unsigned firstGlobInd,
+    double* val) {
+  switch (c) {
+  case RHS:
+    for (auto i = 0u; i < numVals; ++i) {
+      val[i] = mRhs(firstGlobInd + i);
+    }
+    break;
+  case LHS:
+    for (auto i = 0u; i < numVals; ++i) {
+      val[i] = mLhs(firstGlobInd + i);
+    }
+    break;
+  }
+}
+
+//------------------------------------------------------------------------------
+// Solve the system of equations in place
+//------------------------------------------------------------------------------
+bool
+EigenLinearSolver::
+solve() {
+  VERIFY(!mMatrixChangedSinceFactorization);
+  if (mOptions->qr) {
+    mLhs = mQRSolver.solve(mRhs);
+  }
+  else {
+    mLhs = mLUSolver.solve(mRhs);
+  }
+  return true;
+}
+
+//------------------------------------------------------------------------------
+// Multiply by the matrix
+//------------------------------------------------------------------------------
+void
+EigenLinearSolver::
+multiply() {
+  mLhs = mMatrix * mRhs;
+}
+
+} // end namespace Spheral

--- a/src/Solvers/EigenLinearSolver.hh
+++ b/src/Solvers/EigenLinearSolver.hh
@@ -1,0 +1,96 @@
+//---------------------------------Spheral++----------------------------------//
+// EigenLinearSolver
+//
+// Solver linear system using Eigen
+// Only works on one processor
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_EigenLinearSolver_hh__
+#define __Spheral_EigenLinearSolver_hh__
+
+#include <memory>
+#include <vector>
+
+#include "Eigen/OrderingMethods"
+#include "Eigen/Sparse"
+#include "Eigen/SparseLU"
+#include "Eigen/SparseQR"
+
+#include "EigenOptions.hh"
+#include "LinearSolver.hh"
+
+namespace Spheral {
+
+class EigenLinearSolver : public LinearSolver {
+public:
+  typedef Eigen::SparseMatrix<double> MatrixType;
+  typedef Eigen::Triplet<double> DataType;
+  typedef Eigen::VectorXd VectorType;
+  typedef Eigen::SparseLU<MatrixType, Eigen::COLAMDOrdering<int>> LUSolverType;
+  typedef Eigen::SparseQR<MatrixType, Eigen::COLAMDOrdering<int>> QRSolverType;
+
+  using LinearSolver::Component;
+  
+  // Constructor
+  EigenLinearSolver(std::shared_ptr<EigenOptions> options);
+
+  // Create matrices and vectors
+  virtual void initialize(const unsigned numLocVal,
+                          const unsigned firstGlobInd,
+                          const unsigned* numValsPerRow) override;
+
+  // Begin the matrix fill
+  virtual void beginFill() override {}
+  
+  // Set values in matrix
+  virtual void setMatRow(const unsigned numVals,     // Number of values in this row
+                         const unsigned globRowInd,  // Global index of this row
+                         const unsigned* globColInd, // [numVals] Global indices for columns
+                         const double* colVal) override;  // [numVals] Values
+  virtual void setMatRows(const unsigned numRows,        // Number of rows
+                          const unsigned* numColsPerRow, // [numRows] Number of columns for each of these rows
+                          const unsigned* globRowInd,    // [numRows] Global indices for these rows
+                          const unsigned* globColInd,    // [numColsPerRow[numRows]] Global column indies for each value
+                          const double* colVal) override;     // [numColsPerRow[numRows]] Values
+
+  // Assemble matrix after fill
+  virtual void assemble() override;
+  
+  // Create solver/preconditioner
+  virtual void finalize() override;
+
+  // Set/get values
+  virtual void set(const Component c,
+                   const unsigned numVals,      // Number of vector values to set 
+                   const unsigned firstGlobInd, // First global index for values
+                   const double* val) override; // [numVals] Values
+  virtual void get(const Component c,
+                   const unsigned numVals,      // Number of vector values to set 
+                   const unsigned firstGlobInd, // First global index for values
+                   double* val) override;       // [numVals] Values
+  
+  // Solve the system of equations in place; returns true if converged
+  virtual bool solve() override;
+
+  // Multiply the matrix by a vector
+  virtual void multiply() override;
+  
+private:
+  // Have we initialized things correctly?
+  bool mGraphChangedSinceFill;
+  bool mMatrixChangedSinceFactorization;
+  
+  // Input data
+  std::shared_ptr<EigenOptions> mOptions;
+  
+  // Eigen data
+  MatrixType mMatrix;
+  LUSolverType mLUSolver;
+  QRSolverType mQRSolver;
+  VectorType mRhs;
+  VectorType mLhs;
+  
+}; // end class EigenLinearSolver
+
+} // end namespace Spheral
+
+#endif

--- a/src/Solvers/EigenOptions.hh
+++ b/src/Solvers/EigenOptions.hh
@@ -1,0 +1,20 @@
+//---------------------------------Spheral++----------------------------------//
+// EigenOptions
+//
+// Holds the options for Eigen solvers and preconditioners
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_EigenOptions_hh__
+#define __Spheral_EigenOptions_hh__
+
+namespace Spheral {
+
+struct EigenOptions {
+  EigenOptions() { }
+
+  bool qr = false;
+  
+}; // end struct EigenOptions
+
+} // end namespace Spheral
+
+#endif

--- a/src/Solvers/HypreFunctions.cc
+++ b/src/Solvers/HypreFunctions.cc
@@ -287,139 +287,139 @@ createPreconditioner(std::shared_ptr<HypreOptions> opt,
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGCreate, error code " + std::to_string(hypreStatus));
     
-    hypreStatus = HYPRE_BoomerAMGSetCoarsenType(tempPreconditioner, opt->coarsenTypeAMG);
+    hypreStatus = HYPRE_BoomerAMGSetCoarsenType(tempPreconditioner, opt->amg.coarsenType);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetCoarsenType, error code " + std::to_string(hypreStatus));
 
-    hypreStatus = HYPRE_BoomerAMGSetMeasureType(tempPreconditioner, opt->measure_type);
+    hypreStatus = HYPRE_BoomerAMGSetMeasureType(tempPreconditioner, opt->amg.measureType);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetMeasureType, error code " + std::to_string(hypreStatus));
 
-    hypreStatus = HYPRE_BoomerAMGSetTol(tempPreconditioner, opt->pcTol);
+    hypreStatus = HYPRE_BoomerAMGSetTol(tempPreconditioner, opt->amg.tol);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetTol, error code " + std::to_string(hypreStatus));
 
     hypreStatus
-      = HYPRE_BoomerAMGSetStrongThreshold(tempPreconditioner, opt->strongThresholdAMG);
+      = HYPRE_BoomerAMGSetStrongThreshold(tempPreconditioner, opt->amg.strongThreshold);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetStrongThreshold, error code " + std::to_string(hypreStatus));
 
-    hypreStatus = HYPRE_BoomerAMGSetMaxRowSum(tempPreconditioner, opt->maxRowSumAMG);
+    hypreStatus = HYPRE_BoomerAMGSetMaxRowSum(tempPreconditioner, opt->amg.maxRowSum);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetMaxRowSum, error code " + std::to_string(hypreStatus));
 
-    if (opt->interpTypeAMG >= 0) {
-      hypreStatus = HYPRE_BoomerAMGSetInterpType(tempPreconditioner, opt->interpTypeAMG);
+    if (opt->amg.interpType >= 0) {
+      hypreStatus = HYPRE_BoomerAMGSetInterpType(tempPreconditioner, opt->amg.interpType);
       VERIFY2(hypreStatus == 0,
               "HYPRE_BoomerAMGSetInterpType, error code " + std::to_string(hypreStatus));
     }
 
-    if (opt->aggNumLevelsAMG >= 0) {
+    if (opt->amg.aggNumLevels >= 0) {
       hypreStatus
-        = HYPRE_BoomerAMGSetAggNumLevels(tempPreconditioner, opt->aggNumLevelsAMG);
+        = HYPRE_BoomerAMGSetAggNumLevels(tempPreconditioner, opt->amg.aggNumLevels);
       VERIFY2(hypreStatus == 0,
               "HYPRE_BoomerAMGSetAggNumLevels, error code " + std::to_string(hypreStatus));
     }
-    if (opt->aggInterpTypeAMG >= 0) {
+    if (opt->amg.aggInterpType >= 0) {
       hypreStatus
-        = HYPRE_BoomerAMGSetAggInterpType(tempPreconditioner, opt->aggInterpTypeAMG);
+        = HYPRE_BoomerAMGSetAggInterpType(tempPreconditioner, opt->amg.aggInterpType);
       VERIFY2(hypreStatus == 0,
               "HYPRE_BoomerAMGSetAggInterpType, error code " + std::to_string(hypreStatus));
     }
-    if (opt->pMaxElmtsAMG >= 0){
-      hypreStatus = HYPRE_BoomerAMGSetPMaxElmts(tempPreconditioner, opt->pMaxElmtsAMG);
+    if (opt->amg.pMaxElmts >= 0){
+      hypreStatus = HYPRE_BoomerAMGSetPMaxElmts(tempPreconditioner, opt->amg.pMaxElmts);
       VERIFY2(hypreStatus == 0,
               "HYPRE_BoomerAMGSetPMaxElmts, error code " + std::to_string(hypreStatus));
     }
 
-    hypreStatus = HYPRE_BoomerAMGSetTruncFactor(tempPreconditioner, opt->truncFactorAMG);
+    hypreStatus = HYPRE_BoomerAMGSetTruncFactor(tempPreconditioner, opt->amg.truncFactor);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetTruncFactor, error code " + std::to_string(hypreStatus));
 
-    if (opt->printLevelAMG == -1) {
-      opt->printLevelAMG = opt->printLevel;
+    if (opt->amg.printLevel == -1) {
+      opt->amg.printLevel = opt->printLevel;
     }
-    hypreStatus = HYPRE_BoomerAMGSetPrintLevel(tempPreconditioner, opt->printLevelAMG);
+    hypreStatus = HYPRE_BoomerAMGSetPrintLevel(tempPreconditioner, opt->amg.printLevel);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetPrintLevel, error code " + std::to_string(hypreStatus));
 
-    hypreStatus = HYPRE_BoomerAMGSetLogging(tempPreconditioner, opt->logLevelAMG);
+    hypreStatus = HYPRE_BoomerAMGSetLogging(tempPreconditioner, opt->amg.logLevel);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetLogging, error code " + std::to_string(hypreStatus));
 
-    hypreStatus = HYPRE_BoomerAMGSetMinIter(tempPreconditioner, opt->minItersAMG);
+    hypreStatus = HYPRE_BoomerAMGSetMinIter(tempPreconditioner, opt->amg.minIters);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetMinIter, error code " + std::to_string(hypreStatus));
 
-    hypreStatus = HYPRE_BoomerAMGSetMaxIter(tempPreconditioner, opt->maxItersAMG);
+    hypreStatus = HYPRE_BoomerAMGSetMaxIter(tempPreconditioner, opt->amg.maxIters);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetMaxIter, error code " + std::to_string(hypreStatus));
 
-    hypreStatus = HYPRE_BoomerAMGSetCycleType(tempPreconditioner, opt->cycleType);
+    hypreStatus = HYPRE_BoomerAMGSetCycleType(tempPreconditioner, opt->amg.cycleType);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetCycleType, error code " + std::to_string(hypreStatus));
 
-    hypreStatus = HYPRE_BoomerAMGSetRelaxWt(tempPreconditioner, opt->relaxWeightAMG);
+    hypreStatus = HYPRE_BoomerAMGSetRelaxWt(tempPreconditioner, opt->amg.relaxWeight);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetRelaxWt, error code " + std::to_string(hypreStatus));
 
-    if (opt->relaxTypeCoarseAMG == -1) {
-      opt->relaxTypeCoarseAMG = opt->relaxTypeAMG;
+    if (opt->amg.relaxTypeCoarse == -1) {
+      opt->amg.relaxTypeCoarse = opt->amg.relaxType;
     }
 
     hypreStatus
       = HYPRE_BoomerAMGSetCycleRelaxType(tempPreconditioner,
-                                         opt->relaxTypeAMG, 1);
+                                         opt->amg.relaxType, 1);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetCycleRelaxType, error code " + std::to_string(hypreStatus));
 
     hypreStatus
       = HYPRE_BoomerAMGSetCycleRelaxType(tempPreconditioner,
-                                         opt->relaxTypeAMG, 2);
+                                         opt->amg.relaxType, 2);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetCycleRelaxType, error code " + std::to_string(hypreStatus));
 
     hypreStatus
       = HYPRE_BoomerAMGSetCycleRelaxType(tempPreconditioner,
-                                         opt->relaxTypeCoarseAMG, 3);
+                                         opt->amg.relaxTypeCoarse, 3);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetCycleRelaxType, error code " + std::to_string(hypreStatus));
 
     hypreStatus
       = HYPRE_BoomerAMGSetCycleNumSweeps(tempPreconditioner,
-                                         opt->cycleNumSweepsAMG, 1);
+                                         opt->amg.cycleNumSweeps, 1);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetCycleNumSweeps, error code " + std::to_string(hypreStatus));
 
     hypreStatus
       = HYPRE_BoomerAMGSetCycleNumSweeps(tempPreconditioner,
-                                         opt->cycleNumSweepsAMG, 2);
+                                         opt->amg.cycleNumSweeps, 2);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetCycleNumSweeps, error code " + std::to_string(hypreStatus));
 
-    if (opt->relaxTypeCoarseAMG == 19
-        || opt->relaxTypeCoarseAMG == 29
-        || opt->relaxTypeCoarseAMG == 9) {
-      opt->cycleNumSweepsCoarseAMG = 1;
+    if (opt->amg.relaxTypeCoarse == 19
+        || opt->amg.relaxTypeCoarse == 29
+        || opt->amg.relaxTypeCoarse == 9) {
+      opt->amg.cycleNumSweepsCoarse = 1;
     }
-    else if (opt->cycleNumSweepsCoarseAMG == -1) {
-      opt->cycleNumSweepsCoarseAMG = opt->cycleNumSweepsAMG;
+    else if (opt->amg.cycleNumSweepsCoarse == -1) {
+      opt->amg.cycleNumSweepsCoarse = opt->amg.cycleNumSweeps;
     }
     hypreStatus = HYPRE_BoomerAMGSetCycleNumSweeps(tempPreconditioner,
-                                                   opt->cycleNumSweepsCoarseAMG, 3);
+                                                   opt->amg.cycleNumSweepsCoarse, 3);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetCycleNumSweeps, error code " + std::to_string(hypreStatus));
 
-    hypreStatus = HYPRE_BoomerAMGSetMaxLevels(tempPreconditioner, opt->maxLevelsAMG);
+    hypreStatus = HYPRE_BoomerAMGSetMaxLevels(tempPreconditioner, opt->amg.maxLevels);
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGSetMaxLevels, error code " + std::to_string(hypreStatus));
 
-    if (opt->numFunctionsAMG > 1) {
-      hypreStatus = HYPRE_BoomerAMGSetNumFunctions(tempPreconditioner, opt->numFunctionsAMG);
+    if (opt->amg.numFunctions > 1) {
+      hypreStatus = HYPRE_BoomerAMGSetNumFunctions(tempPreconditioner, opt->amg.numFunctions);
       VERIFY2(hypreStatus == 0,
               "HYPRE_BoomerAMGSetNumFunctions, error code " + std::to_string(hypreStatus));
 
-      hypreStatus = HYPRE_BoomerAMGSetNodal(tempPreconditioner, opt->nodalAMG);
+      hypreStatus = HYPRE_BoomerAMGSetNodal(tempPreconditioner, opt->amg.nodal);
       VERIFY2(hypreStatus == 0,
               "HYPRE_BoomerAMGSetNodal, error code " + std::to_string(hypreStatus));
     }
@@ -442,27 +442,27 @@ createPreconditioner(std::shared_ptr<HypreOptions> opt,
     VERIFY2(hypreStatus == 0,
             "HYPRE_BoomerAMGDestroy, error code " + std::to_string(hypreStatus));
     
-    hypreStatus = HYPRE_EuclidSetLevel(tempPreconditioner, opt->factorLevelILU);
+    hypreStatus = HYPRE_EuclidSetLevel(tempPreconditioner, opt->ilu.factorLevel);
     VERIFY2(hypreStatus == 0,
             "HYPRE_EuclidSetLevel, error code " + std::to_string(hypreStatus));
 
-    if (opt->printLevelILU == -1) {
-      opt->printLevelILU = opt->printLevel;
+    if (opt->ilu.printLevel == -1) {
+      opt->ilu.printLevel = opt->printLevel;
     }
-    hypreStatus = HYPRE_EuclidSetStats(tempPreconditioner, opt->printLevelILU);
+    hypreStatus = HYPRE_EuclidSetStats(tempPreconditioner, opt->ilu.printLevel);
     VERIFY2(hypreStatus == 0,
             "HYPRE_EuclidSetStats, error code " + std::to_string(hypreStatus));
 
-    if (opt->useILUT) {
-      hypreStatus = HYPRE_EuclidSetILUT(tempPreconditioner, opt->dropToleranceILU);
+    if (opt->ilu.useILUT) {
+      hypreStatus = HYPRE_EuclidSetILUT(tempPreconditioner, opt->ilu.dropTolerance);
     }
     else {
-      hypreStatus = HYPRE_EuclidSetSparseA(tempPreconditioner, opt->dropToleranceILU);
+      hypreStatus = HYPRE_EuclidSetSparseA(tempPreconditioner, opt->ilu.dropTolerance);
       VERIFY2(hypreStatus == 0,
               "HYPRE_EuclidSetILUT, error code " + std::to_string(hypreStatus));
     }
 
-    hypreStatus = HYPRE_EuclidSetRowScale(tempPreconditioner, opt->rowScaleILU);
+    hypreStatus = HYPRE_EuclidSetRowScale(tempPreconditioner, opt->ilu.rowScale);
     VERIFY2(hypreStatus == 0,
             "HYPRE_EuclidSetRowScale, error code " + std::to_string(hypreStatus));
     

--- a/src/Solvers/HypreFunctions.cc
+++ b/src/Solvers/HypreFunctions.cc
@@ -1,0 +1,699 @@
+//---------------------------------Spheral++----------------------------------//
+// HypreFunctions
+//
+// Convenience functions for Hypre
+//----------------------------------------------------------------------------//
+
+#include "HypreFunctions.hh"
+
+#include <map>
+#include <numeric> // for std::iota
+
+#include "_hypre_parcsr_ls.h"
+#include "HYPRE.h"
+#include "HYPRE_IJ_mv.h"
+
+#include "Distributed/Communicator.hh"
+#include "Solvers/HypreOptions.hh"
+#include "Solvers/IncrementalStatistic.hh"
+#include "Utilities/DBC.hh"
+#include "Utilities/Timer.hh"
+
+static_assert(sizeof(int) == sizeof(HYPRE_Int),
+              "if this fails, need to refactor to convert to HYPRE_Int");
+static_assert(sizeof(int) == sizeof(HYPRE_BigInt),
+              "if this fails, need to refactor to convert to HYPRE_BigInt");
+
+namespace Spheral {
+
+//------------------------------------------------------------------------------
+// Create Hypre vector that should self-destruct when it goes out of scope.
+//------------------------------------------------------------------------------
+std::shared_ptr<HypreFunctions::VectorType>
+HypreFunctions::
+createVector(const unsigned numLocVal,
+             const unsigned firstGlobInd) {
+  TIME_FUNCTION;
+  const auto lastGlobInd = static_cast<int>(firstGlobInd + numLocVal) - 1;
+
+  int hypreStatus;
+  VectorType* tempVector;
+
+  hypreStatus = HYPRE_IJVectorCreate(Communicator::communicator(),
+                                     firstGlobInd,
+                                     lastGlobInd,
+                                     &tempVector);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorCreate, error code " + std::to_string(hypreStatus));
+  
+  hypreStatus = HYPRE_IJVectorSetObjectType(tempVector, HYPRE_PARCSR);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorSetObjectType, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_IJVectorInitialize(tempVector);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorInitialize, error code " + std::to_string(hypreStatus));
+  
+  return std::shared_ptr<VectorType>(tempVector, HYPRE_IJVectorDestroy);
+}
+
+//------------------------------------------------------------------------------
+// Create Hypre matrix that should self-destruct when it goes out of scope.
+//------------------------------------------------------------------------------
+std::shared_ptr<HypreFunctions::MatrixType>
+HypreFunctions::
+createMatrix(const unsigned numLocVal,
+             const unsigned firstGlobInd,
+             const unsigned* numValsPerRow) {
+  TIME_FUNCTION;
+  const auto lastGlobInd = static_cast<int>(firstGlobInd + numLocVal) - 1;
+
+  int hypreStatus;
+  MatrixType* tempMatrix;
+  hypreStatus = HYPRE_IJMatrixCreate(Communicator::communicator(),
+                                     firstGlobInd,
+                                     lastGlobInd,
+                                     firstGlobInd,
+                                     lastGlobInd,
+                                     &tempMatrix);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixCreate, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_IJMatrixSetObjectType(tempMatrix, HYPRE_PARCSR);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixSetObjectType, error code " + std::to_string(hypreStatus));
+  
+  hypreStatus = HYPRE_IJMatrixSetRowSizes(tempMatrix, (const int*)numValsPerRow);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixSetRowSizes, error code " + std::to_string(hypreStatus));
+  
+  return std::shared_ptr<MatrixType>(tempMatrix, HYPRE_IJMatrixDestroy);
+}
+
+//------------------------------------------------------------------------------
+// Create Hypre matrix that should self-destruct when it goes out of scope.
+//------------------------------------------------------------------------------
+void
+HypreFunctions::
+initializeMatrix(std::shared_ptr<MatrixType> matrix) {
+  TIME_FUNCTION;
+  int hypreStatus;
+  hypreStatus = HYPRE_IJMatrixInitialize(matrix.get());
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixInitialize, error code " + std::to_string(hypreStatus));
+}
+
+//------------------------------------------------------------------------------
+// Put values into the matrix
+//------------------------------------------------------------------------------
+void
+HypreFunctions::
+setMatrixValues(const unsigned numRows,
+                const unsigned* numColsPerRow,
+                const unsigned* globRowInd,
+                const unsigned* globColInd,
+                const double* colVal,
+                std::shared_ptr<HypreOptions> opt,
+                std::shared_ptr<MatrixType> matrix) {
+  TIME_FUNCTION;
+  if (numRows == 0) {
+    return;
+  }
+  BEGIN_CONTRACT_SCOPE
+  {
+    auto index = 0u;
+    for (auto i = 0u; i < numRows; ++i) {
+      for (auto j = 0u; j < numColsPerRow[i]; ++j, ++index) {
+        CHECK2(std::isfinite(colVal[index]),
+               "NaN found in input to Hypre matrix at index " + std::to_string(globRowInd[i]) + ", " + std::to_string(globColInd[index]));
+      }
+    }
+  }
+  END_CONTRACT_SCOPE
+
+  int hypreStatus;
+  if (opt->addToValues) {
+    hypreStatus = HYPRE_IJMatrixAddToValues(matrix.get(),
+                                            numRows,
+                                            (int*)numColsPerRow,
+                                            (const int*)globRowInd,
+                                            (const int*)globColInd,
+                                            colVal);
+  }
+  else {
+    hypreStatus = HYPRE_IJMatrixSetValues(matrix.get(),
+                                          numRows,
+                                          (int*)numColsPerRow,
+                                          (const int*)globRowInd,
+                                          (const int*)globColInd,
+                                          colVal);
+  }
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixSetValues, error code " + std::to_string(hypreStatus));
+}
+
+//------------------------------------------------------------------------------
+// Put values into hypre vector
+//------------------------------------------------------------------------------
+void
+HypreFunctions::
+setVectorValues(const unsigned numVals,
+                const unsigned firstGlobInd,
+                const double* val,
+                std::shared_ptr<VectorType> vec) {
+  TIME_FUNCTION;
+  if (numVals == 0) {
+    return;
+  }
+  BEGIN_CONTRACT_SCOPE
+  {
+    for (auto i = 0u; i < numVals; ++i) {
+      CHECK2(std::isfinite(val[i]), "NaN found in input to Hypre vector at index " + std::to_string(firstGlobInd + i));
+    }
+  }
+  END_CONTRACT_SCOPE
+  
+  std::vector<int> globalIndices(numVals);
+  std::iota(globalIndices.begin(), globalIndices.end(), firstGlobInd);
+  
+  int hypreStatus;
+  hypreStatus = HYPRE_IJVectorSetValues(vec.get(),
+                                        numVals,
+                                        &globalIndices[0],
+                                        val);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorSetValues, error code " + std::to_string(hypreStatus));
+  
+}
+
+//------------------------------------------------------------------------------
+// Get values from hypre vector
+//------------------------------------------------------------------------------
+void
+HypreFunctions::
+getVectorValues(const unsigned numVals,
+                const unsigned firstGlobInd,
+                double* val,
+                std::shared_ptr<VectorType> vec) {
+  TIME_FUNCTION;
+  if (numVals == 0) {
+    return;
+  }
+  
+  std::vector<int> globalIndices(numVals);
+  std::iota(globalIndices.begin(), globalIndices.end(), firstGlobInd);
+  
+  int hypreStatus;
+  hypreStatus = HYPRE_IJVectorGetValues(vec.get(),
+                                        numVals,
+                                        &globalIndices[0],
+                                        val);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorGetValues, error code " + std::to_string(hypreStatus));
+
+  BEGIN_CONTRACT_SCOPE
+  {
+    for (auto i = 0u; i < numVals; ++i) {
+      CHECK2(std::isfinite(val[i]), "NaN found in Hypre output at index " + std::to_string(firstGlobInd + i));
+    }
+  }
+  END_CONTRACT_SCOPE
+}
+
+void
+HypreFunctions::
+assembleMatrix(std::shared_ptr<MatrixType> matrix) {
+  TIME_FUNCTION;
+  int hypreStatus;
+  hypreStatus = HYPRE_IJMatrixAssemble(matrix.get());
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixAssemble, error code " + std::to_string(hypreStatus));
+}
+
+//------------------------------------------------------------------------------
+// Create Hypre solver that should self-destruct when it goes out of scope.
+// Right now, the constants and type (GMRES) are hardcoded. At the least, the
+// kDim should be changed to a variable. 
+//------------------------------------------------------------------------------
+std::shared_ptr<HypreFunctions::SolverType>
+HypreFunctions::
+createSolver(std::shared_ptr<HypreOptions> opt) {
+  TIME_FUNCTION;
+  int hypreStatus;
+  SolverType* tempSolver;
+  hypreStatus = HYPRE_ParCSRGMRESCreate(Communicator::communicator(), &tempSolver);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRGMRESCreate, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_ParCSRGMRESSetKDim(tempSolver, opt->kDim);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_PARCSRGMRESSetKDim, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_ParCSRGMRESSetMinIter(tempSolver, opt->minIters);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRGMRESSetMinIter, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_ParCSRGMRESSetLogging(tempSolver, opt->logLevel);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRGMRESSetLogging, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_ParCSRGMRESSetPrintLevel(tempSolver, opt->printLevel);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRMGRESSetPrintLevel, error code " + std::to_string(hypreStatus));
+
+  return std::shared_ptr<SolverType>(tempSolver, HYPRE_ParCSRGMRESDestroy);
+}
+
+//------------------------------------------------------------------------------
+// Create Hypre preconditioner that should self-destruct when it goes out of
+// scope.
+// The constants and type (AMG) are hardcoded to start out with.
+//------------------------------------------------------------------------------
+std::shared_ptr<HypreFunctions::SolverType>
+HypreFunctions::
+createPreconditioner(std::shared_ptr<HypreOptions> opt,
+                     std::shared_ptr<SolverType> solver) {
+  TIME_FUNCTION;
+  CHECK(solver);
+
+  int hypreStatus;
+  SolverType* tempPreconditioner;
+
+  switch (opt->preconditionerType) {
+  case HyprePreconditionerType::NoPreconditioner:
+    return std::shared_ptr<SolverType>();
+  case HyprePreconditionerType::AMGPreconditioner:
+    hypreStatus = HYPRE_BoomerAMGCreate(&tempPreconditioner);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGCreate, error code " + std::to_string(hypreStatus));
+    
+    hypreStatus = HYPRE_BoomerAMGSetCoarsenType(tempPreconditioner, opt->coarsenTypeAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetCoarsenType, error code " + std::to_string(hypreStatus));
+
+    hypreStatus = HYPRE_BoomerAMGSetMeasureType(tempPreconditioner, opt->measure_type);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetMeasureType, error code " + std::to_string(hypreStatus));
+
+    hypreStatus = HYPRE_BoomerAMGSetTol(tempPreconditioner, opt->pcTol);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetTol, error code " + std::to_string(hypreStatus));
+
+    hypreStatus
+      = HYPRE_BoomerAMGSetStrongThreshold(tempPreconditioner, opt->strongThresholdAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetStrongThreshold, error code " + std::to_string(hypreStatus));
+
+    hypreStatus = HYPRE_BoomerAMGSetMaxRowSum(tempPreconditioner, opt->maxRowSumAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetMaxRowSum, error code " + std::to_string(hypreStatus));
+
+    if (opt->interpTypeAMG >= 0) {
+      hypreStatus = HYPRE_BoomerAMGSetInterpType(tempPreconditioner, opt->interpTypeAMG);
+      VERIFY2(hypreStatus == 0,
+              "HYPRE_BoomerAMGSetInterpType, error code " + std::to_string(hypreStatus));
+    }
+
+    if (opt->aggNumLevelsAMG >= 0) {
+      hypreStatus
+        = HYPRE_BoomerAMGSetAggNumLevels(tempPreconditioner, opt->aggNumLevelsAMG);
+      VERIFY2(hypreStatus == 0,
+              "HYPRE_BoomerAMGSetAggNumLevels, error code " + std::to_string(hypreStatus));
+    }
+    if (opt->aggInterpTypeAMG >= 0) {
+      hypreStatus
+        = HYPRE_BoomerAMGSetAggInterpType(tempPreconditioner, opt->aggInterpTypeAMG);
+      VERIFY2(hypreStatus == 0,
+              "HYPRE_BoomerAMGSetAggInterpType, error code " + std::to_string(hypreStatus));
+    }
+    if (opt->pMaxElmtsAMG >= 0){
+      hypreStatus = HYPRE_BoomerAMGSetPMaxElmts(tempPreconditioner, opt->pMaxElmtsAMG);
+      VERIFY2(hypreStatus == 0,
+              "HYPRE_BoomerAMGSetPMaxElmts, error code " + std::to_string(hypreStatus));
+    }
+
+    hypreStatus = HYPRE_BoomerAMGSetTruncFactor(tempPreconditioner, opt->truncFactorAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetTruncFactor, error code " + std::to_string(hypreStatus));
+
+    if (opt->printLevelAMG == -1) {
+      opt->printLevelAMG = opt->printLevel;
+    }
+    hypreStatus = HYPRE_BoomerAMGSetPrintLevel(tempPreconditioner, opt->printLevelAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetPrintLevel, error code " + std::to_string(hypreStatus));
+
+    hypreStatus = HYPRE_BoomerAMGSetLogging(tempPreconditioner, opt->logLevelAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetLogging, error code " + std::to_string(hypreStatus));
+
+    hypreStatus = HYPRE_BoomerAMGSetMinIter(tempPreconditioner, opt->minItersAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetMinIter, error code " + std::to_string(hypreStatus));
+
+    hypreStatus = HYPRE_BoomerAMGSetMaxIter(tempPreconditioner, opt->maxItersAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetMaxIter, error code " + std::to_string(hypreStatus));
+
+    hypreStatus = HYPRE_BoomerAMGSetCycleType(tempPreconditioner, opt->cycleType);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetCycleType, error code " + std::to_string(hypreStatus));
+
+    hypreStatus = HYPRE_BoomerAMGSetRelaxWt(tempPreconditioner, opt->relaxWeightAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetRelaxWt, error code " + std::to_string(hypreStatus));
+
+    if (opt->relaxTypeCoarseAMG == -1) {
+      opt->relaxTypeCoarseAMG = opt->relaxTypeAMG;
+    }
+
+    hypreStatus
+      = HYPRE_BoomerAMGSetCycleRelaxType(tempPreconditioner,
+                                         opt->relaxTypeAMG, 1);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetCycleRelaxType, error code " + std::to_string(hypreStatus));
+
+    hypreStatus
+      = HYPRE_BoomerAMGSetCycleRelaxType(tempPreconditioner,
+                                         opt->relaxTypeAMG, 2);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetCycleRelaxType, error code " + std::to_string(hypreStatus));
+
+    hypreStatus
+      = HYPRE_BoomerAMGSetCycleRelaxType(tempPreconditioner,
+                                         opt->relaxTypeCoarseAMG, 3);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetCycleRelaxType, error code " + std::to_string(hypreStatus));
+
+    hypreStatus
+      = HYPRE_BoomerAMGSetCycleNumSweeps(tempPreconditioner,
+                                         opt->cycleNumSweepsAMG, 1);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetCycleNumSweeps, error code " + std::to_string(hypreStatus));
+
+    hypreStatus
+      = HYPRE_BoomerAMGSetCycleNumSweeps(tempPreconditioner,
+                                         opt->cycleNumSweepsAMG, 2);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetCycleNumSweeps, error code " + std::to_string(hypreStatus));
+
+    if (opt->relaxTypeCoarseAMG == 19
+        || opt->relaxTypeCoarseAMG == 29
+        || opt->relaxTypeCoarseAMG == 9) {
+      opt->cycleNumSweepsCoarseAMG = 1;
+    }
+    else if (opt->cycleNumSweepsCoarseAMG == -1) {
+      opt->cycleNumSweepsCoarseAMG = opt->cycleNumSweepsAMG;
+    }
+    hypreStatus = HYPRE_BoomerAMGSetCycleNumSweeps(tempPreconditioner,
+                                                   opt->cycleNumSweepsCoarseAMG, 3);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetCycleNumSweeps, error code " + std::to_string(hypreStatus));
+
+    hypreStatus = HYPRE_BoomerAMGSetMaxLevels(tempPreconditioner, opt->maxLevelsAMG);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetMaxLevels, error code " + std::to_string(hypreStatus));
+
+    if (opt->numFunctionsAMG > 1) {
+      hypreStatus = HYPRE_BoomerAMGSetNumFunctions(tempPreconditioner, opt->numFunctionsAMG);
+      VERIFY2(hypreStatus == 0,
+              "HYPRE_BoomerAMGSetNumFunctions, error code " + std::to_string(hypreStatus));
+
+      hypreStatus = HYPRE_BoomerAMGSetNodal(tempPreconditioner, opt->nodalAMG);
+      VERIFY2(hypreStatus == 0,
+              "HYPRE_BoomerAMGSetNodal, error code " + std::to_string(hypreStatus));
+    }
+
+    hypreStatus = HYPRE_ParCSRGMRESSetPrecond(solver.get(),
+                                              HYPRE_BoomerAMGSolve,
+                                              HYPRE_BoomerAMGSetup,
+                                              tempPreconditioner);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_ParCSRGMRESSetPrecond, error code " + std::to_string(hypreStatus));
+      
+    // Set up preconditioner
+    hypreStatus = HYPRE_BoomerAMGSetSetupType(tempPreconditioner, 1);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGSetSetupType, error code " + std::to_string(hypreStatus));
+  
+    return std::shared_ptr<SolverType>(tempPreconditioner, HYPRE_BoomerAMGDestroy);
+  case HyprePreconditionerType::ILUPreconditioner:
+    hypreStatus = HYPRE_EuclidCreate(Communicator::communicator(), &tempPreconditioner);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_BoomerAMGDestroy, error code " + std::to_string(hypreStatus));
+    
+    hypreStatus = HYPRE_EuclidSetLevel(tempPreconditioner, opt->factorLevelILU);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_EuclidSetLevel, error code " + std::to_string(hypreStatus));
+
+    if (opt->printLevelILU == -1) {
+      opt->printLevelILU = opt->printLevel;
+    }
+    hypreStatus = HYPRE_EuclidSetStats(tempPreconditioner, opt->printLevelILU);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_EuclidSetStats, error code " + std::to_string(hypreStatus));
+
+    if (opt->useILUT) {
+      hypreStatus = HYPRE_EuclidSetILUT(tempPreconditioner, opt->dropToleranceILU);
+    }
+    else {
+      hypreStatus = HYPRE_EuclidSetSparseA(tempPreconditioner, opt->dropToleranceILU);
+      VERIFY2(hypreStatus == 0,
+              "HYPRE_EuclidSetILUT, error code " + std::to_string(hypreStatus));
+    }
+
+    hypreStatus = HYPRE_EuclidSetRowScale(tempPreconditioner, opt->rowScaleILU);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_EuclidSetRowScale, error code " + std::to_string(hypreStatus));
+    
+    hypreStatus = HYPRE_ParCSRGMRESSetPrecond(solver.get(),
+                                              HYPRE_EuclidSolve,
+                                              HYPRE_EuclidSetup,
+                                              tempPreconditioner);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_ParCSRGMRESSetPrecond, error code " + std::to_string(hypreStatus));
+    
+    return std::shared_ptr<SolverType>(tempPreconditioner, HYPRE_EuclidDestroy);
+  default:
+    VERIFY2(false, "incorrect preconditioner type");
+    return std::shared_ptr<SolverType>(); // So compiler doesn't complain
+  }
+}
+
+void
+HypreFunctions::
+setupSolver(std::shared_ptr<HypreOptions> opt,
+            std::shared_ptr<SolverType> solver,
+            std::shared_ptr<MatrixType> matrix,
+            std::shared_ptr<VectorType> lhs,
+            std::shared_ptr<VectorType> rhs) {
+  TIME_FUNCTION;
+  // Get storage in CRS format
+  HYPRE_ParCSRMatrix hypreParMatrix;
+  HYPRE_ParVector hypreParLHS;
+  HYPRE_ParVector hypreParRHS;
+
+  int hypreStatus;
+  hypreStatus = HYPRE_IJMatrixGetObject(matrix.get(),
+                                        (void **)&hypreParMatrix);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixGetObject, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_IJVectorGetObject(lhs.get(),
+                                        (void **)&hypreParLHS);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorGetObject, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_IJVectorGetObject(rhs.get(),
+                                        (void **)&hypreParRHS);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorGetObject, error code " + std::to_string(hypreStatus));
+  
+  hypreStatus = HYPRE_ParCSRGMRESSetLogging(solver.get(), opt->logLevel);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixPrint, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_ParCSRGMRESSetPrintLevel(solver.get(), opt->printLevel);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRGMRESSetPrintLevel, error code " + std::to_string(hypreStatus));
+
+  hypreStatus
+    = HYPRE_ParCSRGMRESSetMaxIter(solver.get(), opt->maxNumberOfIterations);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRGMRESSetMaxIter, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_ParCSRGMRESSetTol(solver.get(), opt->toleranceL2);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRGMRESSetTol, error code " + std::to_string(hypreStatus));
+
+  if (opt->useRobustTolerance) {
+    hypreStatus = HYPRE_GMRESSetSkipRealResidualCheck(solver.get(), 1);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_GMRESSetSkipRealResidualCheck, error code " + std::to_string(hypreStatus));
+  }
+
+  hypreStatus
+    = HYPRE_ParCSRGMRESSetAbsoluteTol(solver.get(), opt->absoluteTolerance);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRGMRESSetAbsoluteTol, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_ParCSRGMRESSetup(solver.get(),
+                                       hypreParMatrix,
+                                       hypreParRHS,
+                                       hypreParLHS);
+  VERIFY2(hypreStatus == 0,
+          "ParCSRGMRESSetup, error code " + std::to_string(hypreStatus));
+}
+
+//------------------------------------------------------------------------------
+// Solve the linear system
+//------------------------------------------------------------------------------
+static int solveCall = 0;
+std::pair<int, double>
+HypreFunctions::
+solveSystem(std::shared_ptr<HypreOptions> opt,
+            std::shared_ptr<SolverType> solver,
+            std::shared_ptr<MatrixType> matrix,
+            std::shared_ptr<VectorType> lhs,
+            std::shared_ptr<VectorType> rhs,
+            std::string description) {
+  TIME_FUNCTION;
+  // Get storage in CRS format
+  HYPRE_ParCSRMatrix hypreParMatrix;
+  HYPRE_ParVector hypreParLHS;
+  HYPRE_ParVector hypreParRHS;
+
+  int hypreStatus;
+  hypreStatus = HYPRE_IJMatrixGetObject(matrix.get(),
+                                        (void **)&hypreParMatrix);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixGetObject, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_IJVectorGetObject(lhs.get(),
+                                        (void **)&hypreParLHS);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorGetObject, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_IJVectorGetObject(rhs.get(),
+                                        (void **)&hypreParRHS);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorGetObject, error code " + std::to_string(hypreStatus));
+  
+  if (opt->saveLinearSystem) {
+    const auto matName = "HypreMatrix_" + description + "_" + std::to_string(solveCall);
+    const auto rhsName = "HypreRHS_" + description + "_" + std::to_string(solveCall);
+    const auto initName = "HypreInit_" + description + "_" + std::to_string(solveCall);
+    HYPRE_IJMatrixPrint(matrix.get(), matName.c_str());
+    HYPRE_IJVectorPrint(rhs.get(), rhsName.c_str());
+    HYPRE_IJVectorPrint(lhs.get(), initName.c_str());
+  }
+  
+  int solveStatus = HYPRE_ParCSRGMRESSolve(solver.get(),
+                                           hypreParMatrix,
+                                           hypreParRHS,
+                                           hypreParLHS);
+  int numIterations = 0;
+  if (solveStatus) {
+    VERIFY2(!HYPRE_CheckError(solveStatus, HYPRE_ERROR_GENERIC),
+            "INF or NaN in Matrix, RHS, or initial guess (" + description + ")");
+    VERIFY2(!HYPRE_CheckError(solveStatus, HYPRE_ERROR_MEMORY),
+            "HYPRE ParCSRGMRESSetupcannot allocate memory (" + description + ")");
+    VERIFY2(HYPRE_CheckError(solveStatus, HYPRE_ERROR_CONV),
+            "GMRES failed with (unknown) solver status (" + description + "):" << solveStatus);
+    HYPRE_ClearError(HYPRE_ERROR_CONV);
+    numIterations = opt->maxNumberOfIterations;
+  }
+  else {
+    hypreStatus
+      = HYPRE_ParCSRGMRESGetNumIterations(solver.get(), &numIterations);
+    VERIFY2(hypreStatus == 0,
+            "HYPRE_ParCSRGMRESGetNumIterations, error code " + std::to_string(hypreStatus));
+  }
+
+  double finalResNorm;
+  hypreStatus = HYPRE_ParCSRGMRESGetFinalRelativeResidualNorm(solver.get(),
+                                                              &finalResNorm);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRGMRESGetFinalRelativeResidualNorm, error code " + std::to_string(hypreStatus));
+
+  if (opt->saveLinearSystem) {
+    const auto lhsName = "HypreLHS_" + description + "_" + std::to_string(solveCall);
+    HYPRE_IJVectorPrint(lhs.get(), lhsName.c_str());
+    ++solveCall;
+  }
+
+  if (numIterations >= opt->maxNumberOfIterations) {
+    std::ostringstream oss;
+    oss << std::scientific << std::setprecision(2);
+    oss << "Hypre solver (" << description << ") did not converge, norm: " << finalResNorm;
+    const auto message = oss.str();
+    if (opt->quitIfDiverged) {
+      VERIFY2(false, message);
+    }
+    else {
+      if (opt->warnIfDiverged && Process::getRank() == 0) {
+        std::cerr << message << std::endl;
+      }
+    }
+  }
+
+  return std::make_pair(numIterations, finalResNorm);
+}
+
+//------------------------------------------------------------------------------
+// Multiply the linear system
+//------------------------------------------------------------------------------
+void
+HypreFunctions::
+multiplySystem(std::shared_ptr<HypreOptions> opt,
+               std::shared_ptr<MatrixType> matrix,
+               std::shared_ptr<VectorType> lhs,
+               std::shared_ptr<VectorType> rhs,
+               std::string description) {
+  TIME_FUNCTION;
+  // Get storage in CRS format
+  HYPRE_ParCSRMatrix hypreParMatrix;
+  HYPRE_ParVector hypreParLHS;
+  HYPRE_ParVector hypreParRHS;
+
+  int hypreStatus;
+  hypreStatus = HYPRE_IJMatrixGetObject(matrix.get(),
+                                        (void **)&hypreParMatrix);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJMatrixGetObject, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_IJVectorGetObject(lhs.get(),
+                                        (void **)&hypreParLHS);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorGetObject, error code " + std::to_string(hypreStatus));
+
+  hypreStatus = HYPRE_IJVectorGetObject(rhs.get(),
+                                        (void **)&hypreParRHS);
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_IJVectorGetObject, error code " + std::to_string(hypreStatus));
+
+  if (opt->saveLinearSystem) {
+    const auto matName = "HypreMatrix_" + description + "_" + std::to_string(solveCall);
+    const auto initName = "HypreLHS_" + description + "_" + std::to_string(solveCall);
+    HYPRE_IJMatrixPrint(matrix.get(), matName.c_str());
+    HYPRE_IJVectorPrint(lhs.get(), initName.c_str());
+  }
+  
+  // Perform matrix multiplication, y = \alpha * A x + \beta y
+  hypreStatus = HYPRE_ParCSRMatrixMatvec(1.0, // \alpha
+                                         hypreParMatrix, // A
+                                         hypreParLHS, // x
+                                         0.0, // \beta
+                                         hypreParRHS); // y
+  
+  if (opt->saveLinearSystem) {
+    const auto rhsName = "HypreRHS_" + description + "_" + std::to_string(solveCall);
+    HYPRE_IJVectorPrint(rhs.get(), rhsName.c_str());
+    ++solveCall;
+  }
+  
+  VERIFY2(hypreStatus == 0,
+          "HYPRE_ParCSRMatrixMatvec, error code " + std::to_string(hypreStatus));
+}
+
+} // end namespace Spheral

--- a/src/Solvers/HypreFunctions.hh
+++ b/src/Solvers/HypreFunctions.hh
@@ -1,0 +1,102 @@
+//---------------------------------Spheral++----------------------------------//
+// HypreFunctions
+//
+// Convenience functions for Hypre
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_HypreFunctions_hh__
+#define __Spheral_HypreFunctions_hh__
+
+#include <memory>
+#include <string>
+
+struct hypre_IJMatrix_struct;
+struct hypre_IJVector_struct;
+struct hypre_Solver_struct;
+
+namespace Spheral {
+
+class HypreOptions;
+
+// These functions do not check for safety, so make sure objects are initialized
+// Here is an example of how these might be called in order:
+//   rhs = createVector(...);
+//   lhs = createVector(...);
+//   mat = createMatrix(...);
+//   setMatrixValues(...);
+//   assembleMatrix(...);
+//   sol = createSolver(...);
+//   prec = createPreconditioner(...);
+//   setupSolver(...);
+//   setVectorValues(...); // rhs
+//   setVectorValues(...); // lhs
+//   solveSystem(...);
+//   getVectorValues(...); // lhs
+struct HypreFunctions {
+  typedef struct hypre_IJMatrix_struct MatrixType;
+  typedef struct hypre_IJVector_struct VectorType;
+  typedef struct hypre_Solver_struct SolverType;
+  
+  // Get Hypre vectors and matrices that self-destruct
+  static std::shared_ptr<VectorType> createVector(const unsigned numLocVal,
+                                                  const unsigned firstGlobInd);
+  static std::shared_ptr<MatrixType> createMatrix(const unsigned numLocVal,
+                                                  const unsigned firstGlobInd,
+                                                  const unsigned* numValsPerRow);
+
+  // Reinitialize matrix before setting new values
+  static void initializeMatrix(std::shared_ptr<MatrixType> matrix);
+  
+  // Set values in the matrix
+  static void setMatrixValues(const unsigned numRows,
+                              const unsigned* numColsPerRow,
+                              const unsigned* globRowInd,
+                              const unsigned* globColInd,
+                              const double* colVal,
+                              std::shared_ptr<HypreOptions> opt,
+                              std::shared_ptr<MatrixType> matrix);
+  
+  // Set or get the values of a Hypre vector
+  static void setVectorValues(const unsigned numVals,
+                               const unsigned firstGlobInd,
+                               const double* val,
+                               std::shared_ptr<VectorType> hypreVector);
+  static void getVectorValues(const unsigned numVals,
+                               const unsigned firstGlobInd,
+                               double* val,
+                               std::shared_ptr<VectorType> hypreVector);
+
+  // Assemble the matrix
+  static void assembleMatrix(std::shared_ptr<MatrixType> matrix);
+
+  // Get solver and preconditioner that self-destructs
+  static std::shared_ptr<SolverType> createSolver(std::shared_ptr<HypreOptions> opt);
+  static std::shared_ptr<SolverType> createPreconditioner(std::shared_ptr<HypreOptions> opt,
+                                                          std::shared_ptr<SolverType> solver);
+  
+  // Set remaining solver options and set up preconditioner
+  static void setupSolver(std::shared_ptr<HypreOptions> opt,
+                          std::shared_ptr<SolverType> solver,
+                          std::shared_ptr<MatrixType> matrix,
+                          std::shared_ptr<VectorType> lhs,
+                          std::shared_ptr<VectorType> rhs);
+
+  // Solve the linear system
+  // Return iterations and residual norm
+  static std::pair<int, double> solveSystem(std::shared_ptr<HypreOptions> opt,
+                                            std::shared_ptr<SolverType> solver,
+                                            std::shared_ptr<MatrixType> matrix,
+                                            std::shared_ptr<VectorType> lhs,
+                                            std::shared_ptr<VectorType> rhs,
+                                            std::string description);
+
+  // Multiply the linear system
+  static void multiplySystem(std::shared_ptr<HypreOptions> opt,
+                             std::shared_ptr<MatrixType> matrix,
+                             std::shared_ptr<VectorType> lhs,
+                             std::shared_ptr<VectorType> rhs,
+                             std::string description);
+}; // end struct HypreFunctions
+
+} // end namespace Spheral
+
+#endif

--- a/src/Solvers/HypreLinearSolver.cc
+++ b/src/Solvers/HypreLinearSolver.cc
@@ -1,0 +1,212 @@
+//---------------------------------Spheral++----------------------------------//
+// HypreLinearSolver
+//
+// Represents a solver for a linear system of equations
+//----------------------------------------------------------------------------//
+
+#include "HypreLinearSolver.hh"
+
+#include "Solvers/HypreFunctions.hh"
+#include "Solvers/HypreOptions.hh"
+#include "Solvers/IncrementalStatistic.hh"
+#include "Utilities/DBC.hh"
+#include "Utilities/Timer.hh"
+
+namespace Spheral {
+
+//------------------------------------------------------------------------------
+// Constructor
+//------------------------------------------------------------------------------
+HypreLinearSolver::
+HypreLinearSolver(std::shared_ptr<HypreOptions> options) :
+  mInitialized(false),
+  mFilling(false),
+  mAssembled(false),
+  mFinalized(false),
+  mHypreOptions(options),
+  mIterationStatistics(
+    std::make_shared<IncrementalStatistic<double>>(options->meanIterationsGuess,
+                                                   "HypreLinearSolver iterations",
+                                                   options->printIterations)), // print
+  mFinalResidualStatistics(
+    std::make_shared<IncrementalStatistic<double>>(options->toleranceL2,
+                                                   "HypreLinearSolver residual",
+                                                   false)) { // print
+  this->setDescription("HypreLinearSolver");
+}
+
+//------------------------------------------------------------------------------
+// Initialize the matrices and vectors
+//------------------------------------------------------------------------------
+void
+HypreLinearSolver::
+initialize(const unsigned numLocVal,
+           const unsigned firstGlobInd,
+           const unsigned* numValsPerRow) {
+  TIME_SCOPE("HypreLinearSolver::initialize");
+  mInitialized = false;
+  mAssembled = false;
+  mFinalized = false;
+
+  // Release memory so it isn't doubled briefly
+  mHypreLHS.reset();
+  mHypreRHS.reset();
+  mHypreMatrix.reset();
+  mHypreSolver.reset();
+  mHyprePreconditioner.reset();
+  VERIFY2(!mHypreLHS && !mHypreRHS && !mHypreMatrix &&
+          !mHypreSolver && !mHyprePreconditioner,
+          "unauthorized copy of Hypre object");
+
+  // Create new objects
+  mHypreLHS = HypreFunctions::createVector(numLocVal, firstGlobInd);
+  mHypreRHS = HypreFunctions::createVector(numLocVal, firstGlobInd);
+  mHypreMatrix = HypreFunctions::createMatrix(numLocVal, firstGlobInd, numValsPerRow);
+  mHypreSolver = HypreFunctions::createSolver(mHypreOptions);
+  mHyprePreconditioner = HypreFunctions::createPreconditioner(mHypreOptions, mHypreSolver);
+
+  mInitialized = true;
+}
+
+void
+HypreLinearSolver::
+beginFill() {
+  TIME_SCOPE("HypreLinearSolver::beginFill");
+  VERIFY(mInitialized);
+  HypreFunctions::initializeMatrix(mHypreMatrix);
+  mFilling = true;
+}
+
+//------------------------------------------------------------------------------
+// Set matrix values
+//------------------------------------------------------------------------------
+void
+HypreLinearSolver::
+setMatRow(const unsigned numVals,
+          const unsigned globRowInd,
+          const unsigned* globColInd,
+          const double* colVal) {
+  TIME_SCOPE("HypreLinearSolver::setMatRow");
+  VERIFY(mFilling);
+  HypreFunctions::setMatrixValues(1, &numVals, &globRowInd,
+                                  globColInd, colVal,
+                                  mHypreOptions, mHypreMatrix);
+}
+
+void
+HypreLinearSolver::
+setMatRows(const unsigned numRows,
+           const unsigned* numColsPerRow,
+           const unsigned* globRowInd,
+           const unsigned* globColInd,
+           const double* colVal) {
+  TIME_SCOPE("HypreLinearSolver::setMatRows");
+  VERIFY(mFilling);
+  HypreFunctions::setMatrixValues(numRows, numColsPerRow, globRowInd,
+                                  globColInd, colVal,
+                                  mHypreOptions, mHypreMatrix);
+}
+
+//------------------------------------------------------------------------------
+// Assemble matrix after fill
+//------------------------------------------------------------------------------
+void
+HypreLinearSolver::
+assemble() {
+  TIME_SCOPE("HypreLinearSolver::assemble");
+  VERIFY(mFilling);
+  HypreFunctions::assembleMatrix(mHypreMatrix);
+  mFilling = false;
+  mAssembled = true;
+}
+
+//------------------------------------------------------------------------------
+// Create solver and preconditioner
+//------------------------------------------------------------------------------
+void
+HypreLinearSolver::
+finalize() {
+  TIME_SCOPE("HypreLinearSolver::finalize");
+  VERIFY(mAssembled);
+  HypreFunctions::setupSolver(mHypreOptions, mHypreSolver, mHypreMatrix, mHypreLHS, mHypreRHS);
+  mFinalized = true;
+}
+
+//------------------------------------------------------------------------------
+// Set/get values in LHS and RHS
+//------------------------------------------------------------------------------
+void
+HypreLinearSolver::
+set(const Component c,
+    const unsigned numVals,
+    const unsigned firstGlobInd,
+    const double* val) {
+  TIME_SCOPE("HypreLinearSolver::set");
+  VERIFY(mInitialized);
+  switch (c) {
+  case RHS:
+    HypreFunctions::setVectorValues(numVals, firstGlobInd, val, mHypreRHS);
+    break;
+  case LHS:
+    HypreFunctions::setVectorValues(numVals, firstGlobInd, val, mHypreLHS);
+    break;
+  }
+}
+
+void
+HypreLinearSolver::
+get(const Component c,
+    const unsigned numVals,
+    const unsigned firstGlobInd,
+    double* val) {
+  TIME_SCOPE("HypreLinearSolver::get");
+  VERIFY(mInitialized);
+  switch (c) {
+  case RHS:
+    HypreFunctions::getVectorValues(numVals, firstGlobInd, val, mHypreRHS);
+    break;
+  case LHS:
+    HypreFunctions::getVectorValues(numVals, firstGlobInd, val, mHypreLHS);
+    break;
+  }
+}
+
+//------------------------------------------------------------------------------
+// Solve the system of equations in place
+//------------------------------------------------------------------------------
+bool
+HypreLinearSolver::
+solve() {
+  TIME_SCOPE("HypreLinearSolver::solve");
+  VERIFY(mFinalized);
+  auto [it, norm] = HypreFunctions::solveSystem(mHypreOptions, mHypreSolver, mHypreMatrix, mHypreLHS, mHypreRHS, this->getDescription());
+  mIterationStatistics->add(it);
+  mFinalResidualStatistics->add(norm);
+  return it < mHypreOptions->maxNumberOfIterations;
+}
+
+//------------------------------------------------------------------------------
+// Multiply by the matrix
+//------------------------------------------------------------------------------
+void
+HypreLinearSolver::
+multiply() {
+  TIME_SCOPE("HypreLinearSolver::multiply");
+  VERIFY(mAssembled);
+  HypreFunctions::multiplySystem(mHypreOptions, mHypreMatrix, mHypreLHS, mHypreRHS, this->getDescription());
+}
+
+//------------------------------------------------------------------------------
+// Set the description, including for the stats
+//------------------------------------------------------------------------------
+inline
+void
+HypreLinearSolver::
+setDescription(std::string desc) {
+  this->mDescription = desc;
+  mIterationStatistics->setName(desc + " iter");
+  mFinalResidualStatistics->setName(desc + " norm");
+}
+
+
+} // end namespace Spheral

--- a/src/Solvers/HypreLinearSolver.hh
+++ b/src/Solvers/HypreLinearSolver.hh
@@ -1,0 +1,105 @@
+//---------------------------------Spheral++----------------------------------//
+// HypreLinearSolver
+//
+// Represents a solver for a linear system of equations
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_HypreLinearSolver_hh__
+#define __Spheral_HypreLinearSolver_hh__
+
+#include <memory>
+#include <vector>
+
+#include "LinearSolver.hh"
+
+struct hypre_IJMatrix_struct;
+struct hypre_IJVector_struct;
+struct hypre_Solver_struct;
+
+namespace Spheral {
+
+class HypreOptions;
+template<typename DataType> class IncrementalStatistic;
+
+class HypreLinearSolver : public LinearSolver {
+public:
+  typedef struct hypre_IJMatrix_struct MatrixType;
+  typedef struct hypre_IJVector_struct VectorType;
+  typedef struct hypre_Solver_struct SolverType;
+
+  using LinearSolver::Component;
+  
+  // Constructor
+  HypreLinearSolver(std::shared_ptr<HypreOptions> options);
+
+  // Create matrices and vectors
+  virtual void initialize(const unsigned numLocVal,
+                          const unsigned firstGlobInd,
+                          const unsigned* numValsPerRow) override;
+
+  // Begin the matrix fill
+  virtual void beginFill() override;
+  
+  // Set values in matrix
+  virtual void setMatRow(const unsigned numVals,     // Number of values in this row
+                         const unsigned globRowInd,  // Global index of this row
+                         const unsigned* globColInd, // [numVals] Global indices for columns
+                         const double* colVal) override;  // [numVals] Values
+  virtual void setMatRows(const unsigned numRows,        // Number of rows
+                          const unsigned* numColsPerRow, // [numRows] Number of columns for each of these rows
+                          const unsigned* globRowInd,    // [numRows] Global indices for these rows
+                          const unsigned* globColInd,    // [numColsPerRow[numRows]] Global column indies for each value
+                          const double* colVal) override;     // [numColsPerRow[numRows]] Values
+
+  // Assemble matrix after fill
+  virtual void assemble() override;
+  
+  // Create solver/preconditioner
+  virtual void finalize() override;
+
+  // Set/get values
+  virtual void set(const Component c,
+                   const unsigned numVals,      // Number of vector values to set 
+                   const unsigned firstGlobInd, // First global index for values
+                   const double* val) override; // [numVals] Values
+  virtual void get(const Component c,
+                   const unsigned numVals,      // Number of vector values to set 
+                   const unsigned firstGlobInd, // First global index for values
+                   double* val) override;       // [numVals] Values
+  
+  // Solve the system of equations in place; returns true if converged
+  virtual bool solve() override;
+
+  // Multiply the matrix by a vector
+  virtual void multiply() override;
+
+  // Set the description
+  virtual void setDescription(std::string desc) override;
+  
+  // Return statistics
+  virtual std::vector<std::shared_ptr<IncrementalStatistic<double>>> statistics() const override;
+  
+private:
+  // Which stages have we completed?
+  bool mInitialized;
+  bool mFilling;
+  bool mAssembled;
+  bool mFinalized;
+  
+  // Data
+  std::shared_ptr<HypreOptions> mHypreOptions;
+  std::shared_ptr<MatrixType> mHypreMatrix;
+  std::shared_ptr<VectorType> mHypreLHS;
+  std::shared_ptr<VectorType> mHypreRHS;
+  std::shared_ptr<SolverType> mHypreSolver;
+  std::shared_ptr<SolverType> mHyprePreconditioner;
+
+  // Iteration statistics
+  std::shared_ptr<IncrementalStatistic<double>> mIterationStatistics;
+  std::shared_ptr<IncrementalStatistic<double>> mFinalResidualStatistics;
+}; // end class HypreLinearSolver
+
+} // end namespace Spheral
+
+#include "HypreLinearSolverInline.hh"
+
+#endif

--- a/src/Solvers/HypreLinearSolverInline.hh
+++ b/src/Solvers/HypreLinearSolverInline.hh
@@ -1,0 +1,14 @@
+namespace Spheral {
+
+//------------------------------------------------------------------------------
+// Return statistics for number of iterations and tolerance reached
+//------------------------------------------------------------------------------
+inline
+std::vector<std::shared_ptr<IncrementalStatistic<double>>>
+HypreLinearSolver::
+statistics() const {
+  return {mIterationStatistics, mFinalResidualStatistics};
+}
+
+} // end namespace Spheral
+

--- a/src/Solvers/HypreOptions.hh
+++ b/src/Solvers/HypreOptions.hh
@@ -91,136 +91,106 @@ struct HypreOptions {
 
   HyprePreconditionerType preconditionerType = HyprePreconditionerType::AMGPreconditioner;
 
-  // ---------------------------------------------------------------------------
+  // ***************************************************************************
   // BoomerAMG options
-  // ---------------------------------------------------------------------------
+  // ***************************************************************************
+  struct AMG {
+    // Strength-of-connection measure.
+    // 0 = classical (based on matrix entries).
+    int measureType = 0;
 
-  // Strength-of-connection measure.
-  // 0 = classical (based on matrix entries).
-  // Appropriate for scalar diffusion operators.
-  int measure_type = 0;
+    // AMG convergence tolerance. For preconditioning, this should be zero.
+    double tol = 0.;
 
-  // AMG convergence tolerance.
-  // For preconditioning, this should be zero.
-  double pcTol = 0.;
+    // Minimum and maximum AMG iterations per application.
+    // For a preconditioner, both should be 1 (single V-cycle).
+    int minIters = 1;
+    int maxIters = 1;
 
-  // Minimum and maximum AMG iterations per application.
-  // For a preconditioner, both should be 1 (single V-cycle).
-  int minItersAMG = 1;
-  int maxItersAMG = 1;
+    // Multigrid cycle type. 1 = V-cycle, 2 = W-cycle.
+    int cycleType = 1;
 
-  // Multigrid cycle type.
-  // 1 = V-cycle (default and recommended).
-  // 2 = W-cycle (more expensive; rarely needed).
-  int cycleType = 1;
+    // Coarsening algorithm.
+    // 6 = Falgout (structured), 8 = PMIS (irregular graphs), 10 = HMIS (conservative).
+    int coarsenType = 8;
 
-  // Coarsening algorithm.
-  // 6 = Falgout (better for structured problems)
-  // 8 = PMIS (recommended for irregular graphs and large stencils).
-  // 10 = HMIS (more conservative, may improve convergence)
-  int coarsenTypeAMG = 8;
+    // Strength-of-connection threshold.
+    double strongThreshold = 0.25;
 
-  // Strength-of-connection threshold.
-  // Lower values retain more algebraic couplings.
-  // Decrease to ~0.1 if not converging. Increase to ~0.7 for speed. 
-  double strongThresholdAMG = 0.25;
+    // Maximum allowed sum of weak connections relative to strong ones.
+    double maxRowSum = 0.9;
 
-  // Maximum allowed sum of weak connections relative to strong ones.
-  // Used to prevent pathological strength graphs.
-  // Values near 1.0 retain most couplings; smaller values prune aggressively.
-  double maxRowSumAMG = 0.9;
+    // Interpolation type. 6 = extended classical (recommended for PMIS/HMIS).
+    int interpType = 6;
 
-  // Interpolation type.
-  // 6 = extended classical interpolation (recommended for PMIS/HMIS).
-  int interpTypeAMG = 6;
+    // Number of aggressive coarsening levels. -1 disables.
+    int aggNumLevels = -1;
 
-  // Number of aggressive coarsening levels.
-  // -1 disables aggressive coarsening.
-  int aggNumLevelsAMG = -1;
+    // Interpolation type during aggressive coarsening. -1 = default.
+    int aggInterpType = -1;
 
-  // Interpolation type used during aggressive coarsening.
-  // Only relevant if aggNumLevelsAMG >= 0.
-  int aggInterpTypeAMG = -1;
+    // Maximum nonzeros per row in interpolation. -1 = default.
+    int pMaxElmts = 6;
 
-  // Maximum number of nonzeros per row in interpolation operator.
-  // Controls operator complexity.
-  // Decrease to ~4 for more performance or increase to ~8 for more stability.
-  int pMaxElmtsAMG = 6;
+    // Truncation factor for interpolation coefficients. 0.0 = disabled.
+    double truncFactor = 0.0;
 
-  // Truncation factor for interpolation coefficients.
-  // 0.0 disables truncation by magnitude.
-  // Increase to 0.1-0.2 to reduce interpolation complexity. 
-  double truncFactorAMG = 0.0;
+    // AMG-specific print verbosity. -1 inherits from global printLevel.
+    int printLevel = -1;
 
-  // AMG-specific print verbosity.
-  // Increase to > 0 for printing
-  int printLevelAMG = -1;
+    // AMG-specific logging level.
+    int logLevel = 0;
 
-  // AMG-specific logging level.
-  // Increase to > 0 for logging
-  int logLevelAMG = 0;
+    // Relaxation weight for smoothers.
+    double relaxWeight = 1.0;
 
-  // Relaxation weight for smoothers.
-  // Usually 1.0 for GS-based methods.
-  double relaxWeightAMG = 1.0;
+    // Relaxation (smoother) type on fine and intermediate levels.
+    // 8 = L1-scaled hybrid symmetric Gauss-Seidel (default), 16 = Chebyshev.
+    int relaxType = 8;
 
-  // Relaxation (smoother) type on fine and intermediate levels.
-  // In testing, 8 and 16 work, but 88 and 89 do not. 
-  // 8 = L1-scaled hybrid symmetric Gauss-Seidel (default)
-  // 16 = Chebyshev (also works)
-  int relaxTypeAMG = 8;
+    // Relaxation type on the coarsest level. -1 = use relaxType, 9 = Gaussian elimination.
+    int relaxTypeCoarse = 9;
 
-  // Relaxation type on the coarsest level.
-  // -1 = Use value from relaxTypeAMG
-  // 9 = Gaussian elimination
-  // 19 = Gaussian elimination (old version)
-  int relaxTypeCoarseAMG = 9;
+    // Number of pre- and post-smoothing sweeps.
+    int cycleNumSweeps = 1;
 
-  // Number of pre- and post-smoothing sweeps.
-  // Typically 1 is sufficient.
-  int cycleNumSweepsAMG = 1;
+    // Number of coarse-level sweeps. -1 = use cycleNumSweeps.
+    int cycleNumSweepsCoarse = -1;
 
-  // Number of coarse-level sweeps.
-  // -1 defaults to cycleNumSweepsAMG unless overridden by solver type.
-  int cycleNumSweepsCoarseAMG = -1;
+    // Maximum number of AMG levels.
+    int maxLevels = 25;
 
-  // Maximum number of AMG levels.
-  // Acts as a safety cap.
-  int maxLevelsAMG = 25;
+    // Number of DOFs per node for systems of PDEs. 1 = scalar.
+    int numFunctions = 1;
 
-  // Number of DOFs per node for systems of PDEs.
-  // 1 = scalar (default). Set to 3 for coupled vector systems.
-  int numFunctionsAMG = 1;
+    // Nodal coarsening for systems (requires numFunctions > 1).
+    // 0 = unknown-based, 1 = Frobenius norm, 2 = sum abs, 3 = largest, 4 = row-sum, 6 = sum all.
+    int nodal = 1;
+  };
 
-  // Nodal coarsening for systems of PDEs (requires numFunctionsAMG > 1).
-  // 0 = unknown-based (coarsens each function independently).
-  // 1 = Frobenius norm of nodal blocks (recommended for coupled systems).
-  // 2 = sum of absolute values in each block.
-  // 3 = largest element in each block.
-  // 4 = row-sum norm.
-  // 6 = sum of all values in each block.
-  int nodalAMG = 1;
-
-  // ---------------------------------------------------------------------------
+  // ***************************************************************************
   // Euclid (ILU) options
-  // ---------------------------------------------------------------------------
+  // ***************************************************************************
+  struct ILU {
+    // Use ILUT instead of ILU(k).
+    bool useILUT = false;
 
-  // Use ILUT instead of ILU(k).
-  // Generally not useful except for debugging.
-  bool useILUT = false;
+    // Fill level for ILU(k).
+    int factorLevel = 1;
 
-  // Fill level for ILU(k).
-  int factorLevelILU = 1;
+    // Enable row scaling prior to ILU factorization.
+    int rowScale = 0;
 
-  // Enable row scaling prior to ILU factorization.
-  int rowScaleILU = 0;
+    // Euclid print verbosity. -1 inherits from global printLevel.
+    int printLevel = -1;
 
-  // Euclid print verbosity.
-  // -1 inherits from global printLevel.
-  int printLevelILU = -1;
+    // Drop tolerance for ILUT or sparse ILU.
+    double dropTolerance = 0;
+  };
 
-  // Drop tolerance for ILUT or sparse ILU.
-  double dropToleranceILU = 0;
+  // Sub-struct members
+  AMG amg;
+  ILU ilu;
   
   // ---------------------------------------------------------------------------
   // Postprocessing
@@ -243,48 +213,48 @@ struct HypreOptions {
 
     case HyprePreset::OldDefault:
       // Historical defaults
-      measure_type              = 0;
-      pcTol                     = 0.0;
-      minItersAMG               = 1;
-      maxItersAMG               = 1;
-      cycleType                 = 1;
-      coarsenTypeAMG            = 6;
-      strongThresholdAMG        = 0.25;
-      maxRowSumAMG              = 0.5;
-      interpTypeAMG             = -1;
-      aggNumLevelsAMG           = -1;
-      aggInterpTypeAMG          = -1;
-      pMaxElmtsAMG              = -1;
-      truncFactorAMG            = 0.0;
-      printLevelAMG             = -1;
-      logLevelAMG               = 0;
-      relaxWeightAMG            = 1.0;
-      relaxTypeAMG              = 8;
-      relaxTypeCoarseAMG        = 19;
-      cycleNumSweepsAMG         = 1;
-      cycleNumSweepsCoarseAMG   = -1;
-      maxLevelsAMG              = 25;
+      amg.measureType            = 0;
+      amg.tol                    = 0.0;
+      amg.minIters               = 1;
+      amg.maxIters               = 1;
+      amg.cycleType              = 1;
+      amg.coarsenType            = 6;
+      amg.strongThreshold        = 0.25;
+      amg.maxRowSum              = 0.5;
+      amg.interpType             = -1;
+      amg.aggNumLevels           = -1;
+      amg.aggInterpType          = -1;
+      amg.pMaxElmts              = -1;
+      amg.truncFactor            = 0.0;
+      amg.printLevel             = -1;
+      amg.logLevel               = 0;
+      amg.relaxWeight            = 1.0;
+      amg.relaxType              = 8;
+      amg.relaxTypeCoarse        = 19;
+      amg.cycleNumSweeps         = 1;
+      amg.cycleNumSweepsCoarse   = -1;
+      amg.maxLevels              = 25;
       break;
 
     case HyprePreset::Robust:
       // Improve convergence
-      kDim                      = 20;    // Larger Krylov space
-      cycleType                 = 2;     // W-cycle for better coarse convergence
-      strongThresholdAMG        = 0.20;  // More strong connections
-      maxRowSumAMG              = 1.0;   // Disable diagonal-dominance check
-      pMaxElmtsAMG              = 8;     // More interpolation elements
-      truncFactorAMG            = 0.0;   // No truncation
+      kDim                       = 20;    // Larger Krylov space
+      amg.cycleType              = 2;     // W-cycle for better coarse convergence
+      amg.strongThreshold        = 0.20;  // More strong connections
+      amg.maxRowSum              = 1.0;   // Disable diagonal-dominance check
+      amg.pMaxElmts              = 8;     // More interpolation elements
+      amg.truncFactor            = 0.0;   // No truncation
       break;
 
     case HyprePreset::Fast:
       // Improve speed where convergence isn't an issue
-      toleranceL2               = 1.e-6; // Looser tolerance
-      absoluteTolerance         = 1.e-10; 
-      strongThresholdAMG        = 0.50;  // Aggressive coarsening
-      maxRowSumAMG              = 0.5;   // Increase number of rows considered diagonally dominant
-      aggNumLevelsAMG           = 1;     // One level of aggressive coarsening
-      pMaxElmtsAMG              = 3;     // Fewer interpolation elements
-      truncFactorAMG            = 0.15;  // Truncate weak entries
+      toleranceL2                = 1.e-6; // Looser tolerance
+      absoluteTolerance          = 1.e-10; 
+      amg.strongThreshold        = 0.50;  // Aggressive coarsening
+      amg.maxRowSum              = 0.5;   // Increase number of rows considered diagonally dominant
+      amg.aggNumLevels           = 1;     // One level of aggressive coarsening
+      amg.pMaxElmts              = 3;     // Fewer interpolation elements
+      amg.truncFactor            = 0.15;  // Truncate weak entries
       break;
     }
   }

--- a/src/Solvers/HypreOptions.hh
+++ b/src/Solvers/HypreOptions.hh
@@ -1,0 +1,295 @@
+//---------------------------------Spheral++----------------------------------//
+// HypreOptions
+//
+// Holds the options for Hypre solvers and preconditioners
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_HypreOptions_hh__
+#define __Spheral_HypreOptions_hh__
+
+namespace Spheral {
+
+enum class HyprePreset {
+  Default,    // Don't change anything
+  OldDefault, // Historical defaults
+  Robust,     // Make more robust
+  Fast        // Make faster
+};
+
+enum class HyprePreconditionerType {
+  NoPreconditioner,   // Use GMRES without preconditioning
+  AMGPreconditioner,  // BoomerAMG (default, best for diffusion problems)
+  ILUPreconditioner   // Euclid ILU (for debugging or fallback)
+};
+
+struct HypreOptions {
+  // Constructor
+  HypreOptions(HyprePreset preset = HyprePreset::Default) {
+    if (preset != HyprePreset::Default) {
+      // Avoid recursion
+      setPreset(preset);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // General options
+  // ---------------------------------------------------------------------------
+  
+  // If true, abort execution when the linear solver fails to converge.
+  bool quitIfDiverged = false;
+
+  // If true, emit a warning when the solver fails to converge.
+  bool warnIfDiverged = true;
+
+  // If true, sum all row values that share an index
+  bool addToValues = false;
+  
+  // 0 = no logging; set to 1+ for increasing verbosity.
+  int logLevel = 0;
+
+  // 0 = no printing; set to 1+ for increasing verbosity.
+  int printLevel = 0;
+  
+  // ---------------------------------------------------------------------------
+  // GMRES solve options
+  // ---------------------------------------------------------------------------
+
+  // Save the linear system (A, b, x) to disk for debugging.
+  bool saveLinearSystem = false;
+
+  // Print information after each iteration.
+  bool printIterations = false;
+
+  // Only used for keeping statistics.
+  int meanIterationsGuess = 5;
+
+  // Maximum number of GMRES iterations.
+  int maxNumberOfIterations = 100;
+
+  // Relative L2 convergence tolerance.
+  double toleranceL2 = 1.e-8;
+
+  // If enabled, use Hypre's robust convergence criterion.
+  // Recommended for ill-conditioned systems.
+  int useRobustTolerance = 1;
+
+  // Absolute tolerance. Used with an OR along with the L2 tolerance above. 
+  double absoluteTolerance = 1.e-12;
+  
+  // ---------------------------------------------------------------------------
+  // GMRES initialization
+  // ---------------------------------------------------------------------------
+
+  // Krylov subspace dimension.
+  int kDim = 10;
+
+  // Minimum number of GMRES iterations before convergence is tested.
+  int minIters = 1;
+
+  // ---------------------------------------------------------------------------
+  // Preconditioner selection
+  // ---------------------------------------------------------------------------
+
+  HyprePreconditionerType preconditionerType = HyprePreconditionerType::AMGPreconditioner;
+
+  // ---------------------------------------------------------------------------
+  // BoomerAMG options
+  // ---------------------------------------------------------------------------
+
+  // Strength-of-connection measure.
+  // 0 = classical (based on matrix entries).
+  // Appropriate for scalar diffusion operators.
+  int measure_type = 0;
+
+  // AMG convergence tolerance.
+  // For preconditioning, this should be zero.
+  double pcTol = 0.;
+
+  // Minimum and maximum AMG iterations per application.
+  // For a preconditioner, both should be 1 (single V-cycle).
+  int minItersAMG = 1;
+  int maxItersAMG = 1;
+
+  // Multigrid cycle type.
+  // 1 = V-cycle (default and recommended).
+  // 2 = W-cycle (more expensive; rarely needed).
+  int cycleType = 1;
+
+  // Coarsening algorithm.
+  // 6 = Falgout (better for structured problems)
+  // 8 = PMIS (recommended for irregular graphs and large stencils).
+  // 10 = HMIS (more conservative, may improve convergence)
+  int coarsenTypeAMG = 8;
+
+  // Strength-of-connection threshold.
+  // Lower values retain more algebraic couplings.
+  // Decrease to ~0.1 if not converging. Increase to ~0.7 for speed. 
+  double strongThresholdAMG = 0.25;
+
+  // Maximum allowed sum of weak connections relative to strong ones.
+  // Used to prevent pathological strength graphs.
+  // Values near 1.0 retain most couplings; smaller values prune aggressively.
+  double maxRowSumAMG = 0.9;
+
+  // Interpolation type.
+  // 6 = extended classical interpolation (recommended for PMIS/HMIS).
+  int interpTypeAMG = 6;
+
+  // Number of aggressive coarsening levels.
+  // -1 disables aggressive coarsening.
+  int aggNumLevelsAMG = -1;
+
+  // Interpolation type used during aggressive coarsening.
+  // Only relevant if aggNumLevelsAMG >= 0.
+  int aggInterpTypeAMG = -1;
+
+  // Maximum number of nonzeros per row in interpolation operator.
+  // Controls operator complexity.
+  // Decrease to ~4 for more performance or increase to ~8 for more stability.
+  int pMaxElmtsAMG = 6;
+
+  // Truncation factor for interpolation coefficients.
+  // 0.0 disables truncation by magnitude.
+  // Increase to 0.1-0.2 to reduce interpolation complexity. 
+  double truncFactorAMG = 0.0;
+
+  // AMG-specific print verbosity.
+  // Increase to > 0 for printing
+  int printLevelAMG = -1;
+
+  // AMG-specific logging level.
+  // Increase to > 0 for logging
+  int logLevelAMG = 0;
+
+  // Relaxation weight for smoothers.
+  // Usually 1.0 for GS-based methods.
+  double relaxWeightAMG = 1.0;
+
+  // Relaxation (smoother) type on fine and intermediate levels.
+  // In testing, 8 and 16 work, but 88 and 89 do not. 
+  // 8 = L1-scaled hybrid symmetric Gauss-Seidel (default)
+  // 16 = Chebyshev (also works)
+  int relaxTypeAMG = 8;
+
+  // Relaxation type on the coarsest level.
+  // -1 = Use value from relaxTypeAMG
+  // 9 = Gaussian elimination
+  // 19 = Gaussian elimination (old version)
+  int relaxTypeCoarseAMG = 9;
+
+  // Number of pre- and post-smoothing sweeps.
+  // Typically 1 is sufficient.
+  int cycleNumSweepsAMG = 1;
+
+  // Number of coarse-level sweeps.
+  // -1 defaults to cycleNumSweepsAMG unless overridden by solver type.
+  int cycleNumSweepsCoarseAMG = -1;
+
+  // Maximum number of AMG levels.
+  // Acts as a safety cap.
+  int maxLevelsAMG = 25;
+
+  // Number of DOFs per node for systems of PDEs.
+  // 1 = scalar (default). Set to 3 for coupled vector systems.
+  int numFunctionsAMG = 1;
+
+  // Nodal coarsening for systems of PDEs (requires numFunctionsAMG > 1).
+  // 0 = unknown-based (coarsens each function independently).
+  // 1 = Frobenius norm of nodal blocks (recommended for coupled systems).
+  // 2 = sum of absolute values in each block.
+  // 3 = largest element in each block.
+  // 4 = row-sum norm.
+  // 6 = sum of all values in each block.
+  int nodalAMG = 1;
+
+  // ---------------------------------------------------------------------------
+  // Euclid (ILU) options
+  // ---------------------------------------------------------------------------
+
+  // Use ILUT instead of ILU(k).
+  // Generally not useful except for debugging.
+  bool useILUT = false;
+
+  // Fill level for ILU(k).
+  int factorLevelILU = 1;
+
+  // Enable row scaling prior to ILU factorization.
+  int rowScaleILU = 0;
+
+  // Euclid print verbosity.
+  // -1 inherits from global printLevel.
+  int printLevelILU = -1;
+
+  // Drop tolerance for ILUT or sparse ILU.
+  double dropToleranceILU = 0;
+  
+  // ---------------------------------------------------------------------------
+  // Postprocessing
+  // ---------------------------------------------------------------------------
+
+  // If true, clamp negative solution values to zero after solve.
+  bool zeroOutNegativities = false;
+
+  // ---------------------------------------------------------------------------
+  // Set presets
+  // ---------------------------------------------------------------------------
+  
+  void setPreset(HyprePreset preset) {
+    // Reset to member defaults before applying preset
+    *this = HypreOptions(HyprePreset::Default);
+
+    switch (preset) {
+    case HyprePreset::Default:
+      break;
+
+    case HyprePreset::OldDefault:
+      // Historical defaults
+      measure_type              = 0;
+      pcTol                     = 0.0;
+      minItersAMG               = 1;
+      maxItersAMG               = 1;
+      cycleType                 = 1;
+      coarsenTypeAMG            = 6;
+      strongThresholdAMG        = 0.25;
+      maxRowSumAMG              = 0.5;
+      interpTypeAMG             = -1;
+      aggNumLevelsAMG           = -1;
+      aggInterpTypeAMG          = -1;
+      pMaxElmtsAMG              = -1;
+      truncFactorAMG            = 0.0;
+      printLevelAMG             = -1;
+      logLevelAMG               = 0;
+      relaxWeightAMG            = 1.0;
+      relaxTypeAMG              = 8;
+      relaxTypeCoarseAMG        = 19;
+      cycleNumSweepsAMG         = 1;
+      cycleNumSweepsCoarseAMG   = -1;
+      maxLevelsAMG              = 25;
+      break;
+
+    case HyprePreset::Robust:
+      // Improve convergence
+      kDim                      = 20;    // Larger Krylov space
+      cycleType                 = 2;     // W-cycle for better coarse convergence
+      strongThresholdAMG        = 0.20;  // More strong connections
+      maxRowSumAMG              = 1.0;   // Disable diagonal-dominance check
+      pMaxElmtsAMG              = 8;     // More interpolation elements
+      truncFactorAMG            = 0.0;   // No truncation
+      break;
+
+    case HyprePreset::Fast:
+      // Improve speed where convergence isn't an issue
+      toleranceL2               = 1.e-6; // Looser tolerance
+      absoluteTolerance         = 1.e-10; 
+      strongThresholdAMG        = 0.50;  // Aggressive coarsening
+      maxRowSumAMG              = 0.5;   // Increase number of rows considered diagonally dominant
+      aggNumLevelsAMG           = 1;     // One level of aggressive coarsening
+      pMaxElmtsAMG              = 3;     // Fewer interpolation elements
+      truncFactorAMG            = 0.15;  // Truncate weak entries
+      break;
+    }
+  }
+}; // end struct HypreOptions
+
+} // end namespace Spheral
+
+#endif

--- a/src/Solvers/IncrementalStatistic.hh
+++ b/src/Solvers/IncrementalStatistic.hh
@@ -1,0 +1,75 @@
+//---------------------------------Spheral++----------------------------------//
+// IncrementalStatistic
+//
+// Allows tracking of incrementally added stats, such as iteration counts
+// For now, all variables use the same DataType
+// The mean guess prevents overflow for data with a large mean
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_IncrementalStatistic_hh__
+#define __Spheral_IncrementalStatistic_hh__
+
+#include <string>
+
+namespace Spheral {
+
+template<typename DataType>
+class IncrementalStatistic {
+public:
+  // Constructor
+  IncrementalStatistic(const DataType meanGuess = 0,
+                       const std::string name = "IncrementalStatistic",
+                       bool printAdd = false);
+
+  // Add a point of data
+  void add(const DataType data);
+
+  // Calculated data
+  DataType mean() const;
+  DataType variance() const;
+  DataType total() const;
+  
+  // Stored data
+  std::string name() const;
+  DataType meanGuess() const;
+  DataType min() const;
+  DataType max() const;
+  DataType numPoints() const;
+  DataType shiftedSum() const;
+  DataType shiftedSum2() const;
+  
+  // Print to console
+  void print() const;
+
+  // Print summary to console
+  void printSummary() const;
+
+  // Set name
+  void setName(std::string newName);
+
+private:
+  // Convenience function
+  void getStats(DataType& min,
+                DataType& max,
+                DataType& numPoints,
+                DataType& mean,
+                DataType& variance,
+                DataType& total) const;
+  
+  // Input data
+  const DataType mMeanGuess;
+  std::string mName;
+  bool mPrint;
+  
+  // Incrementally updated data
+  DataType mMin;
+  DataType mMax;
+  DataType mNumPoints;
+  DataType mShiftedSum;
+  DataType mShiftedSum2;
+};
+
+} // end namespace Spheral
+
+#include "IncrementalStatisticInline.hh"
+
+#endif

--- a/src/Solvers/IncrementalStatisticInline.hh
+++ b/src/Solvers/IncrementalStatisticInline.hh
@@ -1,0 +1,295 @@
+#include <iostream>
+#include <iomanip>
+#include <limits>
+#include <vector>
+
+#include "Distributed/Communicator.hh"
+#include "Utilities/DataTypeTraits.hh"
+
+namespace { // anonymous
+
+template<typename DataType>
+inline
+DataType
+calculateMean(DataType numPoints,
+              DataType shiftedSum,
+              DataType meanGuess) {
+  return shiftedSum / numPoints + meanGuess;
+}
+
+template<typename DataType>
+inline
+DataType
+calculateVariance(DataType numPoints,
+                  DataType shiftedSum,
+                  DataType shiftedSum2) {
+  return (shiftedSum2 - shiftedSum * shiftedSum / numPoints) / numPoints;
+}
+
+template<typename DataType>
+inline
+DataType
+calculateTotal(DataType numPoints,
+               DataType shiftedSum,
+               DataType meanGuess) {
+  return shiftedSum + numPoints * meanGuess;
+}
+
+} // namespace anonymous
+
+namespace Spheral {
+
+//------------------------------------------------------------------------------
+// Constructor
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+IncrementalStatistic<DataType>::
+IncrementalStatistic(const DataType meanGuess,
+                     std::string name,
+                     bool print):
+  mMeanGuess(meanGuess),
+  mName(name),
+  mPrint(print),
+  mMin(std::numeric_limits<DataType>::max()),
+  mMax(std::numeric_limits<DataType>::min()),
+  mNumPoints(0),
+  mShiftedSum(0),
+  mShiftedSum2(0) {
+}
+
+//------------------------------------------------------------------------------
+// Add a data point
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+void
+IncrementalStatistic<DataType>::
+add(const DataType data) {
+  if (data < mMin) mMin = data;
+  if (data > mMax) mMax = data;
+  mNumPoints += 1;
+  const DataType delta = data - mMeanGuess;
+  mShiftedSum += delta;
+  mShiftedSum2 += delta * delta;
+  
+  if (mPrint and Process::getRank() == 0) {
+    std::cout << mName;
+    std::cout << "\tadd: " << data;
+    std::cout << std::endl;
+  }
+}
+
+//------------------------------------------------------------------------------
+// Calculate mean
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+DataType
+IncrementalStatistic<DataType>::
+mean() const {
+  return calculateMean(mNumPoints, mShiftedSum, mMeanGuess);
+}
+
+//------------------------------------------------------------------------------
+// Calculate variance
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+DataType
+IncrementalStatistic<DataType>::
+variance() const {
+  return calculateVariance(mNumPoints, mShiftedSum, mShiftedSum2);
+}
+
+//------------------------------------------------------------------------------
+// Calculate total
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+DataType
+IncrementalStatistic<DataType>::
+total() const {
+  return calculateTotal(mNumPoints, mShiftedSum, mMeanGuess);
+}
+
+
+//------------------------------------------------------------------------------
+// Set name
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+void
+IncrementalStatistic<DataType>::
+setName(std::string name) {
+  mName = name;
+  return;
+}
+
+//------------------------------------------------------------------------------
+// Get mean guess
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+DataType
+IncrementalStatistic<DataType>::
+min() const {
+  return mMin;
+}
+
+//------------------------------------------------------------------------------
+// Get mean guess
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+DataType
+IncrementalStatistic<DataType>::
+max() const {
+  return mMax;
+}
+
+//------------------------------------------------------------------------------
+// Get mean guess
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+DataType
+IncrementalStatistic<DataType>::
+meanGuess() const {
+  return mMeanGuess;
+}
+
+//------------------------------------------------------------------------------
+// Get numPoints
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+DataType
+IncrementalStatistic<DataType>::
+numPoints() const {
+  return mNumPoints;
+}
+
+//------------------------------------------------------------------------------
+// Get shiftedSum
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+DataType
+IncrementalStatistic<DataType>::
+shiftedSum() const {
+  return mShiftedSum;
+}
+
+//------------------------------------------------------------------------------
+// Get shiftedSum2
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+DataType
+IncrementalStatistic<DataType>::
+shiftedSum2() const {
+  return mShiftedSum2;
+}
+
+//------------------------------------------------------------------------------
+// Print results
+//------------------------------------------------------------------------------
+template<typename DataType>
+inline
+void
+IncrementalStatistic<DataType>::
+print() const {
+  typedef std::pair<std::string, DataType> PairType;
+
+  auto outputPair = [](PairType val) {
+    std::cout << std::setw(20) << val.first;
+    std::cout << std::setw(14) << std::setprecision(6) << val.second;
+  };
+
+  DataType min, max, numPoints, mean, variance, total;
+  getStats(min, max, numPoints, mean, variance, total);
+
+  if (Process::getRank() == 0) {
+    std::cout << mName << std::endl;
+    if (numPoints == 0) {
+      PairType val = {"points", numPoints};
+      outputPair(val);
+      std::cout << "(no data recorded)" << std::endl;
+    }
+    else {
+      // Output in two columns
+      std::vector<PairType> vals =
+        {{"points",   numPoints}, {"total",   total},
+         {"mean",     mean},      {"minimum", min},
+         {"variance", variance},  {"maximum", max}};
+      auto index = 0;
+      for (auto val : vals) {
+        outputPair(val);
+        if (index % 2 == 1) {
+          std::cout << std::endl;
+        }
+        index += 1;
+      }
+    }
+  }
+}
+
+template<typename DataType>
+inline
+void
+IncrementalStatistic<DataType>::
+printSummary() const {
+  DataType min, max, numPoints, mean, variance, total;
+  getStats(min, max, numPoints, mean, variance, total);
+
+  if (Process::getRank() == 0) {
+    std::cout << std::left << std::setw(22) << mName;
+    if (numPoints == 0) {
+      std::cout << " (no data recorded)" << std::endl;
+    }
+    else {
+      std::cout << std::scientific << std::setprecision(4);
+      std::cout << " mean=" << mean
+                << "  min=" << min
+                << "  max=" << max
+                << "  tot=" << total << std::endl;
+    }
+  }
+}
+
+// Get raw stats communicated over all ranks
+template<typename DataType>
+inline
+void
+IncrementalStatistic<DataType>::
+getStats(DataType& min,
+         DataType& max,
+         DataType& numPoints,
+         DataType& mean,
+         DataType& variance,
+         DataType& total) const {
+  // Communicate raw data
+  DataType shiftedSum, shiftedSum2;
+  const auto mpiDataType = DataTypeTraits<DataType>::MpiDataType();
+  MPI_Allreduce(&mMin, &min, 1, mpiDataType, MPI_MIN, Communicator::communicator());
+  MPI_Allreduce(&mMax, &max, 1, mpiDataType, MPI_MAX, Communicator::communicator());
+  MPI_Allreduce(&mNumPoints, &numPoints, 1, mpiDataType, MPI_SUM, Communicator::communicator());
+  MPI_Allreduce(&mShiftedSum, &shiftedSum, 1, mpiDataType, MPI_SUM, Communicator::communicator());
+  MPI_Allreduce(&mShiftedSum2, &shiftedSum2, 1, mpiDataType, MPI_SUM, Communicator::communicator());
+
+  // Calculate mean and variance with total num points, since they are divided through
+  mean = calculateMean(numPoints, shiftedSum, mMeanGuess);
+  variance = calculateVariance(numPoints, shiftedSum, shiftedSum2);
+  total = calculateTotal(numPoints, shiftedSum, mMeanGuess);
+
+  // Divide total and numPoints by procs, since these are usually added similarly on every proc
+  const auto numProcs = Process::getTotalNumberOfProcesses();
+  numPoints /= numProcs;
+  total /= numProcs;
+}
+                        
+  
+
+
+} // end namespace Spheral

--- a/src/Solvers/LinearSolver.cc
+++ b/src/Solvers/LinearSolver.cc
@@ -1,0 +1,19 @@
+//---------------------------------Spheral++----------------------------------//
+// LinearSolver
+//
+// Represents a solver for a linear system of equations
+//----------------------------------------------------------------------------//
+
+#include "LinearSolver.hh"
+
+namespace Spheral {
+
+//------------------------------------------------------------------------------
+// Constructor
+//------------------------------------------------------------------------------
+LinearSolver::
+LinearSolver():
+  mDescription("LinearSolver") {
+}
+
+} // end namespace Spheral

--- a/src/Solvers/LinearSolver.hh
+++ b/src/Solvers/LinearSolver.hh
@@ -1,0 +1,100 @@
+//---------------------------------Spheral++----------------------------------//
+// LinearSolver
+//
+// Represents a solver for a linear system of equations
+// A given type only needs to fill in the pure virtual methods, and the rest
+// is done through the setMap and setData functions. 
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_LinearSolver_hh__
+#define __Spheral_LinearSolver_hh__
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Spheral {
+
+template<class DataType> class IncrementalStatistic;
+
+/* To set up the class for a solve (each time the matrix changes)
+     initialize(...);
+     for (auto i = 0; i < numLocalRows; ++i) {
+       setMatRow(...);
+     }
+     assemble(...);
+     finalize(...);
+   To solve or multiply (as many times as needed after initialization)
+     setLHS(...); // Set guess
+     setRHS(...); // Set source
+     solve();     // Solve in place
+     getLHS(...); // Get solution
+
+*/
+class LinearSolver {
+public:
+  // Specify which part of the system to apply set/get to
+  enum Component {
+    LHS,
+    RHS,
+  };
+    
+  // Constructor
+  LinearSolver();
+
+  // Create matrices and vectors
+  virtual void initialize(const unsigned numLocVal,
+                          const unsigned firstGlobInd,
+                          const unsigned* numValsPerRow) = 0;
+
+  // Begin matrix fill
+  virtual void beginFill() = 0;
+
+  // Set values in matrix
+  virtual void setMatRow(const unsigned numVals,     // Number of values in this row
+                         const unsigned globRowInd,  // Global index of this row
+                         const unsigned* globColInd, // [numVals] Global indices for columns
+                         const double* colVal) = 0;  // [numVals] Values
+  virtual void setMatRows(const unsigned numRows,        // Number of rows
+                          const unsigned* numColsPerRow, // [numRows] Number of columns for each of these rows
+                          const unsigned* globRowInd,    // [numRows] Global indices for these rows
+                          const unsigned* globColInd,    // [numColsPerRow[numRows]] Global column indies for each value
+                          const double* colVal) = 0;     // [numColsPerRow[numRows]] Values
+
+  // Assemble matrix after fill
+  virtual void assemble() = 0;
+  
+  // Create solver/preconditioner
+  virtual void finalize() = 0;
+
+  // Set/get values in vectors
+  virtual void set(const Component c,                // Which vector to apply this to
+                   const unsigned numVals,      // Number of vector values to set 
+                   const unsigned firstGlobInd, // First global index for values
+                   const double* val) = 0;      // [numVals] Values
+  virtual void get(const Component c,                // Which vector to apply this to
+                   const unsigned numVals,      // Number of vector values to set 
+                   const unsigned firstGlobInd, // First global index for values
+                   double* val) = 0;            // [numVals] Values
+
+  // Solve the system of equations in place; returns true if converged
+  virtual bool solve() = 0;
+
+  // Multiply the matrix by a vector
+  virtual void multiply() = 0;
+
+  // Set/get description
+  virtual void setDescription(std::string desc);
+  virtual std::string getDescription() const;
+
+  // Return statistics if available, empty vector if not
+  virtual std::vector<std::shared_ptr<IncrementalStatistic<double>>> statistics() const;
+
+protected:
+  std::string mDescription;
+}; // end class LinearSolver
+
+} // end namespace Spheral
+
+#include "LinearSolverInline.hh"
+
+#endif

--- a/src/Solvers/LinearSolverInline.hh
+++ b/src/Solvers/LinearSolverInline.hh
@@ -1,0 +1,30 @@
+namespace Spheral {
+
+//------------------------------------------------------------------------------
+// Return empty statistics
+//------------------------------------------------------------------------------
+inline
+std::vector<std::shared_ptr<IncrementalStatistic<double>>>
+LinearSolver::
+statistics() const {
+  return std::vector<std::shared_ptr<IncrementalStatistic<double>>>();
+}
+
+//------------------------------------------------------------------------------
+// Set/get description
+//------------------------------------------------------------------------------
+inline
+void
+LinearSolver::
+setDescription(std::string desc) {
+  mDescription = desc;
+}
+
+inline
+std::string
+LinearSolver::
+getDescription() const {
+  return mDescription;
+}
+
+} // end namespace Spheral

--- a/src/Solvers/containsConstantNodes.hh
+++ b/src/Solvers/containsConstantNodes.hh
@@ -1,0 +1,25 @@
+//---------------------------------Spheral++----------------------------------//
+// containsConstantNodes
+//
+// Checks whether boundaries contain constant nodes
+//----------------------------------------------------------------------------//
+#ifndef __Spheral_containsConstantNodes_hh__
+#define __Spheral_containsConstantNodes_hh__
+
+#include <vector>
+
+namespace Spheral {
+
+template<typename Dimension> class Boundary;
+
+template<typename Dimension>
+inline bool containsConstantNodes(const Boundary<Dimension>* boundary);
+
+template<typename Dimension>
+inline bool containsConstantNodes(const std::vector<Boundary<Dimension>*>& boundaries);
+
+} // end namespace Spheral
+
+#include "containsConstantNodesInline.hh"
+
+#endif

--- a/src/Solvers/containsConstantNodesInline.hh
+++ b/src/Solvers/containsConstantNodesInline.hh
@@ -1,0 +1,28 @@
+#include "Boundary/ConstantBoundary.hh"
+#include "Boundary/InflowOutflowBoundary.hh"
+
+namespace Spheral {
+
+template<typename Dimension>
+inline
+bool
+containsConstantNodes(const Boundary<Dimension>* boundary) {
+  // This is bad. It would probably be better to add a bool to the boundaries
+  // that is true for boundaries that contain constant nodes.
+  return (dynamic_cast<const ConstantBoundary<Dimension>*>(boundary) != nullptr
+          || dynamic_cast<const InflowOutflowBoundary<Dimension>*>(boundary) != nullptr);
+}
+
+template<typename Dimension>
+inline
+bool
+containsConstantNodes(const std::vector<Boundary<Dimension>*>& boundaries) {
+  for (auto& boundary : boundaries) {
+    if (containsConstantNodes(boundary)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // end namespace Spheral

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -35,6 +35,7 @@ set(Utilities_sources
     clipFacetedVolume.cc
     uniform_random.cc
     initializeAxom.cc
+    initializeHypre.cc
     )
 
 instantiate(Utilities_inst Utilities_sources)
@@ -144,6 +145,7 @@ set(Utilities_headers
     SpheralMessage.hh
     StrideIterator.hh
     initializeAxom.hh
+    initializeHypre.hh
   )
 
 spheral_install_python_files(fitspline.py)

--- a/src/Utilities/initializeHypre.cc
+++ b/src/Utilities/initializeHypre.cc
@@ -1,0 +1,33 @@
+//---------------------------------Spheral++----------------------------------//
+// Initialize Spheral's use of HYPRE constructs.
+// HYPRE 3.0.0 requires HYPRE_Initialize() before any API call.
+//----------------------------------------------------------------------------//
+#include "Utilities/initializeHypre.hh"
+
+#ifdef SPHERAL_ENABLE_SOLVERS
+#include "HYPRE_utilities.h"
+#endif
+
+namespace Spheral {
+
+//------------------------------------------------------------------------------
+// Set up HYPRE at the start of Spheral
+//------------------------------------------------------------------------------
+void initializeHypre() {
+#ifdef SPHERAL_ENABLE_SOLVERS
+  HYPRE_Initialize();
+#endif
+}
+
+//------------------------------------------------------------------------------
+// Finalize HYPRE at the termination of a Spheral session
+//------------------------------------------------------------------------------
+void finalizeHypre() {
+#ifdef SPHERAL_ENABLE_SOLVERS
+  if (HYPRE_Initialized() && !HYPRE_Finalized()) {
+    HYPRE_Finalize();
+  }
+#endif
+}
+
+}

--- a/src/Utilities/initializeHypre.hh
+++ b/src/Utilities/initializeHypre.hh
@@ -1,0 +1,14 @@
+//---------------------------------Spheral++----------------------------------//
+// Initialize Spheral's use of HYPRE constructs
+//----------------------------------------------------------------------------//
+#ifndef Spheral_initializeHypre
+#define Spheral_initializeHypre
+
+namespace Spheral {
+
+void initializeHypre();   // Set up HYPRE at the start of a Spheral run
+void finalizeHypre();     // Finalize HYPRE at the end of a Spheral run
+
+}
+
+#endif

--- a/tests/integration.ats
+++ b/tests/integration.ats
@@ -91,6 +91,7 @@ source("unit/Mesh/testLineMesh.py")
 
 # Solvers unit tests
 source("unit/Solvers/testKinsol.py")
+source("unit/Solvers/testLinearSolver.py")
 
 # MPI python interface unit tests
 source("unit/Distributed/testMPI4PYasPYMPI.py")

--- a/tests/unit/Solvers/testLinearSolver.py
+++ b/tests/unit/Solvers/testLinearSolver.py
@@ -284,7 +284,7 @@ if preconditioner == "amg":
     options.preconditionerType = HyprePreconditionerType.AMGPreconditioner
 elif preconditioner == "ilu":
     options.preconditionerType = HyprePreconditionerType.ILUPreconditioner
-    options.factorLevelILU = 5
+    options.ilu.factorLevel = 5
 else:
     options.preconditionerType = HyprePreconditionerType.NoPreconditioner
 solver = HypreLinearSolver(options);

--- a/tests/unit/Solvers/testLinearSolver.py
+++ b/tests/unit/Solvers/testLinearSolver.py
@@ -1,0 +1,406 @@
+#ATS:test(SELF, "--dimension 1 --nx 64 --preconditioner 'none' --numpyTest True", np=1, label="Linear solver, 1d GMRES")
+#ATS:test(SELF, "--dimension 2 --nx 16 --preconditioner 'ilu' --reflecting True --numpyTest True", np=4, label="Linear solver, 2d ILU")
+#ATS:test(SELF, "--dimension 3 --nx 8 --preconditioner 'amg' --periodic True --numpyTest True --nPerh 4.01", np=8, label="Linear solver, 3d AMG")
+# #ATS:test(SELF, "--dimension 3 --nx 50 --preconditioner 'amg' --reflecting True --nPerh 4.01 --numTests 10 --numSolves 5 --caliperConfig 'spot,runtime-report'", np=32, label="Linear solver, timing check")
+
+#-------------------------------------------------------------------------------
+# Set up a system of equations and solve them with the linear solver operator
+#-------------------------------------------------------------------------------
+from Spheral import *
+from SpheralTestUtilities import *
+import numpy as np
+import time, mpi
+title("Linear solver test")
+
+#-------------------------------------------------------------------------------
+# Generic problem parameters
+#-------------------------------------------------------------------------------
+commandLine(
+    # Spatial stuff
+    dimension = 1,
+    nx = 32,
+    x0 = 0.0,
+    x1 = 1.0,
+
+    # Interpolation kernel
+    nPerh = 2.01,
+
+    # Solver options
+    preconditioner = "amg",
+
+    # Test reinitialization
+    numTests = 4, # Multiple tests, same graph but different data
+    numSolves = 2, # Solve the same thing multiple times for timing
+
+    # Include boundary conditions
+    reflecting = False,
+    periodic = False,
+
+    # Test options
+    tolerance = 1e-4,
+    numpyTest = False,
+    seed = None,
+    saveSystem = False, # Save hypre matrices
+    exactGuess = False,
+)    
+exec("from Spheral%id import *" % dimension, globals())
+
+if seed is None:
+    seed = np.random.randint(0, 2**8)
+output("seed")
+np.random.seed(seed)
+
+#-------------------------------------------------------------------------------
+# Create nodes
+#------------------------------------------------------------------------------
+units = MKS()
+output("units")
+
+eos = GammaLawGas(5.0/3.0, 1.0, units)
+output("eos")
+
+WT = TableKernel(WendlandC4Kernel(), 1000)
+kernelExtent = WT.kernelExtent
+output("WT")
+
+delta = (x1 - x0) / nx
+hmid = delta * nPerh * kernelExtent
+hmin = hmid * 1.e-3
+hmax = hmid * 1.e3
+nodes = makeFluidNodeList("nodes", eos,
+                          hmin = hmin,
+                          hmax = hmax,
+                          nPerh = nPerh,
+                          kernelExtent = kernelExtent)
+output("nodes")
+output("nodes.hmin")
+output("nodes.hmax")
+output("nodes.nodesPerSmoothingScale")
+    
+#-------------------------------------------------------------------------------
+# Seed the nodes
+#-------------------------------------------------------------------------------
+rho0 = 1.0
+if dimension == 1:
+    from DistributeNodes import distributeNodesInRange1d
+    distributeNodesInRange1d([(nodes, nx, rho0, (x0, x1))],
+                             nPerh = nPerh)
+elif dimension == 2:
+    from GenerateNodeDistribution2d import *
+    generator = GenerateNodeDistribution2d(distributionType="lattice",
+                                           nRadial = nx, nTheta = nx,
+                                           xmin = (x0, x0),
+                                           xmax = (x1, x1),
+                                           rho = rho0,
+                                           nNodePerh = nPerh)
+    if mpi.procs > 1:
+        from VoronoiDistributeNodes import distributeNodes2d
+    else:
+        from DistributeNodes import distributeNodes2d
+    distributeNodes2d((nodes, generator))
+else:
+    from GenerateNodeDistribution3d import *
+    generator = GenerateNodeDistribution3d(distributionType="lattice",
+                                           n1 = nx, n2 = nx, n3 = nx,
+                                           xmin = (x0, x0, x0),
+                                           xmax = (x1, x1, x1),
+                                           rho=rho0,
+                                           nNodePerh = nPerh)
+    if mpi.procs > 1:
+        from VoronoiDistributeNodes import distributeNodes3d
+    else:
+        from DistributeNodes import distributeNodes3d
+    distributeNodes3d((nodes, generator))
+output("nodes.numNodes")
+numLocal = nodes.numInternalNodes
+output("numLocal")
+
+#-------------------------------------------------------------------------------
+# Create DataBase
+#-------------------------------------------------------------------------------
+dataBase = DataBase()
+dataBase.appendNodeList(nodes)
+output("dataBase")
+
+#-------------------------------------------------------------------------------
+# Set initial conditions
+#------------------------------------------------------------------------------
+inp = dataBase.newFluidScalarFieldList(0.0, "input")
+out = dataBase.newFluidScalarFieldList(0.0, "output")
+inp0 = dataBase.newFluidScalarFieldList(0.0, "initial input")
+out0 = dataBase.newFluidScalarFieldList(0.0, "initial output")
+for i in range(numLocal):
+    inp[0][i] = np.random.uniform(0.0, 2.0)
+    inp0[0][i] = inp[0][i]
+    out[0][i] = np.random.uniform(-2.0, 2.0)
+    out0[0][i] = out[0][i]
+pos = dataBase.fluidPosition
+
+#-------------------------------------------------------------------------------
+# Construct boundary conditions.
+#-------------------------------------------------------------------------------
+limits = [x0, x1]
+bounds = []
+assert(not (reflecting and periodic))
+if reflecting or periodic:
+    for d in range(dimension):
+        planes = []
+        for n in range(2):
+            point = Vector.zero
+            point[d] = limits[n]
+            normal = Vector.zero
+            normal[d] = 1.0 if n == 0 else -1.0
+            planes.append(Plane(point, normal))
+            if reflecting:
+                bounds.append(ReflectingBoundary(planes[n]))
+        if periodic:
+            bounds.append(PeriodicBoundary(planes[0], planes[1]))
+if mpi.procs > 1:
+    bounds.append(TreeDistributedBoundary.instance())
+output("bounds")
+
+#-------------------------------------------------------------------------------
+# Iterate h
+#-------------------------------------------------------------------------------
+method = SPHSmoothingScale(IdealH, WT)
+iterateIdealH(dataBase,
+              [method],
+              bounds,
+              100, # max h iterations
+              1.e-4) # h tolerance
+
+#-------------------------------------------------------------------------------
+# Finish setting up connectivity
+#-------------------------------------------------------------------------------
+nodes.numGhostNodes = 0
+nodes.neighbor().updateNodes()
+for bc in bounds:
+    bc.setAllGhostNodes(dataBase)
+    bc.finalizeGhostBoundary()
+    nodes.neighbor().updateNodes()
+dataBase.updateConnectivityMap()
+for bc in bounds:
+    for fl in [inp, out, inp0, out0]:
+        bc.applyFieldListGhostBoundary(fl)
+for bc in bounds:
+    bc.finalizeGhostBoundary()
+
+#-------------------------------------------------------------------------------
+# Create map using generated points
+#------------------------------------------------------------------------------
+flatConnectivity = FlatConnectivity()
+flatConnectivity.computeIndices(dataBase)
+flatConnectivity.computeGlobalIndices(dataBase, bounds)
+flatConnectivity.computeBoundaryInformation(dataBase, bounds)
+output("flatConnectivity")
+numGlobal = flatConnectivity.numGlobalNodes()
+output("numGlobal")
+
+#-------------------------------------------------------------------------------
+# Test functions
+#------------------------------------------------------------------------------
+maxErr = 0.0
+def norm(s1, s2, eps = 1.0e-16):
+    v1 = np.array(s1)
+    v2 = np.array(s2)
+    return np.amax(2.0 * np.abs(v1 - v2) / (np.abs(v1) + np.abs(v2) + eps))
+def check(s1, s2, label, tol = tolerance, eps = 1.0e-16):
+    err = norm(s1, s2, eps)
+    global maxErr
+    if err > maxErr:
+        maxErr = err
+    if err > tol:
+        message = "{}\n\tcalculated={} does not agree with\n\texpected={}\n\terr={}".format(label, s1, s2, err)
+        if ignoreErr:
+            print(message)
+        else:
+            raise ValueError(message)
+        
+#-------------------------------------------------------------------------------
+# Generate matrix
+#------------------------------------------------------------------------------
+globRowInd = []
+numColsPerRow = []
+globColInd = []
+colVal = [[] for t in range(numTests)]
+multDirect = [np.zeros(numLocal) for t in range(numTests)]
+if numpyTest:
+    spRow = []
+    spCol = []
+    spDat = [[] for t in range(numTests)]
+for i in range(numLocal):
+    # Also check unique neighbors as a bonus since this function is designed for matrices
+    globali = flatConnectivity.localToGlobal(i)
+    numNeighbors = flatConnectivity.numNonConstNeighbors(i)
+    numConst = flatConnectivity.numConstNeighbors(i)
+    numUnique, localCols, globalCols, constCols, indexMap = flatConnectivity.uniqueNeighborIndices(i)
+    check(localCols, flatConnectivity.nonConstNeighborIndices(i), "local cols")
+    check(globalCols, flatConnectivity.globalNeighborIndices(i), "global cols")
+    if numConst > 0:
+        check(constCols, flatConnectivity.constNeighborIndices(i), "const cols")
+
+    # Set row information
+    numColsPerRow.append(numUnique)
+    globRowInd.append(globali)
+
+    # Initialize the column data
+    firstInd = len(globColInd)
+    globColInd.extend([-1 for j in range(numUnique)])
+    for t in range(numTests):
+        colVal[t].extend([0.0 for j in range(numUnique)])
+    
+    for j in range(numNeighbors):
+        ind = localCols[j]
+        globInd = globalCols[j]
+        uniqueInd = indexMap[j]
+        flatInd = firstInd + uniqueInd # Index for globColInd and colVal
+        globColInd[flatInd] = globInd
+        if numpyTest:
+            spRow.append(globali)
+            spCol.append(globInd)
+        for t in range(numTests):
+            val = -1.0 * np.random.uniform(1.5, 2.5) if ind == i else np.random.uniform(0.5, 1.5) / numNeighbors
+            colVal[t][flatInd] += val
+            multDirect[t][i] += val * inp0[0][ind]
+            if numpyTest:
+                spDat[t].append(val)
+if numpyTest:
+    import scipy.sparse as sps
+    globDat = [mpi.allreduce(spDat[t]) for t in range(numTests)]
+    globRow = mpi.allreduce(spRow)
+    globCol = mpi.allreduce(spCol)
+    npMat = [sps.coo_matrix((globDat[t], (globRow, globCol)), shape=(numGlobal, numGlobal)).tocsr() for t in range(numTests)]
+    lhsVec = [inp0[0][i] for i in range(numLocal)]
+    lhsVec = np.array(mpi.allreduce(lhsVec))
+    multNumpy = [npMat[t] @ lhsVec for t in range(numTests)]
+
+#-------------------------------------------------------------------------------
+# Initialize solver
+#------------------------------------------------------------------------------
+options = HypreOptions()
+options.maxNumberOfIterations = 1000
+options.saveLinearSystem = saveSystem
+if preconditioner == "amg":
+    options.preconditionerType = HyprePreconditionerType.AMGPreconditioner
+elif preconditioner == "ilu":
+    options.preconditionerType = HyprePreconditionerType.ILUPreconditioner
+    options.factorLevelILU = 5
+else:
+    options.preconditionerType = HyprePreconditionerType.NoPreconditioner
+solver = HypreLinearSolver(options);
+output("solver")
+
+start = time.perf_counter()
+firstGlobInd = flatConnectivity.firstGlobalIndex()
+mpi.barrier()
+solver.initialize(numLocal, firstGlobInd, vector_of_unsigned(numColsPerRow))
+hypre_init_time = mpi.allreduce(time.perf_counter() - start, mpi.MAX)
+output("hypre_init_time")
+
+#-------------------------------------------------------------------------------
+# Run tests
+#------------------------------------------------------------------------------
+for t in range(numTests):
+    mpi.barrier()
+    start = time.perf_counter()
+    solver.beginFill()
+    solver.setMatRows(numLocal,
+                      vector_of_unsigned(numColsPerRow),
+                      vector_of_unsigned(globRowInd),
+                      vector_of_unsigned(globColInd),
+                      vector_of_double(colVal[t]))
+    hypre_fill_time = mpi.allreduce(time.perf_counter() - start, mpi.MAX)
+    output("hypre_fill_time")
+    
+    mpi.barrier()
+    start = time.perf_counter()
+    solver.assemble()
+    hypre_assemble_time = mpi.allreduce(time.perf_counter() - start, mpi.MAX)
+    output("hypre_assemble_time")
+
+    mpi.barrier()
+    start = time.perf_counter()
+    solver.finalize()
+    hypre_finalize_time = mpi.allreduce(time.perf_counter() - start, mpi.MAX)
+    output("hypre_finalize_time")
+
+    #-------------------------------------------------------------------------------
+    # Multiply through to get RHS
+    #------------------------------------------------------------------------------
+    # output("inp0[0][0]")
+    
+    lhsVec = vector_of_double([inp0[0][i] for i in range(numLocal)])
+    mpi.barrier()
+    solver.set(LinearSolver.LHS, numLocal, firstGlobInd, lhsVec)
+    mpi.barrier()
+    solver.multiply()
+    
+    rhsVec = solver.get(LinearSolver.RHS, numLocal, firstGlobInd)
+    for i in range(numLocal):
+        out[0][i] = rhsVec[i]
+
+    for i in range(numLocal):
+        if abs(out[0][i] - out0[0][i]) < 1e-16:
+            raise ValueError("output has not been changed")
+    
+    for bc in bounds:
+        for fl in [inp, out]:
+            bc.applyFieldListGhostBoundary(fl)
+    for bc in bounds:
+        bc.finalizeGhostBoundary()
+    
+    #-------------------------------------------------------------------------------
+    # Check that the multiplication result is as expected
+    #------------------------------------------------------------------------------
+    if numpyTest:
+        firstGlobal = flatConnectivity.localToGlobal(0)
+        for i in range(numLocal):
+            globali = flatConnectivity.localToGlobal(i)
+            if abs(multNumpy[t][globali] - multDirect[t][i]) > tolerance:
+                print("warning: numpy and direct mult differ: np={}, dir={}".format(multNumpy[t][globali], multDirect[t][globali]))
+            if abs(multNumpy[t][globali] - out[0][i]) > tolerance:
+                raise ValueError("numpy comparison failed for test {}, point {}: exp={}, calc={}".format(t, i, multDirect[t][i], out[0][i]))
+        print("numpy comparison successful: {} -> {}, {}".format(lhsVec[0], multDirect[t][0], multNumpy[t][firstGlobal]))
+        
+    for i in range(numLocal):
+        if abs(multDirect[t][i] - out[0][i]) > tolerance:
+            raise ValueError("multiplication incorrect for test {}, point {}: exp={}, calc={}".format(t, i, multDirect[t][i], out[0][i]))
+    
+    #-------------------------------------------------------------------------------
+    # Solve the linear system to get back the LHS
+    #------------------------------------------------------------------------------
+    if exactGuess:
+        for i in range(numLocal):
+            inp[0][i] = inp0[0][i]
+    else:
+        for i in range(numLocal):
+            inp[0][i] = np.random.uniform(0.0, 1.0)
+
+    for i in range(numSolves):
+        lhsVec = vector_of_double([inp[0][i] for i in range(numLocal)])
+        rhsVec = vector_of_double([out[0][i] for i in range(numLocal)])
+        
+        start = time.perf_counter()
+        mpi.barrier()
+        solver.set(LinearSolver.LHS, numLocal, firstGlobInd, lhsVec)
+        solver.set(LinearSolver.RHS, numLocal, firstGlobInd, rhsVec)
+        mpi.barrier()
+        solver.solve()
+        hypre_solve_time = mpi.allreduce(time.perf_counter() - start, mpi.MAX)
+        output("hypre_solve_time")
+    
+    mpi.barrier()
+    lhsVec = solver.get(LinearSolver.LHS, numLocal, firstGlobInd)
+    for i in range(numLocal):
+        inp[0][i] = lhsVec[i]
+
+    # output("inp[0][0]")
+
+    #-------------------------------------------------------------------------------
+    # Check the results
+    #------------------------------------------------------------------------------
+    for i in range(numLocal):
+        if abs(inp[0][i] - inp0[0][i]) > tolerance:
+            raise ValueError("error too high for test {} point {}: begin={}, end={}".format(t + 1, i, inp0[0][i], inp[0][i]))
+    print("test {} passed".format(t+1))
+


### PR DESCRIPTION
# Summary

- Adds a general-purpose linear solver interface with Hypre (distributed, iterative) and Eigen (local, direct) backends.
- Renames the SPHERAL_INCLUDE_SUNDIALS CMake option to SPHERAL_INCLUDE_SOLVERS. 
- Adds tests for solvers.

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

