### PR TITLE
Fixed a long standing bug in the solid hydro deviatoric stress update

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,7 @@ Notable changes include:
     * SPH now requests volume from RK.
     * Fixed a circular dependency in the Johnson-Cook damage model.
     * Fixed a bug that could allow multiple copies of the same boundary condition in Physics subpackages.
+    * Fixed a bug in the definition of the Jaumann stress rate in all the solid hydro packages.
 
   * Build changes / improvements:
     * Updated to PYB11Generator 2025.12.1.

--- a/src/CRKSPH/SolidCRKSPH.cc
+++ b/src/CRKSPH/SolidCRKSPH.cc
@@ -576,7 +576,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
       const auto deformation = localDvDxi.Symmetric();
       const auto spin = localDvDxi.SkewSymmetric();
       const auto deviatoricDeformation = deformation - deformation.Trace()/3.0*SymTensor::one();
-      const auto spinCorrection = (spin*Si + Si*spin).Symmetric();
+      const auto spinCorrection = (Si*spin - spin*Si).Symmetric();
       DSDti = spinCorrection + 2.0*mui*deviatoricDeformation;
 
       // In the presence of damage, add a term to reduce the stress on this point.

--- a/src/CRKSPH/SolidCRKSPHRZ.cc
+++ b/src/CRKSPH/SolidCRKSPHRZ.cc
@@ -650,7 +650,7 @@ evaluateDerivativesImpl(const Dimension::Scalar /*time*/,
       const auto deformationTT = vi.y()*riInv;
       const auto spin = localDvDxi.SkewSymmetric();
       const auto deviatoricDeformation = deformation - ((deformation.Trace() + deformationTT)/3.0)*SymTensor::one();
-      const auto spinCorrection = (spin*Si + Si*spin).Symmetric();
+      const auto spinCorrection = (Si*spin - spin*Si).Symmetric();
       DSDti = spinCorrection + 2.0*mui*deviatoricDeformation;
 
       // In the presence of damage, add a term to reduce the stress on this point.

--- a/src/FSISPH/SolidFSISPHEvaluateDerivatives.cc
+++ b/src/FSISPH/SolidFSISPHEvaluateDerivatives.cc
@@ -738,7 +738,7 @@ secondDerivativesLoop(const typename Dimension::Scalar time,
       const auto deformation = localDvDxi.Symmetric();
       const auto spin = localDvDxi.SkewSymmetric();
       const auto deviatoricDeformation = deformation - deformation.Trace()/3.0*SymTensor::one();
-      const auto spinCorrection = (spin*Si + Si*spin).Symmetric();
+      const auto spinCorrection = (Si*spin - spin*Si).Symmetric();
       DSDti += spinCorrection + 2.0*mui*deviatoricDeformation;
       
     } //loop-nodes

--- a/src/SPH/SolidSPH.cc
+++ b/src/SPH/SolidSPH.cc
@@ -762,7 +762,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
       const auto deformation = localDvDxi.Symmetric();
       const auto spin = localDvDxi.SkewSymmetric();
       const auto deviatoricDeformation = deformation - deformation.Trace()/3.0*SymTensor::one();
-      const auto spinCorrection = (spin*Si + Si*spin).Symmetric();
+      const auto spinCorrection = (Si*spin - spin*Si).Symmetric();
       DSDti = spinCorrection + 2.0*mui*deviatoricDeformation;
 
       // Optionally use damage to ramp down stress on damaged material.

--- a/src/SPH/SolidSPHRZ.cc
+++ b/src/SPH/SolidSPHRZ.cc
@@ -749,7 +749,7 @@ evaluateDerivativesImpl(const Dimension::Scalar time,
       const auto deformationTT = vi.y()*riInv;
       const auto spin = localDvDxi.SkewSymmetric();
       const auto deviatoricDeformation = deformation - ((deformation.Trace() + deformationTT)/3.0)*SymTensor::one();
-      const auto spinCorrection = (spin*Si + Si*spin).Symmetric();
+      const auto spinCorrection = (Si*spin - spin*Si).Symmetric();
       DSDti = spinCorrection + (2.0*mui)*deviatoricDeformation;
 
       // In the presence of damage, add a term to reduce the stress on this point.

--- a/src/SPH/SolidSPH_RAJA.cc
+++ b/src/SPH/SolidSPH_RAJA.cc
@@ -684,7 +684,7 @@ evaluateDerivativesImpl(const typename Dimension::Scalar /*time*/,
       const auto deformation = localDvDxi.Symmetric();
       const auto spin = localDvDxi.SkewSymmetric();
       const auto deviatoricDeformation = deformation - deformation.Trace()/3.0*SymTensor::one();
-      const auto spinCorrection = (spin*Si + Si*spin).Symmetric();
+      const auto spinCorrection = (Si*spin - spin*Si).Symmetric();
       DSDti = spinCorrection + 2.0*mui*deviatoricDeformation;
 
       // Optionally use damage to ramp down stress on damaged material.


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes an incorrect defintion of the Jaumann rate tensor used to update the deviatoric stress. 
  - This error existed in all our solid hydro algorithms due to copy/pasting the original mistake.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

