### PR TITLE
Fixed a logical typo in the Johnson Cook strength model

### DIFF
--- a/src/SolidMaterial/JohnsonCookStrength.cc
+++ b/src/SolidMaterial/JohnsonCookStrength.cc
@@ -95,7 +95,7 @@ yieldStrength(Field<Dimension, Scalar>& yieldStrength,
   const auto n = yieldStrength.numInternalElements();
 #pragma omp for
   for (auto i = 0u; i < n; ++i) {
-    const auto Tstar = std::max(0.0, std::min(1.0, T(i) - mTroom)/(mTmelt - mTroom));
+    const auto Tstar = std::max(0.0, std::min(1.0, ((T(i) - mTroom)/(mTmelt - mTroom))));
     const auto fmelt = std::max(0.0, std::min(1.0, 1.0 - pow(Tstar, mm)));
     yieldStrength(i) = 
       ((mA + mB*pow(plasticStrain(i), mnhard))*


### PR DESCRIPTION
Fixed a logical typo in the Johnson Cook strength model that would cause the temperature dependence to behave nonphysically.

# Summary
This PR fixes a line in the Johnson Cook strength model that would cause the temperature dependence within the model to behave nonphysically. 

Specifically the homologous temperature would get artificially clamped to 1 / (Tmelt - Troom) not allowing proper yielding at temperatures above the room temperature. For temperatures below room temperature updated equation results in the same homologous temperature Tstar. 

Line updated from:
    const auto Tstar = std::max(0.0, std::min(1.0, T(i) - mTroom)/(mTmelt - mTroom));
To:
    const auto Tstar = std::max(0.0, std::min(1.0, ((T(i) - mTroom)/(mTmelt - mTroom))));
    
I have performed a test of my own and the yield strength now behaves more physically, without any nonphysical yield strengths emerging when a material heats up.

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

