### PR TITLE
Enable CI for Debug HIP builds

### DIFF
--- a/.gitlab/jobs-seq.yml
+++ b/.gitlab/jobs-seq.yml
@@ -25,27 +25,27 @@ toss_gcc_~mpi_cleanup:
 
 
 
-cray_hip_rocm_~mpi_init:
-  extends: [.cray_shell1, .hip_rocm_~mpi, .init]
+cray_hip_rocm_~mpi_Debug_init:
+  extends: [.cray_shell1, .hip_rocm_~mpi_Debug, .init]
 
-cray_hip_rocm_~mpi_tpls:
-  extends: [.cray_resource2, .hip_rocm_~mpi, .tpls]
+cray_hip_rocm_~mpi_Debug_tpls:
+  extends: [.cray_resource2, .hip_rocm_~mpi_Debug, .tpls]
   needs:
     - job: cray_update_tpls
       optional: true
-    - job: cray_hip_rocm_~mpi_init
+    - job: cray_hip_rocm_~mpi_Debug_init
 
-cray_hip_rocm_~mpi_build:
-  extends: [.cray_resource2, .hip_rocm_~mpi, .build_and_test]
-  needs: [cray_hip_rocm_~mpi_tpls]
+cray_hip_rocm_~mpi_Debug_build:
+  extends: [.cray_resource2, .hip_rocm_~mpi_Debug, .build_and_test]
+  needs: [cray_hip_rocm_~mpi_Debug_tpls]
 
-cray_hip_rocm_~mpi_test:
-  extends: [.cray_resource2, .hip_rocm_~mpi, .run_ats]
-  needs: [cray_hip_rocm_~mpi_build]
+cray_hip_rocm_~mpi_Debug_test:
+  extends: [.cray_resource2, .hip_rocm_~mpi_Debug, .run_ats]
+  needs: [cray_hip_rocm_~mpi_Debug_build]
 
-cray_hip_rocm_~mpi_cleanup:
-  extends: [.cray_resource2, .hip_rocm_~mpi, .cleanup_dir]
-  needs: [cray_hip_rocm_~mpi_test]
+cray_hip_rocm_~mpi_Debug_cleanup:
+  extends: [.cray_resource2, .hip_rocm_~mpi_Debug, .cleanup_dir]
+  needs: [cray_hip_rocm_~mpi_Debug_test]
 
 
 

--- a/.gitlab/specs.yml
+++ b/.gitlab/specs.yml
@@ -58,6 +58,7 @@
     SPEC: '+mpi+rocm%rocmcc'
     EXTRA_CMAKE_ARGS: '-DENABLE_WARNINGS_AS_ERRORS=On'
 
-.hip_rocm_~mpi:
+.hip_rocm_~mpi_Debug:
   variables:
     SPEC: '~mpi+rocm%rocmcc'
+    EXTRA_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug -DENABLE_WARNINGS_AS_ERRORS=On'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+Version vYYYY.MM.p -- Release date YYYY-MM-DD
+==============================================
+  * Important Notes:
+
+Notable changes include:
+
+  * Build changes / improvements:
+    * Performance testing and CI improvements:
+      * Enable CI to run for Debug HIP builds
+
 Version v2026.06.0 -- Release date 2026-06-19
 ==============================================
   * Important Notes:

--- a/src/Utilities/GPUUtils.cc
+++ b/src/Utilities/GPUUtils.cc
@@ -18,7 +18,7 @@ int deviceCount() {
   return device_count;
 }
 
-void initGPUs(const int stack_mult = 8) {
+void initGPUs(const int stack_mult) {
 #ifdef SPHERAL_ENABLE_HIP
   int device_count = deviceCount();
   if (device_count > 0) {

--- a/src/Utilities/GPUUtils.hh
+++ b/src/Utilities/GPUUtils.hh
@@ -47,7 +47,7 @@ namespace GPUUtils {
 
 int deviceCount();
 
-void initGPUs(const int stack_mult);
+void initGPUs(const int stack_mult = 8);
 
 void deviceSync();
 

--- a/tests/cpp/ArtificialViscosity/artvisc_tests.cc
+++ b/tests/cpp/ArtificialViscosity/artvisc_tests.cc
@@ -23,6 +23,10 @@ using LimMonGArtVisc = Spheral::LimitedMonaghanGingoldViscosity<Spheral::Dim<3>>
 using LimMonGArtView = Spheral::LimitedMonaghanGingoldViscosityView<Spheral::Dim<3>>;
 
 class ArtViscTest : public ::testing::Test {
+public:
+  ArtViscTest() {
+    Spheral::GPUUtils::initGPUs();
+  }
 };
 
 // Setting up G Test for ArtificialViscosity

--- a/tests/cpp/ArtificialViscosity/tensorav_tests.cc
+++ b/tests/cpp/ArtificialViscosity/tensorav_tests.cc
@@ -24,6 +24,10 @@ using TensorArtVisc = Spheral::TensorMonaghanGingoldViscosity<Spheral::Dim<3>>;
 using TensorArtView = Spheral::TensorMonaghanGingoldViscosityView<Spheral::Dim<3>>;
 
 class TensorAVTest : public ::testing::Test {
+public:
+  TensorAVTest() {
+    Spheral::GPUUtils::initGPUs();
+  }
 };
 
 // Setting up G Test for ArtificialViscosity

--- a/tests/cpp/Loops/forall_tests.cc
+++ b/tests/cpp/Loops/forall_tests.cc
@@ -73,6 +73,7 @@ public:
     tree_neighbor(fluid_node_list,
                   Spheral::NeighborSearchType::GatherScatter,
                   kernelExtents, xmin, xmax) {
+    Spheral::GPUUtils::initGPUs();
     fluid_node_list.registerNeighbor(tree_neighbor);
   }
 

--- a/tests/cpp/Loops/sph_tests.cc
+++ b/tests/cpp/Loops/sph_tests.cc
@@ -89,6 +89,7 @@ public:
     tree_neighbor(fluid_node_list,
                   Spheral::NeighborSearchType::GatherScatter,
                   kernelExtents, xmin, xmax) {
+    Spheral::GPUUtils::initGPUs();
     fluid_node_list.registerNeighbor(tree_neighbor);
   }
 

--- a/tests/cpp/Utilities/managedptr_tests.cc
+++ b/tests/cpp/Utilities/managedptr_tests.cc
@@ -56,6 +56,10 @@ protected:
 };
 
 class ManagedPointerTest : public ::testing::Test {
+public:
+  ManagedPointerTest() {
+    Spheral::GPUUtils::initGPUs();
+  }
 };
 
 // Setting up G Test for managed ptr


### PR DESCRIPTION
# Summary
This is to address issue #513 

- This PR enables CI to run for HIP Debug builds.  
- Minor updates to a couple of the C++ tests were also done to allow them to complete successfully by setting the stack size for threads running on the device to match what is already in place for the python interface.

------
### ToDo :

- [x] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [x] Create LLNLSpheral PR pointing at this branch. (MR#219)
- [x] LLNLSpheral PR has passed all tests.

