### PR TITLE
Fixed typo in ShadowIvanoviSALEDamageModel.py file and added guard to JohnsonCookStrength

### DIFF
--- a/src/Damage/ShadowIvanoviSALEDamageModel.py
+++ b/src/Damage/ShadowIvanoviSALEDamageModel.py
@@ -118,7 +118,7 @@ default values listed in parens):
                            "criticalDamageThreshold",
                            "mask"]
             for iarg, argval in enumerate(args):
-                damage_kwargs[kward_order[iarg]] = argval
+                damage_kwargs[kwarg_order[iarg]] = argval
 
             # Process any keyword arguments.  Note we already removed any deprecated keywords.
             for argname in kwargs:

--- a/src/SolidMaterial/JohnsonCookStrength.cc
+++ b/src/SolidMaterial/JohnsonCookStrength.cc
@@ -47,6 +47,8 @@ JohnsonCookStrength(const SolidEquationOfState<Dimension>& eos,
   mShearModulusScaling(shearModulusScaling) {
   VERIFY2(mEpsdot0 > 0.0,
           "JohnsonCookStrength ERROR: reference strain-rate must be greater than zero.");
+  VERIFY2(mEpsdotmin > 0.0,
+          "JohnsonCookStrength ERROR: reference strain-rate must be greater than zero.");
   VERIFY2(mTmelt > mTroom,
           "JohnsonCookStrength ERROR: Tmelt must be greater than or equal Troom.");
   VERIFY2((not shearModulusScaling) or mu0 > 0.0,

--- a/src/SolidMaterial/JohnsonCookStrength.cc
+++ b/src/SolidMaterial/JohnsonCookStrength.cc
@@ -48,7 +48,7 @@ JohnsonCookStrength(const SolidEquationOfState<Dimension>& eos,
   VERIFY2(mEpsdot0 > 0.0,
           "JohnsonCookStrength ERROR: reference strain-rate must be greater than zero.");
   VERIFY2(mEpsdotmin > 0.0,
-          "JohnsonCookStrength ERROR: reference strain-rate must be greater than zero.");
+          "JohnsonCookStrength ERROR: minimum strain-rate must be greater than zero.");
   VERIFY2(mTmelt > mTroom,
           "JohnsonCookStrength ERROR: Tmelt must be greater than or equal Troom.");
   VERIFY2((not shearModulusScaling) or mu0 > 0.0,


### PR DESCRIPTION
Found a typo in the ShadowIvanoviSALEDamageModel.py file (was kward now kwarg). Also added an additional guard to the JohnsonCookStrength model so that nobody puts a 0 for the minimum stress rate.

# Summary

- This PR is bugfix and a guard addition to a strength model
- It does the following:
  - Fixes a typo in ShadowIvanoviSALEDamageModel.py
     - Typo was "kward_order" when it should have been "kwarg_order"
     - This could be a problem if the user wanted to have multiple positional arguments.  
  - Added an additional guard to the JohnsonCookStrength model
     - Before the user could enter a value less than or equal to zero for the minimum allowed strain rate. 
     - This would cause -inf values
     - New guard prevents the user from running the strength model if their input isn't greater than zero.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (PR#)
- [x] LLNLSpheral PR has passed all tests.

