### PR TITLE
Inconsistent definition in FSISPH

### DIFF
--- a/src/FSISPH/SolidFSISPHEvaluateDerivatives.cc
+++ b/src/FSISPH/SolidFSISPHEvaluateDerivatives.cc
@@ -860,7 +860,7 @@ firstDerivativesLoop(const typename Dimension::Scalar /*time*/,
       // logic
       //---------------------------------------
       const auto sameMatij = (nodeListi == nodeListj and fragIDi == fragIDj);
-      const auto differentMatij = (nodeListi!=nodeListj);
+      const auto differentMatij = !sameMatij;
       const auto averageKernelij = ( (differentMatij and averageInterfaceKernels) or alwaysAverageKernels);
 
       // Kernels


### PR DESCRIPTION
# Summary

This makes the definition of `differentMatij` consistent across derivative loops. 

```
      // Original second loop
      const auto sameMatij =  (nodeListi == nodeListj and fragIDi==fragIDj);
      const auto differentMatij = !sameMatij; 
      const auto averageKernelij = ( (differentMatij and averageInterfaceKernels) or alwaysAverageKernels);
      
      // Original first loop
      const auto sameMatij = (nodeListi == nodeListj and fragIDi == fragIDj);
      const auto differentMatij = (nodeListi!=nodeListj); // <-- inconsistent
      const auto averageKernelij = ( (differentMatij and averageInterfaceKernels) or alwaysAverageKernels);
```

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

