### PR TITLE
Bugfixes for Strain-Porosity model

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ Notable changes include:
       * Enable CI to run for Debug HIP builds
 
   * Bug Fixes / improvements:
+    * Bugfix for strain-porosity in power-law compaction regime from Sean Wiggins (apparently the paper by Collins et al. had a typo).
 
 Version v2026.06.0 -- Release date 2026-06-22
 ==============================================

--- a/src/Porosity/StrainPorosity.cc
+++ b/src/Porosity/StrainPorosity.cc
@@ -47,8 +47,8 @@ StrainPorosity(const SolidNodeList<Dimension>& nodeList,
           "ERROR : epsE required to be epsE <= 0.0.");
   VERIFY2(mEpsX <= mEpsE,
           "StrainPorosity ERROR : epsX required to be epsX <= epsE.");
-  VERIFY2(kappa >= 0.0 and kappa <= 1.0,
-          "ERROR : kappa required to be in range kappa = [0.0, 1.0]");
+  VERIFY2(kappa > 0.0 and kappa <= 1.0,
+          "ERROR : kappa required to be in range kappa = (0.0, 1.0]");
 }
 
 //------------------------------------------------------------------------------
@@ -77,8 +77,8 @@ StrainPorosity(const SolidNodeList<Dimension>& nodeList,
           "ERROR : epsE required to be epsE <= 0.0.");
   VERIFY2(mEpsX <= mEpsE,
           "StrainPorosity ERROR : epsX required to be epsX <= epsE.");
-  VERIFY2(kappa >= 0.0 and kappa <= 1.0,
-          "ERROR : kappa required to be in range kappa = [0.0, 1.0]");
+  VERIFY2(kappa > 0.0 and kappa <= 1.0,
+          "ERROR : kappa required to be in range kappa = (0.0, 1.0]");
 }
 
 //------------------------------------------------------------------------------
@@ -168,7 +168,7 @@ evaluateDerivatives(const Scalar /*time*/,
           // Power-law -- irreversible compaction.
           const auto epsCi = 2.0*(1.0 - alpha0i*exp(mKappa*(mEpsX - mEpsE)))/(mKappa*alpha0i*exp(mKappa*(mEpsX - mEpsE))) + mEpsX;
           const auto PLcoefi = 2.0*(1.0 - alpha0i*exp(mKappa*(mEpsX - mEpsE)))/FastMath::square(epsCi - mEpsX);
-          DalphaDepsi = PLcoefi*(mEpsE - epsi);
+          DalphaDepsi = PLcoefi*(epsCi - epsi);
           DalphaDt(i) = min(0.0, DalphaDepsi*strainRate);
         }
       }


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes incorrect evolution in some limits in the strain-porosity model due to typos in the Collins paper

------
### ToDo :

- [ ] Annotate ``RELEASE_NOTES.md`` with notable changes.
- [ ] Create LLNLSpheral PR pointing at this branch. (PR#)
- [ ] LLNLSpheral PR has passed all tests.

