### PR TITLE
Field lookup optimization 491

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ Notable changes include:
     * Refactored use of pair-wise fields in hydro packages to avoid using pointers and allow empty PairwiseFields.
     * Bin files in install (bin/spheral and bin/spheral-ats) now use relative paths instead of being configured for one specific path.
     * Added a page to the docs about GPU development. 
+    * Optimized field lookups in state, reducing per-call cost from O(N) to O(log N)
 
   * Bug fixes:
     * Adiak memory leak is fixed by calling adiak::clean() before exit.

--- a/src/DataBase/StateBase.cc
+++ b/src/DataBase/StateBase.cc
@@ -233,10 +233,17 @@ template<typename Dimension>
 bool
 StateBase<Dimension>::
 fieldNameRegistered(const FieldName& name) const {
-  KeyType fieldName, nodeListName;
-  for (auto [key, valptr]: mStorage) {
-    splitFieldKey(key, fieldName, nodeListName);
-    if (fieldName == name) return true;
+  // Field keys have the form <name>|<nodeListName>, so we can jump straight to the neighborhood
+  const auto prefix = name + "|";
+  auto itr = mStorage.lower_bound(prefix);
+  if (itr == mStorage.end()) return false;
+  if (itr->first.compare(0, prefix.size(), prefix) != 0) return false;
+  // Confirm this key actually refers to a Field (as opposed to a non-field entry)
+  for (; itr != mStorage.end(); ++itr) {
+    if (itr->first.compare(0, prefix.size(), prefix) != 0) break;
+    if (itr->second.type() == typeid(std::reference_wrapper<FieldBase<Dimension>>)) {
+      return true;
+    }
   }
   return false;
 }
@@ -261,7 +268,7 @@ std::vector<typename StateBase<Dimension>::KeyType>
 StateBase<Dimension>::
 fullFieldKeys() const {
   vector<KeyType> result;
-  for (auto [key, aref]: mStorage) {
+  for (const auto& [key, aref]: mStorage) {
     if (aref.type() == typeid(std::reference_wrapper<FieldBase<Dimension>>)) {
       result.push_back(key);
     }
@@ -277,7 +284,7 @@ std::vector<typename StateBase<Dimension>::KeyType>
 StateBase<Dimension>::
 miscKeys() const {
   vector<KeyType> result;
-  for (auto [key, aref]: mStorage) {
+  for (const auto& [key, aref]: mStorage) {
     if (aref.type() != typeid(std::reference_wrapper<FieldBase<Dimension>>)) {
       result.push_back(key);
     }
@@ -294,9 +301,9 @@ StateBase<Dimension>::
 fieldNames() const {
   vector<FieldName> result;
   KeyType fieldName, nodeListName;
-  for (auto [key, aref]: mStorage) {
+  for (const auto& [key, aref]: mStorage) {
     if (aref.type() == typeid(std::reference_wrapper<FieldBase<Dimension>>)) {
-      auto fref = std::any_cast<std::reference_wrapper<FieldBase<Dimension>>>(aref);
+      auto& fref = std::any_cast<const std::reference_wrapper<FieldBase<Dimension>>&>(aref);
       splitFieldKey(fref.get().name(), fieldName, nodeListName);
       result.push_back(fieldName);
     }

--- a/src/DataBase/StateBaseInline.hh
+++ b/src/DataBase/StateBaseInline.hh
@@ -1,4 +1,3 @@
-#include "boost/algorithm/string.hpp"
 #include "DataBase/UpdatePolicyBase.hh"
 #include "RK/RKCorrectionParams.hh"
 #include "RK/ReproducingKernel.hh"
@@ -67,10 +66,9 @@ std::vector<Field<Dimension, Value>*>
 StateBase<Dimension>::
 allFields() const {
   std::vector<Field<Dimension, Value>*> result;
-  KeyType fieldName, nodeListName;
-  for (auto [key, aref]: mStorage) {
+  for (const auto& [key, aref]: mStorage) {
     if (aref.type() == typeid(std::reference_wrapper<FieldBase<Dimension>>)) {
-      auto fb = std::any_cast<std::reference_wrapper<FieldBase<Dimension>>>(aref);
+      auto& fb = std::any_cast<const std::reference_wrapper<FieldBase<Dimension>>&>(aref);
       auto* fptr = dynamic_cast<Field<Dimension, Value>*>(&fb.get());
       if (fptr != nullptr) result.push_back(fptr);
     }
@@ -98,16 +96,16 @@ StateBase<Dimension>::
 fields(const std::string& name,
        bool allowNone) const {
   FieldList<Dimension, Value> result;
-  KeyType fieldName, nodeListName;
-  for (auto [key, aref]: mStorage) {
-    splitFieldKey(key, fieldName, nodeListName);
-    if (fieldName == name) {
-      CHECK(nodeListName != "");
-      if (aref.type() == typeid(std::reference_wrapper<FieldBase<Dimension>>)) {
-        auto fb = std::any_cast<std::reference_wrapper<FieldBase<Dimension>>>(aref);
-        auto* fptr = dynamic_cast<Field<Dimension, Value>*>(&fb.get());
-        if (fptr != nullptr) result.appendField(*fptr);
-      }
+  // Keys are "fieldName|nodeListName" in map, all entries for field are contiguous
+  const auto prefix = name + "|";
+  for (auto itr = mStorage.lower_bound(prefix); itr != mStorage.end(); ++itr) {
+    const auto& key = itr->first;
+    if (key.compare(0, prefix.size(), prefix) != 0) break;
+    const auto& aref = itr->second;
+    if (aref.type() == typeid(std::reference_wrapper<FieldBase<Dimension>>)) {
+      auto& fb = std::any_cast<const std::reference_wrapper<FieldBase<Dimension>>&>(aref);
+      auto* fptr = dynamic_cast<Field<Dimension, Value>*>(&fb.get());
+      if (fptr != nullptr) result.appendField(*fptr);
     }
   }
   CHECK2(allowNone or result.size() > 0u, "Error: found no fields for key " << name);
@@ -233,17 +231,13 @@ StateBase<Dimension>::
 splitFieldKey(const KeyType& key,
               KeyType& fieldName,
               KeyType& nodeListName) {
-  std::vector<std::string> keys;
-  boost::split(keys, key, boost::is_any_of("|"));
-  if (keys.size() > 1) {
-    fieldName = keys[0];
-    nodeListName = keys[1];
-  } else if (keys.size() == 1) {
-    fieldName = keys[0];
-    nodeListName = "";
+  const auto sep = key.find('|');
+  if (sep == std::string::npos) {
+    fieldName = key;
+    nodeListName.clear();
   } else {
-    fieldName = "";
-    nodeListName = "";
+    fieldName.assign(key, 0, sep);
+    nodeListName.assign(key, sep + 1, std::string::npos);
   }
 }
 

--- a/src/DataBase/StateDerivatives.cc
+++ b/src/DataBase/StateDerivatives.cc
@@ -103,7 +103,7 @@ Zero() {
   ZERO.addVisitor<std::reference_wrapper<PairwiseField<Dimension, Scalar, 2u>>>([](const std::any& x) { std::any_cast<reference_wrapper<PairwiseField<Dimension, Scalar, 2u>>>(x).get().Zero(); });
 
   // Walk the state values and zero them
-  for (auto itr: mStorage) {
+  for (auto& itr: mStorage) {
     ZERO.visit(itr.second);
   }
 }


### PR DESCRIPTION
### ToDo :
- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral MR pointing at this branch. ([MR#205](https://rzlc.llnl.gov/gitlab/owen/LLNLSpheral/-/merge_requests/205))
- [x] LLNLSpheral PR has [passed all tests](https://rzlc.llnl.gov/gitlab/owen/LLNLSpheral/-/pipelines/668495).
------
# Summary
- This PR is an internal representation of #491 from a forked repository.

The state lookups were very inefficient. The fields function, for example, was looping through everything in the state and checking whether the query matches each of these. The state is stored in a std::map! Which is sorted! So why was Spheral using O(N) lookups? Nobody knows.

This also removes `boost::split` calls, which allocate memory and are slower than standard string comparisons. 

Here is a comparison for all the functional tests that take > 30s. 

| Test | Old (s) | New (s) | Speedup |
|---|---:|---:|---:|
| CollisionlessSphereCollapse(Collisionless sphere gravitational collapse restart test (serial, acceleration ratio) INITIAL RUN) | 32.88 | 16.64 | 1.98× |
| Noh-cylindrical-2d(Noh cylindrical ACRK (sum vol), nPerh=4.0) | 37.69 | 35.95 | 1.05× |
| Noh-cylindrical-2d(Noh cylindrical ACRK (Voronoi vol), nPerh=4.0) | 36.65 | 35.90 | 1.02× |
| Noh-cylindrical-2d(Noh cylindrical ASPH, nPerh=4.0) | 35.10 | 32.24 | 1.09× |
| Noh-cylindrical-2d(Noh cylindrical CRK (sum vol), nPerh=4.0) | 37.93 | 37.71 | 1.01× |
| Noh-cylindrical-2d(Noh cylindrical SPH, nPerh=2.0) | 38.80 | 35.27 | 1.10× |
| Noh-planar-1d(Planar Noh problem -- 1-D (parallel) with Sidre (SPIO check)) | 52.33 | 53.25 | 0.98× |
| Noh-planar-1d(Planar Noh problem -- 1-D (parallel) with Sidre) | 44.92 | 44.50 | 1.01× |
| Noh-planar-1d(Planar Noh problem -- 1-D (parallel)) | 47.37 | 44.97 | 1.05× |
| Noh-planar-1d(Planar Noh problem -- 1-D (serial) with Sidre) | 44.96 | 42.78 | 1.05× |
| Noh-planar-1d(Planar Noh problem -- 1-D (serial)) | 43.55 | 42.40 | 1.03× |
| Noh-planar-1d(Planar Noh problem with CRK -- 1-D (serial)) | 57.58 | 53.13 | 1.08× |
| Noh-planar-1d(Planar Noh problem with FSISPH -- 1-D (serial)) | 54.40 | 39.88 | 1.36× |
| Noh-planar-1d(Planar Noh problem with GSPH and and HydroAccelerationGradient -- 1-D (serial)) | 44.97 | 42.44 | 1.06× |
| Noh-planar-1d(Planar Noh problem with GSPH and RiemannGradient -- 1-D (serial)) | 44.12 | 43.20 | 1.02× |
| Noh-planar-1d(Planar Noh problem with GSPH and SPHGradient -- 1-D (serial)) | 44.02 | 42.40 | 1.04× |
| Noh-planar-1d(Planar Noh problem with MFM -- 1-D (serial)) | 43.98 | 40.32 | 1.09× |
| Noh-planar-1d(Planar Noh problem with PSPH -- 1-D (serial)) | 45.65 | 42.19 | 1.08× |
| Noh-planar-1d(Planar Noh problem with solid SPH -- 1-D (parallel)) | 48.71 | 48.12 | 1.01× |
| Noh-planar-1d(Planar Noh problem with solid SPH -- 1-D (serial)) | 49.17 | 47.40 | 1.04× |
| Noh-RZ(Planar RZ Noh problem (SPH serial)) | 56.29 | 48.69 | 1.16× |
| Noh-spherical-1d(Spherical Noh problem -- 1-D (parallel)) | 47.67 | 42.13 | 1.13× |
| Noh-spherical-1d(Spherical Noh problem with solid SPH -- 1-D (parallel)) | 50.18 | 46.27 | 1.08× |
| Noh-spherical-1d(Spherical Noh problem with solid SPH -- 1-D (serial)) | 42.23 | 48.16 | 0.88× |
| PlanarCompaction-1d(Planar porous aluminum compaction problem -- 1-D (CRKSPH, 4 proc)) | 30.39 | 16.29 | 1.87× |
| PlanarCompaction-1d(Planar porous aluminum compaction problem -- 1-D (FSISPH, 4 proc)) | 32.34 | 16.73 | 1.93× |
| pureTorsion-3d(DEM pure torsion test -- 3-D (serial)) | 31.86 | 27.81 | 1.15× |
| RKInterpolation(RK interpolation - 3D septic) | 117.00 | 119.00 | 0.98× |
| RKInterpolation(RK interpolation - 3D sextic) | 58.33 | 57.98 | 1.01× |
| TaylorImpact(Generate 8 proc CRK 3D reference data) | 233.00 | 226.00 | 1.03× |
| TaylorImpact(Generate 8 proc SPH 3D reference data (no grad h)) | 242.00 | 245.00 | 0.99× |
| TaylorImpact(Generate 8 proc SPH 3D reference data) | 248.00 | 249.00 | 1.00× |
| TaylorImpact(Generate 8 proc SPH 3D reference data)#2 | 143.00 | 145.00 | 0.99× |
| TensileRod-1d(Tensile rod (GradyKippOwen damage) domain independence test SERIAL RUN) | 33.68 | 14.81 | 2.27× |
| TensileRod-1d(Tensile rod (probabilistic damage) domain independence test SERIAL RUN) | 34.37 | 14.78 | 2.33× |
| Verney-spherical(Spherical Verney problem with solid SPH -- 1-D (4 proc reproducing test)) | 61.00 | 52.72 | 1.16× |
| Verney-spherical(Spherical Verney problem with solid SPH -- 1-D (parallel)) | 91.00 | 82.00 | 1.11× |
| Verney-spherical(Spherical Verney problem with solid SPH -- 1-D (serial reproducing test setup)) | 56.68 | 49.90 | 1.14× |
| Verney-spherical(Spherical Verney problem with solid SPH -- 1-D (serial)) | 86.00 | 78.00 | 1.10× |

Tests have a higher proportion of time spent in startup tasks, so the actual speedup per cycle should be greater. Here is a comparison of the average, median, and variance of the speedup for the above tests, which is well above the noise between two identical test runs. 

| Comparison | Mean | Median | Variance |
|---|---:|---:|---:|
| Optimized vs baseline | 1.19× | 1.06× | 0.128 |
| Noise baseline (two identical optimized runs) | 1.03× | 1.01× | 0.082 |

